### PR TITLE
Refactor: Use static properties for wallet types

### DIFF
--- a/BlueComponents.js
+++ b/BlueComponents.js
@@ -957,32 +957,32 @@ export class WalletsCarousel extends Component {
     let gradient1 = '#65ceef';
     let gradient2 = '#68bbe1';
 
-    if (new WatchOnlyWallet().type === item.type) {
+    if (WatchOnlyWallet.type === item.type) {
       gradient1 = '#7d7d7d';
       gradient2 = '#4a4a4a';
     }
 
-    if (new LegacyWallet().type === item.type) {
+    if (LegacyWallet.type === item.type) {
       gradient1 = '#40fad1';
       gradient2 = '#15be98';
     }
 
-    if (new HDLegacyP2PKHWallet().type === item.type) {
+    if (HDLegacyP2PKHWallet.type === item.type) {
       gradient1 = '#e36dfa';
       gradient2 = '#bd10e0';
     }
 
-    if (new HDLegacyBreadwalletWallet().type === item.type) {
+    if (HDLegacyBreadwalletWallet.type === item.type) {
       gradient1 = '#fe6381';
       gradient2 = '#f99c42';
     }
 
-    if (new HDSegwitP2SHWallet().type === item.type) {
+    if (HDSegwitP2SHWallet.type === item.type) {
       gradient1 = '#c65afb';
       gradient2 = '#9053fe';
     }
 
-    if (new LightningCustodianWallet().type === item.type) {
+    if (LightningCustodianWallet.type === item.type) {
       gradient1 = '#f1be07';
       gradient2 = '#f79056';
     }
@@ -1015,9 +1015,7 @@ export class WalletsCarousel extends Component {
             }}
           >
             <Image
-              source={
-                (new LightningCustodianWallet().type === item.type && require('./img/lnd-shape.png')) || require('./img/btc-shape.png')
-              }
+              source={(LightningCustodianWallet.type === item.type && require('./img/lnd-shape.png')) || require('./img/btc-shape.png')}
               style={{
                 width: 99,
                 height: 94,

--- a/class/abstract-hd-wallet.js
+++ b/class/abstract-hd-wallet.js
@@ -6,9 +6,11 @@ const BigNumber = require('bignumber.js');
 const bitcoin = require('bitcoinjs-lib');
 
 export class AbstractHDWallet extends LegacyWallet {
+  static type = 'abstract';
+  static typeReadable = 'abstract';
+
   constructor() {
     super();
-    this.type = 'abstract';
     this.next_free_address_index = 0;
     this.next_free_change_address_index = 0;
     this.internal_addresses_cache = {}; // index => address
@@ -91,10 +93,6 @@ export class AbstractHDWallet extends LegacyWallet {
 
   getMnemonicToSeedHex() {
     return bip39.mnemonicToSeedHex(this.secret);
-  }
-
-  getTypeReadable() {
-    throw new Error('Not implemented');
   }
 
   /**

--- a/class/abstract-wallet.js
+++ b/class/abstract-wallet.js
@@ -1,8 +1,20 @@
 import { BitcoinUnit } from '../models/bitcoinUnits';
 
 export class AbstractWallet {
+  static type = 'abstract';
+  static typeReadable = 'abstract';
+
+  static fromJson(obj) {
+    let obj2 = JSON.parse(obj);
+    let temp = new this();
+    for (let key2 of Object.keys(obj2)) {
+      temp[key2] = obj2[key2];
+    }
+
+    return temp;
+  }
+
   constructor() {
-    this.type = 'abstract';
     this.label = '';
     this.secret = ''; // private key or recovery phrase
     this.balance = 0;
@@ -15,12 +27,16 @@ export class AbstractWallet {
     this.preferredBalanceUnit = BitcoinUnit.BTC;
   }
 
-  getTransactions() {
-    return this.transactions;
+  get type() {
+    return this.constructor.type;
   }
 
-  getTypeReadable() {
-    return this.type;
+  get typeReadable() {
+    return this.constructor.typeReadable;
+  }
+
+  getTransactions() {
+    return this.transactions;
   }
 
   /**
@@ -82,16 +98,6 @@ export class AbstractWallet {
 
   getLatestTransactionTime() {
     return 0;
-  }
-
-  static fromJson(obj) {
-    let obj2 = JSON.parse(obj);
-    let temp = new this();
-    for (let key2 of Object.keys(obj2)) {
-      temp[key2] = obj2[key2];
-    }
-
-    return temp;
   }
 
   getAddress() {}

--- a/class/app-storage.js
+++ b/class/app-storage.js
@@ -132,25 +132,25 @@ export class AppStorage {
           let tempObj = JSON.parse(key);
           let unserializedWallet;
           switch (tempObj.type) {
-            case 'segwitBech32':
+            case SegwitBech32Wallet.type:
               unserializedWallet = SegwitBech32Wallet.fromJson(key);
               break;
-            case 'segwitP2SH':
+            case SegwitP2SHWallet.type:
               unserializedWallet = SegwitP2SHWallet.fromJson(key);
               break;
-            case 'watchOnly':
+            case WatchOnlyWallet.type:
               unserializedWallet = WatchOnlyWallet.fromJson(key);
               break;
-            case new HDLegacyP2PKHWallet().type:
+            case HDLegacyP2PKHWallet.type:
               unserializedWallet = HDLegacyP2PKHWallet.fromJson(key);
               break;
-            case new HDSegwitP2SHWallet().type:
+            case HDSegwitP2SHWallet.type:
               unserializedWallet = HDSegwitP2SHWallet.fromJson(key);
               break;
-            case new HDLegacyBreadwalletWallet().type:
+            case HDLegacyBreadwalletWallet.type:
               unserializedWallet = HDLegacyBreadwalletWallet.fromJson(key);
               break;
-            case new LightningCustodianWallet().type:
+            case LightningCustodianWallet.type:
               /** @type {LightningCustodianWallet} */
               unserializedWallet = LightningCustodianWallet.fromJson(key);
               let lndhub = false;
@@ -168,7 +168,7 @@ export class AppStorage {
               }
               unserializedWallet.init();
               break;
-            case 'legacy':
+            case LegacyWallet.type:
             default:
               unserializedWallet = LegacyWallet.fromJson(key);
               break;
@@ -218,7 +218,7 @@ export class AppStorage {
     let walletsToSave = [];
     for (let key of this.wallets) {
       if (typeof key === 'boolean') continue;
-      walletsToSave.push(JSON.stringify(key));
+      walletsToSave.push(JSON.stringify({ ...key, type: key.type }));
     }
 
     let data = {

--- a/class/hd-legacy-breadwallet-wallet.js
+++ b/class/hd-legacy-breadwallet-wallet.js
@@ -8,14 +8,8 @@ const bip39 = require('bip39');
  * In particular, Breadwallet-compatible (Legacy addresses)
  */
 export class HDLegacyBreadwalletWallet extends AbstractHDWallet {
-  constructor() {
-    super();
-    this.type = 'HDLegacyBreadwallet';
-  }
-
-  getTypeReadable() {
-    return 'HD Legacy Breadwallet (P2PKH)';
-  }
+  static type = 'HDLegacyBreadwallet';
+  static typeReadable = 'HD Legacy Breadwallet (P2PKH)';
 
   /**
    * @see https://github.com/bitcoinjs/bitcoinjs-lib/issues/584

--- a/class/hd-legacy-p2pkh-wallet.js
+++ b/class/hd-legacy-p2pkh-wallet.js
@@ -11,14 +11,8 @@ const signer = require('../models/signer');
  * @see https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
  */
 export class HDLegacyP2PKHWallet extends AbstractHDWallet {
-  constructor() {
-    super();
-    this.type = 'HDlegacyP2PKH';
-  }
-
-  getTypeReadable() {
-    return 'HD Legacy (BIP44 P2PKH)';
-  }
+  static type = 'HDlegacyP2PKH';
+  static typeReadable = 'HD Legacy (BIP44 P2PKH)';
 
   allowSend() {
     return true;

--- a/class/hd-segwit-p2sh-wallet.js
+++ b/class/hd-segwit-p2sh-wallet.js
@@ -14,14 +14,8 @@ const signer = require('../models/signer');
  * @see https://github.com/bitcoin/bips/blob/master/bip-0049.mediawiki
  */
 export class HDSegwitP2SHWallet extends AbstractHDWallet {
-  constructor() {
-    super();
-    this.type = 'HDsegwitP2SH';
-  }
-
-  getTypeReadable() {
-    return 'HD SegWit (BIP49 P2SH)';
-  }
+  static type = 'HDsegwitP2SH';
+  static typeReadable = 'HD SegWit (BIP49 P2SH)';
 
   allowSend() {
     return true;

--- a/class/legacy-wallet.js
+++ b/class/legacy-wallet.js
@@ -13,10 +13,8 @@ const signer = require('../models/signer');
  *  (legacy P2PKH compressed)
  */
 export class LegacyWallet extends AbstractWallet {
-  constructor() {
-    super();
-    this.type = 'legacy';
-  }
+  static type = 'legacy';
+  static typeReadable = 'Legacy (P2PKH)';
 
   /**
    * Simple function which says that we havent tried to fetch balance
@@ -75,10 +73,6 @@ export class LegacyWallet extends AbstractWallet {
         resolve();
       });
     });
-  }
-
-  getTypeReadable() {
-    return 'Legacy (P2PKH)';
   }
 
   /**

--- a/class/lightning-custodian-wallet.js
+++ b/class/lightning-custodian-wallet.js
@@ -4,11 +4,13 @@ import { BitcoinUnit } from '../models/bitcoinUnits';
 let BigNumber = require('bignumber.js');
 
 export class LightningCustodianWallet extends LegacyWallet {
+  static type = 'lightningCustodianWallet';
+  static typeReadable = 'Lightning';
+
   constructor() {
     super();
     this.setBaseURI(); // no args to init with default value
     this.init();
-    this.type = 'lightningCustodianWallet';
     this.refresh_token = '';
     this.access_token = '';
     this._refresh_token_created_ts = 0;
@@ -77,10 +79,6 @@ export class LightningCustodianWallet extends LegacyWallet {
 
   generate() {
     // nop
-  }
-
-  getTypeReadable() {
-    return 'Lightning';
   }
 
   async createAccount(isTest) {

--- a/class/segwit-bech-wallet.js
+++ b/class/segwit-bech-wallet.js
@@ -2,14 +2,8 @@ import { LegacyWallet } from './legacy-wallet';
 const bitcoin = require('bitcoinjs-lib');
 
 export class SegwitBech32Wallet extends LegacyWallet {
-  constructor() {
-    super();
-    this.type = 'segwitBech32';
-  }
-
-  getTypeReadable() {
-    return 'P2 WPKH';
-  }
+  static type = 'segwitBech32';
+  static typeReadable = 'P2 WPKH';
 
   getAddress() {
     if (this._address) return this._address;

--- a/class/segwit-p2sh-wallet.js
+++ b/class/segwit-p2sh-wallet.js
@@ -4,17 +4,11 @@ const signer = require('../models/signer');
 const BigNumber = require('bignumber.js');
 
 export class SegwitP2SHWallet extends LegacyWallet {
-  constructor() {
-    super();
-    this.type = 'segwitP2SH';
-  }
+  static type = 'segwitP2SH';
+  static typeReadable = 'SegWit (P2SH)';
 
   allowRBF() {
     return true;
-  }
-
-  getTypeReadable() {
-    return 'SegWit (P2SH)';
   }
 
   static witnessToAddress(witness) {

--- a/class/watch-only-wallet.js
+++ b/class/watch-only-wallet.js
@@ -2,14 +2,8 @@ import { LegacyWallet } from './legacy-wallet';
 const bitcoin = require('bitcoinjs-lib');
 
 export class WatchOnlyWallet extends LegacyWallet {
-  constructor() {
-    super();
-    this.type = 'watchOnly';
-  }
-
-  getTypeReadable() {
-    return 'Watch-only';
-  }
+  static type = 'watchOnly';
+  static typeReadable = 'Watch-only';
 
   allowSend() {
     return false;

--- a/screen/lnd/manageFunds.js
+++ b/screen/lnd/manageFunds.js
@@ -47,7 +47,7 @@ export default class ManageFunds extends Component {
     data = [];
     for (let c = 0; c < BlueApp.getWallets().length; c++) {
       let w = BlueApp.getWallets()[c];
-      if (w.type !== new LightningCustodianWallet().type) {
+      if (w.type !== LightningCustodianWallet.type) {
         data.push({
           value: c,
           label: w.getLabel() + ' (' + w.getBalance() + ' BTC)',

--- a/screen/lnd/scanLndInvoice.js
+++ b/screen/lnd/scanLndInvoice.js
@@ -30,7 +30,7 @@ export default class ScanLndInvoice extends React.Component {
     let fromWallet = {};
 
     if (!fromSecret) {
-      const lightningWallets = BlueApp.getWallets().filter(item => item.type === new LightningCustodianWallet().type);
+      const lightningWallets = BlueApp.getWallets().filter(item => item.type === LightningCustodianWallet.type);
       if (lightningWallets.length > 0) {
         fromSecret = lightningWallets[0].getSecret();
       }

--- a/screen/send/details.js
+++ b/screen/send/details.js
@@ -348,7 +348,7 @@ export default class SendDetails extends Component {
           fee: this.calculateFee(
             utxo,
             tx,
-            this.state.fromWallet.type === new HDSegwitP2SHWallet().type || this.state.fromWallet.type === new HDLegacyP2PKHWallet().type,
+            this.state.fromWallet.type === HDSegwitP2SHWallet.type || this.state.fromWallet.type === HDLegacyP2PKHWallet.type,
           ),
           address: this.state.address,
           memo: this.state.memo,

--- a/screen/settings/lightningSettings.js
+++ b/screen/settings/lightningSettings.js
@@ -45,7 +45,7 @@ export default class LightningSettings extends Component {
 
     // set each lnd wallets and re-init api
     for (/** @type {LightningCustodianWallet} */ let w of BlueApp.getWallets()) {
-      if (w.type === new LightningCustodianWallet().type) {
+      if (w.type === LightningCustodianWallet.type) {
         w.setBaseURI(this.state.URI);
         w.init();
         console.log('inited', w.baseURI);

--- a/screen/wallets/add.js
+++ b/screen/wallets/add.js
@@ -156,11 +156,11 @@ export default class WalletsAdd extends Component {
                       }}
                     >
                       <RadioGroup onSelect={(index, value) => this.onSelect(index, value)} selectedIndex={0}>
-                        <RadioButton value={new HDSegwitP2SHWallet().type}>
-                          <BlueText>{new HDSegwitP2SHWallet().getTypeReadable()}</BlueText>
+                        <RadioButton value={HDSegwitP2SHWallet.type}>
+                          <BlueText>{HDSegwitP2SHWallet.typeReadable}</BlueText>
                         </RadioButton>
-                        <RadioButton value={new SegwitP2SHWallet().type}>
-                          <BlueText>{new SegwitP2SHWallet().getTypeReadable()}</BlueText>
+                        <RadioButton value={SegwitP2SHWallet.type}>
+                          <BlueText>{SegwitP2SHWallet.typeReadable}</BlueText>
                         </RadioButton>
                       </RadioGroup>
                     </View>
@@ -197,14 +197,14 @@ export default class WalletsAdd extends Component {
                       if (global.lightning_create_try++ < 9 && +new Date() < 1545264000000) return alert('Coming soon');
                       // eslint-disable-next-line
                     for (let t of BlueApp.getWallets()) {
-                        if (t.type === new LightningCustodianWallet().type) {
+                        if (t.type === LightningCustodianWallet.type) {
                           // already exist
                           return alert('Only 1 Ligthning wallet allowed for now');
                         }
                       }
 
                       w = new LightningCustodianWallet();
-                      w.setLabel(this.state.label || w.getTypeReadable());
+                      w.setLabel(this.state.label || w.typeReadable);
 
                       try {
                         let lndhub = await AsyncStorage.getItem(AppStorage.LNDHUB);

--- a/screen/wallets/details.js
+++ b/screen/wallets/details.js
@@ -125,7 +125,7 @@ export default class WalletDetails extends Component {
               <Text style={{ color: '#0c2550', fontWeight: '500', fontSize: 14, marginVertical: 12 }}>
                 {loc.wallets.details.type.toLowerCase()}
               </Text>
-              <Text style={{ color: '#81868e', fontWeight: '500', fontSize: 14 }}>{this.state.wallet.getTypeReadable()}</Text>
+              <Text style={{ color: '#81868e', fontWeight: '500', fontSize: 14 }}>{this.state.wallet.typeReadable}</Text>
             </BlueCard>
             <View>
               <BlueSpacing20 />
@@ -141,9 +141,9 @@ export default class WalletDetails extends Component {
 
               <BlueSpacing20 />
 
-              {(this.state.wallet.type === new HDLegacyBreadwalletWallet().type ||
-                this.state.wallet.type === new HDLegacyP2PKHWallet().type ||
-                this.state.wallet.type === new HDSegwitP2SHWallet().type) && (
+              {(this.state.wallet.type === HDLegacyBreadwalletWallet.type ||
+                this.state.wallet.type === HDLegacyP2PKHWallet.type ||
+                this.state.wallet.type === HDSegwitP2SHWallet.type) && (
                 <BlueButton
                   onPress={() =>
                     this.props.navigation.navigate('WalletXpub', {
@@ -156,7 +156,7 @@ export default class WalletDetails extends Component {
 
               <BlueSpacing20 />
 
-              {this.state.wallet.type !== new LightningCustodianWallet().type && (
+              {this.state.wallet.type !== LightningCustodianWallet.type && (
                 <BlueButton
                   icon={{
                     name: 'shopping-cart',

--- a/screen/wallets/details.js
+++ b/screen/wallets/details.js
@@ -144,17 +144,19 @@ export default class WalletDetails extends Component {
               {(this.state.wallet.type === HDLegacyBreadwalletWallet.type ||
                 this.state.wallet.type === HDLegacyP2PKHWallet.type ||
                 this.state.wallet.type === HDSegwitP2SHWallet.type) && (
-                <BlueButton
-                  onPress={() =>
-                    this.props.navigation.navigate('WalletXpub', {
-                      secret: this.state.wallet.getSecret(),
-                    })
-                  }
-                  title={loc.wallets.details.show_xpub}
-                />
-              )}
+                <React.Fragment>
+                  <BlueButton
+                    onPress={() =>
+                      this.props.navigation.navigate('WalletXpub', {
+                        secret: this.state.wallet.getSecret(),
+                      })
+                    }
+                    title={loc.wallets.details.show_xpub}
+                  />
 
-              <BlueSpacing20 />
+                  <BlueSpacing20 />
+                </React.Fragment>
+              )}
 
               {this.state.wallet.type !== LightningCustodianWallet.type && (
                 <BlueButton

--- a/screen/wallets/export.js
+++ b/screen/wallets/export.js
@@ -90,7 +90,7 @@ export default class WalletExport extends Component {
         })()}
         <BlueCard style={{ alignItems: 'center', flex: 1 }}>
           <View>
-            <BlueText>{this.state.wallet.getTypeReadable()}</BlueText>
+            <BlueText>{this.state.wallet.typeReadable}</BlueText>
           </View>
 
           {(() => {

--- a/screen/wallets/import.js
+++ b/screen/wallets/import.js
@@ -53,7 +53,7 @@ export default class WalletsImport extends Component {
   async _saveWallet(w) {
     alert(loc.wallets.import.success);
     ReactNativeHapticFeedback.trigger('notificationSuccess', false);
-    w.setLabel(loc.wallets.import.imported + ' ' + w.getTypeReadable());
+    w.setLabel(loc.wallets.import.imported + ' ' + w.typeReadable);
     BlueApp.wallets.push(w);
     await BlueApp.saveToDisk();
     EV(EV.enum.WALLETS_COUNT_CHANGED);
@@ -67,7 +67,7 @@ export default class WalletsImport extends Component {
       if (text.indexOf('blitzhub://') !== -1 || text.indexOf('lndhub://') !== -1) {
         // yep its lnd
         for (let t of BlueApp.getWallets()) {
-          if (t.type === new LightningCustodianWallet().type) {
+          if (t.type === LightningCustodianWallet.type) {
             // already exist
             return alert('Only 1 Ligthning wallet allowed for now');
           }

--- a/screen/wallets/reorderWallets.js
+++ b/screen/wallets/reorderWallets.js
@@ -70,32 +70,32 @@ export default class ReorderWallets extends Component {
     let gradient1 = '#65ceef';
     let gradient2 = '#68bbe1';
 
-    if (new WatchOnlyWallet().type === item.type) {
+    if (WatchOnlyWallet.type === item.type) {
       gradient1 = '#7d7d7d';
       gradient2 = '#4a4a4a';
     }
 
-    if (new LegacyWallet().type === item.type) {
+    if (LegacyWallet.type === item.type) {
       gradient1 = '#40fad1';
       gradient2 = '#15be98';
     }
 
-    if (new HDLegacyP2PKHWallet().type === item.type) {
+    if (HDLegacyP2PKHWallet.type === item.type) {
       gradient1 = '#e36dfa';
       gradient2 = '#bd10e0';
     }
 
-    if (new HDLegacyBreadwalletWallet().type === item.type) {
+    if (HDLegacyBreadwalletWallet.type === item.type) {
       gradient1 = '#fe6381';
       gradient2 = '#f99c42';
     }
 
-    if (new HDSegwitP2SHWallet().type === item.type) {
+    if (HDSegwitP2SHWallet.type === item.type) {
       gradient1 = '#c65afb';
       gradient2 = '#9053fe';
     }
 
-    if (new LightningCustodianWallet().type === item.type) {
+    if (LightningCustodianWallet.type === item.type) {
       gradient1 = '#f1be07';
       gradient2 = '#f79056';
     }
@@ -119,8 +119,7 @@ export default class ReorderWallets extends Component {
         >
           <Image
             source={
-              (new LightningCustodianWallet().type === item.type && require('../../img/lnd-shape.png')) ||
-              require('../../img/btc-shape.png')
+              (LightningCustodianWallet.type === item.type && require('../../img/lnd-shape.png')) || require('../../img/btc-shape.png')
             }
             style={{
               width: 99,

--- a/screen/wallets/scanQrWif.js
+++ b/screen/wallets/scanQrWif.js
@@ -85,7 +85,7 @@ export default class ScanQrWif extends React.Component {
       await hd.fetchTransactions();
       if (hd.getTransactions().length !== 0) {
         await hd.fetchBalance();
-        hd.setLabel(loc.wallets.import.imported + ' ' + hd.getTypeReadable());
+        hd.setLabel(loc.wallets.import.imported + ' ' + hd.typeReadable);
         BlueApp.wallets.push(hd);
         await BlueApp.saveToDisk();
         alert(loc.wallets.import.success);
@@ -107,7 +107,7 @@ export default class ScanQrWif extends React.Component {
         }
       }
       this.setState({ isLoading: true });
-      hd.setLabel(loc.wallets.import.imported + ' ' + hd.getTypeReadable());
+      hd.setLabel(loc.wallets.import.imported + ' ' + hd.typeReadable);
       BlueApp.wallets.push(hd);
       await hd.fetchBalance();
       await hd.fetchTransactions();
@@ -134,7 +134,7 @@ export default class ScanQrWif extends React.Component {
       }
 
       BlueApp.wallets.push(lnd);
-      lnd.setLabel(loc.wallets.import.imported + ' ' + lnd.getTypeReadable());
+      lnd.setLabel(loc.wallets.import.imported + ' ' + lnd.typeReadable);
       this.props.navigation.popToTop();
       alert(loc.wallets.import.success);
       setTimeout(() => EV(EV.enum.WALLETS_COUNT_CHANGED), 500);

--- a/screen/wallets/selectWallet.js
+++ b/screen/wallets/selectWallet.js
@@ -28,7 +28,7 @@ export default class SelectWallet extends Component {
   }
 
   componentDidMount() {
-    const wallets = BlueApp.getWallets().filter(item => item.type !== new LightningCustodianWallet().type);
+    const wallets = BlueApp.getWallets().filter(item => item.type !== LightningCustodianWallet.type);
     this.setState({
       data: wallets,
       isLoading: false,
@@ -39,32 +39,32 @@ export default class SelectWallet extends Component {
     let gradient1 = '#65ceef';
     let gradient2 = '#68bbe1';
 
-    if (new WatchOnlyWallet().type === item.type) {
+    if (WatchOnlyWallet.type === item.type) {
       gradient1 = '#7d7d7d';
       gradient2 = '#4a4a4a';
     }
 
-    if (new LegacyWallet().type === item.type) {
+    if (LegacyWallet.type === item.type) {
       gradient1 = '#40fad1';
       gradient2 = '#15be98';
     }
 
-    if (new HDLegacyP2PKHWallet().type === item.type) {
+    if (HDLegacyP2PKHWallet.type === item.type) {
       gradient1 = '#e36dfa';
       gradient2 = '#bd10e0';
     }
 
-    if (new HDLegacyBreadwalletWallet().type === item.type) {
+    if (HDLegacyBreadwalletWallet.type === item.type) {
       gradient1 = '#fe6381';
       gradient2 = '#f99c42';
     }
 
-    if (new HDSegwitP2SHWallet().type === item.type) {
+    if (HDSegwitP2SHWallet.type === item.type) {
       gradient1 = '#c65afb';
       gradient2 = '#9053fe';
     }
 
-    if (new LightningCustodianWallet().type === item.type) {
+    if (LightningCustodianWallet.type === item.type) {
       gradient1 = '#f1be07';
       gradient2 = '#f79056';
     }
@@ -94,8 +94,7 @@ export default class SelectWallet extends Component {
           >
             <Image
               source={
-                (new LightningCustodianWallet().type === item.type && require('../../img/lnd-shape.png')) ||
-                require('../../img/btc-shape.png')
+                (LightningCustodianWallet.type === item.type && require('../../img/lnd-shape.png')) || require('../../img/btc-shape.png')
               }
               style={{
                 width: 99,

--- a/screen/wallets/transactions.js
+++ b/screen/wallets/transactions.js
@@ -96,10 +96,10 @@ export default class WalletTransactions extends Component {
 
       let showManageFundsBigButton = false;
       let showManageFundsSmallButton = false;
-      if (wallet && wallet.type === new LightningCustodianWallet().type && wallet.getBalance() * 1 === 0) {
+      if (wallet && wallet.type === LightningCustodianWallet.type && wallet.getBalance() * 1 === 0) {
         showManageFundsBigButton = true;
         showManageFundsSmallButton = false;
-      } else if (wallet && wallet.type === new LightningCustodianWallet().type && wallet.getBalance() > 0) {
+      } else if (wallet && wallet.type === LightningCustodianWallet.type && wallet.getBalance() > 0) {
         showManageFundsSmallButton = true;
         showManageFundsBigButton = false;
       }
@@ -126,7 +126,7 @@ export default class WalletTransactions extends Component {
 
   isLightning() {
     let w = this.state.wallet;
-    if (w && w.type === new LightningCustodianWallet().type) {
+    if (w && w.type === LightningCustodianWallet.type) {
       return true;
     }
 
@@ -198,7 +198,7 @@ export default class WalletTransactions extends Component {
       <LinearGradient colors={[gradients[0], gradients[1]]} style={{ padding: 15, minHeight: 164 }}>
         <Image
           source={
-            (new LightningCustodianWallet().type === this.state.wallet.type && require('../../img/lnd-shape.png')) ||
+            (LightningCustodianWallet.type === this.state.wallet.type && require('../../img/lnd-shape.png')) ||
             require('../../img/btc-shape.png')
           }
           style={{
@@ -498,7 +498,7 @@ export default class WalletTransactions extends Component {
               return (
                 <BlueSendButtonIcon
                   onPress={() => {
-                    if (this.state.wallet.type === new LightningCustodianWallet().type) {
+                    if (this.state.wallet.type === LightningCustodianWallet.type) {
                       navigate('ScanLndInvoice', { fromSecret: this.state.wallet.getSecret() });
                     } else {
                       navigate('SendDetails', { fromAddress: this.state.wallet.getAddress(), fromSecret: this.state.wallet.getSecret() });

--- a/screen/wallets/xpub.js
+++ b/screen/wallets/xpub.js
@@ -80,12 +80,10 @@ export default class WalletXpub extends Component {
 
     return (
       <SafeBlueArea style={{ flex: 1, paddingTop: 20 }}>
-        {isIpad && (
-          <BlueSpacing40 />
-        )}
+        {isIpad && <BlueSpacing40 />}
         <BlueCard style={{ alignItems: 'center', flex: 1 }}>
           <View>
-            <BlueText>{this.state.wallet.getTypeReadable()}</BlueText>
+            <BlueText>{this.state.wallet.typeReadable}</BlueText>
           </View>
 
           {(() => {


### PR DESCRIPTION
It is very costly (performance-wise) to create new instance of wallet everytime we need to read a static property. Let's just read static field from class and access this field using native getter when reading from class instance.

This is supposed to be a non-breakable change and I tested it locally on various types of wallets with success.