### PR TITLE
WIP: Handle BIP21 deeplinks

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Linking } from 'react-native';
+import { NavigationActions } from 'react-navigation';
+
+import MainBottomTabs from './MainBottomTabs';
+
+export default class App extends React.Component {
+  navigator = null;
+
+  componentDidMount() {
+    Linking.getInitialURL()
+      .then(url => this.handleOpenURL({ url }))
+      .catch(console.error);
+
+    Linking.addEventListener('url', this.handleOpenURL);
+  }
+
+  componentWillUnmount() {
+    Linking.removeEventListener('url', this.handleOpenURL);
+  }
+
+  handleOpenURL = event => {
+    if (event.url && event.url.indexOf('bitcoin:') === 0) {
+      this.navigator &&
+        this.navigator.dispatch(
+          NavigationActions.navigate({
+            routeName: 'SendDetails',
+            params: {
+              uri: event.url,
+            },
+          }),
+        );
+    }
+  };
+
+  render() {
+    return (
+      <MainBottomTabs
+        ref={nav => {
+          this.navigator = nav;
+        }}
+      />
+    );
+  }
+}

--- a/App.js
+++ b/App.js
@@ -20,7 +20,7 @@ export default class App extends React.Component {
   }
 
   handleOpenURL = event => {
-    if (event.url && event.url.indexOf('bitcoin:') === 0) {
+    if (event.url && event.url.toLowerCase().indexOf('bitcoin:') === 0) {
       this.navigator &&
         this.navigator.dispatch(
           NavigationActions.navigate({

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,6 +20,12 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
+        <intent-filter>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="bitcoin" />
+        </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import './shim.js';
-import MainBottomTabs from './MainBottomTabs';
+import App from './App';
 import { Sentry } from 'react-native-sentry';
 import { AppRegistry } from 'react-native';
 import WalletMigrate from './screen/wallets/walletMigrate';
@@ -28,7 +28,7 @@ class BlueAppComponent extends React.Component {
   }
 
   render() {
-    return this.state.isMigratingData ? <WalletMigrate onComplete={() => this.setIsMigratingData()} /> : <MainBottomTabs />;
+    return this.state.isMigratingData ? <WalletMigrate onComplete={() => this.setIsMigratingData()} /> : <App />;
   }
 }
 

--- a/ios/BlueWallet/AppDelegate.m
+++ b/ios/BlueWallet/AppDelegate.m
@@ -7,6 +7,7 @@
 
 #import "AppDelegate.h"
 
+#import <React/RCTLinkingManager.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
 #if __has_include(<React/RNSentry.h>)
@@ -37,6 +38,13 @@ RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   return YES;
+}
+
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
+  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+{
+  return [RCTLinkingManager application:application openURL:url
+                      sourceApplication:sourceApplication annotation:annotation];
 }
 
 @end

--- a/ios/BlueWallet/Info.plist
+++ b/ios/BlueWallet/Info.plist
@@ -20,6 +20,19 @@
 	<string>3.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>bitcoin</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>bitcoin</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>151</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/screen/send/details.js
+++ b/screen/send/details.js
@@ -75,9 +75,9 @@ export default class SendDetails extends Component {
       try {
         parsedBitcoinUri = bip21.decode(props.navigation.state.params.uri);
 
-        address = parsedBitcoinUri.address ? parsedBitcoinUri.address : address;
-        amount = parsedBitcoinUri.options.amount ? parsedBitcoinUri.options.amount : amount;
-        memo = parsedBitcoinUri.options.label ? parsedBitcoinUri.options.label : memo;
+        address = parsedBitcoinUri.address || address;
+        amount = parsedBitcoinUri.options.amount || amount;
+        memo = parsedBitcoinUri.options.label || memo;
       } catch (error) {
         console.error(error);
         alert('Error: Unable to decode Bitcoin address');


### PR DESCRIPTION
This is a work in progress to handle BIP21 (`bitcoin:`) deeplinks.
Current state is: clicked link opens the BlueWallet app, redirects to `SendDetails` page which opens the first wallet and parses amount+label and inserts into send form.

Desired state: Open app, open modal window with available wallets (only those able to send and only those with sufficient balance) and let user choose a wallet.