### PR TITLE
FIX: wallets/list pull-to-refresh animation duration

### DIFF
--- a/screen/wallets/list.js
+++ b/screen/wallets/list.js
@@ -60,7 +60,7 @@ export default class WalletsList extends Component {
     }
     this.setState(
       {
-        isFlatListRefreshControlHidden: true,
+        isFlatListRefreshControlHidden: false,
       },
       () => {
         InteractionManager.runAfterInteractions(async () => {


### PR DESCRIPTION
without that animation starts and almost instantly terminates, while balance and txs are actually fetched in the background