### PR TITLE
Lock bitcoinjs5 dependency to specific commit hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2734,7 +2734,7 @@
     },
     "bitcoinjs5": {
       "version": "git+https://github.com/Overtorment/bitcoinjs5.git#846c0185a6693f86540d58a7a5fffe8173dc8b34",
-      "from": "git+https://github.com/Overtorment/bitcoinjs5.git",
+      "from": "git+https://github.com/Overtorment/bitcoinjs5.git#846c018",
       "requires": {
         "@types/node": "10.12.18",
         "bech32": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "bip32": "2.0.3",
     "bip39": "2.5.0",
     "bitcoinjs-lib": "3.3.2",
-    "bitcoinjs5": "git+https://github.com/Overtorment/bitcoinjs5.git",
+    "bitcoinjs5": "git+https://github.com/Overtorment/bitcoinjs5.git#846c018",
     "buffer": "5.2.1",
     "buffer-reverse": "1.0.1",
     "coinselect": "3.1.11",


### PR DESCRIPTION
Related to https://github.com/BlueWallet/BlueWallet/issues/597