### PR TITLE
added Mexican Peso (MXN) as new fiatUnit

### DIFF
--- a/models/fiatUnit.js
+++ b/models/fiatUnit.js
@@ -9,6 +9,7 @@ export const FiatUnit = Object.freeze({
   HRK: { endPointKey: 'HRK', symbol: 'HRK', locale: 'hr-HR' },
   INR: { endPointKey: 'INR', symbol: '₹', locale: 'hi-HN' },
   JPY: { endPointKey: 'JPY', symbol: '¥', locale: 'ja-JP' },
+  MXN: { endPointKey: 'MXN', symbol: '$', locale: 'es-MX' },
   PLN: { endPointKey: 'PLN', symbol: 'zł', locale: 'pl-PL' },
   RUB: { endPointKey: 'RUB', symbol: '₽', locale: 'ru-RU' },
   SGD: { endPointKey: 'SGD', symbol: 'S$', locale: 'zh-SG' },


### PR DESCRIPTION
hey BlueWallet team! First simple PR here. We're using your awesome wallet down in MX and we'd love to be able to see our balance in Mexican Peso. Let me know if you have any questions.