### PR TITLE
Refresh wallet info on page focus

### DIFF
--- a/screen/wallets/list.js
+++ b/screen/wallets/list.js
@@ -14,6 +14,7 @@ import {
   BlueHeaderDefaultMain,
 } from '../../BlueComponents';
 import { Icon } from 'react-native-elements';
+import { NavigationEvents } from 'react-navigation';
 import PropTypes from 'prop-types';
 const BigNumber = require('bignumber.js');
 let EV = require('../../events');
@@ -49,7 +50,7 @@ export default class WalletsList extends Component {
     EV(EV.enum.TRANSACTIONS_COUNT_CHANGED, this.refreshFunction.bind(this));
   }
 
-  async componentDidMount() {
+  componentDidMount() {
     this.refreshFunction();
   }
 
@@ -223,6 +224,7 @@ export default class WalletsList extends Component {
 
     return (
       <SafeBlueArea style={{ flex: 1, backgroundColor: '#FFFFFF' }}>
+        <NavigationEvents onWillFocus={() => { this.refreshFunction() }} />
         <ScrollView
           refreshControl={<RefreshControl onRefresh={() => this.refreshTransactions()} refreshing={this.state.isTransactionsLoading} />}
         >

--- a/screen/wallets/transactions.js
+++ b/screen/wallets/transactions.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Text, View, Image, FlatList, RefreshControl, TouchableOpacity } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import PropTypes from 'prop-types';
+import { NavigationEvents } from 'react-navigation';
 import { LightningCustodianWallet } from '../../class';
 import {
   BlueText,
@@ -67,7 +68,7 @@ export default class WalletTransactions extends Component {
     };
   }
 
-  async componentDidMount() {
+  componentDidMount() {
     this.refreshFunction();
   }
 
@@ -285,6 +286,7 @@ export default class WalletTransactions extends Component {
     const { navigate } = this.props.navigation;
     return (
       <View style={{ flex: 1 }}>
+        <NavigationEvents onWillFocus={() => { this.refreshFunction() }} />
         {this.renderWalletHeader()}
         <View style={{ flex: 1, backgroundColor: '#FFFFFF' }}>
           {(() => {


### PR DESCRIPTION
Wallet name stays the same when changed in options and user has to manually refresh to get new name (as described in #27 ).

Since `react-navigation` keeps staked pages mounted, `componentDidMount` is called only after first render. We have to use `NavigationEvents` component which listens on `onWillFocus` event and calls the `refreshFunction` to get new data.

I'm not sure if this has any large drawbacks, but it is currently the only way to do it properly, the other being using Redux or other state container which would be the single source of truth.

I also removed `async` keywords which do nothing.