### PR TITLE
Fix: Display proper link to block explorer

### DIFF
--- a/loc/en.js
+++ b/loc/en.js
@@ -103,6 +103,7 @@ module.exports = {
       to: 'Output',
       copy: 'Copy',
       transaction_details: 'Transaction details',
+      show_in_block_explorer: 'Show in block explorer',
     },
   },
   send: {

--- a/loc/es.js
+++ b/loc/es.js
@@ -103,6 +103,7 @@ module.exports = {
       to: 'A',
       copy: 'Copiar',
       transaction_details: 'Detalles de la transacción',
+      show_in_block_explorer: 'Show in block explorer',
     },
   },
   send: {

--- a/loc/pt_BR.js
+++ b/loc/pt_BR.js
@@ -104,6 +104,7 @@ module.exports = {
       to: 'Para',
       copy: 'Copiar',
       transaction_details: 'Transaction details',
+      show_in_block_explorer: 'Show in block explorer',
     },
   },
   send: {

--- a/loc/pt_PT.js
+++ b/loc/pt_PT.js
@@ -103,6 +103,7 @@ module.exports = {
       to: 'Para',
       copy: 'Copiar',
       transaction_details: 'Transaction details',
+      show_in_block_explorer: 'Show in block explorer',
     },
   },
   send: {

--- a/loc/ru.js
+++ b/loc/ru.js
@@ -102,6 +102,7 @@ module.exports = {
       to: 'Кому',
       copy: 'копировать',
       transaction_details: 'Transaction details',
+      show_in_block_explorer: 'Show in block explorer',
     },
   },
   send: {

--- a/loc/ua.js
+++ b/loc/ua.js
@@ -102,6 +102,7 @@ module.exports = {
       to: 'Кому',
       copy: 'копія',
       transaction_details: 'Transaction details',
+      show_in_block_explorer: 'Show in block explorer',
     },
   },
   send: {

--- a/screen/transactions/details.js
+++ b/screen/transactions/details.js
@@ -152,6 +152,7 @@ export default class TransactionsDetails extends Component {
                   <BlueText style={{ fontSize: 16, fontWeight: '500' }}>Txid</BlueText>
                   <BlueCopyToClipboardButton stringToCopy={this.state.tx.hash} />
                 </View>
+                <BlueText style={{ marginBottom: 8, color: 'grey' }}>{this.state.tx.hash}</BlueText>
                 <TouchableOpacity
                   onPress={() => {
                     const url = `https://live.blockcypher.com/btc/tx/${this.state.tx.hash}`;
@@ -162,7 +163,7 @@ export default class TransactionsDetails extends Component {
                     });
                   }}
                 >
-                  <BlueText style={{ marginBottom: 26, color: 'grey' }}>{this.state.tx.hash}</BlueText>
+                  <BlueText style={{ marginBottom: 26, color: '#2f5fb3' }}>{loc.transactions.details.show_in_block_explorer}</BlueText>
                 </TouchableOpacity>
               </React.Fragment>
             )}


### PR DESCRIPTION
I noticed (by accident) that in transaction detail, the TX ID is actually opens BlockCypher explorer. For a better UX, there needs to be a specific "Show in block explorer" link that user can see and use.

Before:
![current](https://user-images.githubusercontent.com/2407408/50483617-d4e1a400-09ec-11e9-9243-a65b3765e62d.png)

After:
![new](https://user-images.githubusercontent.com/2407408/50483621-d9a65800-09ec-11e9-95d1-d9b59c0fba0f.png)
