### PR TITLE
Fix: Fee slider not setting new value on change

### DIFF
--- a/screen/send/details.js
+++ b/screen/send/details.js
@@ -358,7 +358,7 @@ export default class SendDetails extends Component {
             {this.state.networkTransactionFees.fastestFee > 1 && (
               <View style={{ flex: 1, marginTop: 32, minWidth: 240, width: 240 }}>
                 <Slider
-                  onValueChange={value => this.setState({ feeSliderValue: this.state.feeSliderValue, fee: value.toFixed(0) })}
+                  onValueChange={value => this.setState({ feeSliderValue: value.toFixed(0), fee: value.toFixed(0) })}
                   minimumValue={1}
                   maximumValue={this.state.networkTransactionFees.fastestFee}
                   value={Number(this.state.feeSliderValue)}


### PR DESCRIPTION
Current buggy behavior: 
- User sets fee using slider and closes modal with fee slider.
- Then decides to set fee again and opens fee modal
- Slider is set to the end even though value is lower

This fixed it