### PR TITLE
Make patch files keep their line endings. Fix #429

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.pbxproj -text
+*.patch -text


### PR DESCRIPTION
This fixes a problem with applying the patches
on Windows where the patch and the files to be
patched have different format for line endings.