### PR TITLE
Fix: Display wallet balance consistently on all screens

### DIFF
--- a/screen/wallets/reorderWallets.js
+++ b/screen/wallets/reorderWallets.js
@@ -152,7 +152,7 @@ export default class ReorderWallets extends Component {
               color: '#fff',
             }}
           >
-            {loc.formatBalance(item.getBalance())}
+            {loc.formatBalance(Number(item.getBalance()), item.getPreferredBalanceUnit())}
           </Text>
           <Text style={{ backgroundColor: 'transparent' }} />
           <Text

--- a/screen/wallets/selectWallet.js
+++ b/screen/wallets/selectWallet.js
@@ -127,7 +127,7 @@ export default class SelectWallet extends Component {
                 color: '#fff',
               }}
             >
-              {loc.formatBalance(item.getBalance())}
+              {loc.formatBalance(Number(item.getBalance()), item.getPreferredBalanceUnit())}
             </Text>
             <Text style={{ backgroundColor: 'transparent' }} />
             <Text


### PR DESCRIPTION
This is something I stumbled upon: on "reorder wallets" screen and "choose wallet" screen, the Lightning wallet displays BTC as unit and not sats - as on the home screen.

This fixes it for now. I will create a separate reusable component for wallet item so these inconsistencies won't happen anymore.