### PR TITLE
Support Safello redirect URLs

### DIFF
--- a/App.js
+++ b/App.js
@@ -95,6 +95,12 @@ export default class App extends React.Component {
     return isValidLightningInvoice;
   }
 
+  isSafelloRedirect(event) {
+    let urlObject = url.parse(event.url, true) // eslint-disable-line
+
+    return !!urlObject.query["safello-state-token"]
+  }
+
   handleOpenURL = event => {
     if (event.url === null) {
       return;
@@ -122,6 +128,21 @@ export default class App extends React.Component {
             },
           }),
         );
+    } else if (this.isSafelloRedirect(event)) {
+      let urlObject = url.parse(event.url, true) // eslint-disable-line
+
+       const safelloStateToken = urlObject.query["safello-state-token"]
+
+       this.navigator &&
+        this.navigator.dispatch(
+          NavigationActions.navigate({
+            routeName: "BuyBitcoin",
+            params: {
+              uri: event.url,
+              safelloStateToken,
+            },
+          }),
+        )
     } else {
       let urlObject = url.parse(event.url, true); // eslint-disable-line
       console.log('parsed', urlObject);

--- a/screen/wallets/buyBitcoin.js
+++ b/screen/wallets/buyBitcoin.js
@@ -96,6 +96,7 @@ BuyBitcoin.propTypes = {
       params: PropTypes.shape({
         address: PropTypes.string,
         secret: PropTypes.string,
+        safelloStateToken: PropTypes.string,
       }),
     }),
   }),

--- a/screen/wallets/buyBitcoin.js
+++ b/screen/wallets/buyBitcoin.js
@@ -65,24 +65,16 @@ export default class BuyBitcoin extends Component {
 
     const { safelloStateToken } = this.props.navigation.state.params
 
-     if (safelloStateToken) {
-      return (
-        <WebView
-          source={{
-            uri:
-              "https://app.safello.com/sdk/quickbuy.html?appId=1234-5678&stateToken=" +
-              safelloStateToken,
-          }}
-        />
-      )
+    let uri = "https://bluewallet.io/buy-bitcoin-redirect.html?address=" + this.state.address
+
+    if (safelloStateToken) {
+      uri += "&safelloStateToken=" + safelloStateToken
     }
 
      return (
       <WebView
         source={{
-          uri:
-            "https://bluewallet.io/buy-bitcoin-redirect.html?address=" +
-            this.state.address,
+          uri,
         }}
       />
     )

--- a/screen/wallets/buyBitcoin.js
+++ b/screen/wallets/buyBitcoin.js
@@ -63,7 +63,29 @@ export default class BuyBitcoin extends Component {
       return <BlueLoading />;
     }
 
-    return <WebView source={{ uri: 'https://bluewallet.io/buy-bitcoin-redirect.html?address=' + this.state.address }} />;
+    const { safelloStateToken } = this.props.navigation.state.params
+
+     if (safelloStateToken) {
+      return (
+        <WebView
+          source={{
+            uri:
+              "https://app.safello.com/sdk/quickbuy.html?appId=1234-5678&stateToken=" +
+              safelloStateToken,
+          }}
+        />
+      )
+    }
+
+     return (
+      <WebView
+        source={{
+          uri:
+            "https://bluewallet.io/buy-bitcoin-redirect.html?address=" +
+            this.state.address,
+        }}
+      />
+    )
   }
 }
 


### PR DESCRIPTION
When the user buys bitcoin through Safello, they will be redirected to the Yoti app to verify their identity.

Previously, when the process was done, they would be redirected to a browser window to continue their purchase, but since bluewallet has a `bluewallet://` redirect URI associated to its
app ID, we can redirect them back to the app with a `safello-state-token` query parameter appended to the URI instead.

Bluewallet then simply needs to check if that query parameter is present, and if so, open a new WebView with the same Safello URL + `stateToken=xxx` in order to resume the user's session. This way, the whole buying process can take place inside Bluewallet's app, which is a clear improvement in terms of user experience.

What it looks like after the changes:

![yoti](https://user-images.githubusercontent.com/2598660/57446499-144eb580-7255-11e9-8fae-fc49372e9fdb.gif)

Note: You'll probably still want to make some changes, like passing the state token to your bluewallet.io URL instead of using my solution which opens app.safello.com directly. This is mostly to show how it should be handled. 😊
