### PR TITLE
fixes settings.lightning_settings_explain in loc/pt_PT.js

### DIFF
--- a/loc/pt_PT.js
+++ b/loc/pt_PT.js
@@ -187,9 +187,10 @@ module.exports = {
     encrypt_storage: 'Encriptar',
     lightning_settings: 'Definições do Lightning',
     lightning_settings_explain:
-      'Para se ligar ao seu próprio node LND, por favor instale o LndHub' +
-      ' e coloque o seu endereço aqui nas definições. Deixe em branco para usar o valor por omissão' +
-      'ndHub\n (lndhub.io)',
+      'Para se ligar ao seu próprio node LND, por favor instale o LndHub ' +
+      'e coloque o seu endereço aqui nas definições. ' +
+      'Deixe em branco para usar o LNDHub da BlueWallet (lndhub.io). ' +
+      'Wallets criadas depois desta alteração ligar-se-ão ao LNDHub especificado.',
     electrum_settings: 'Definições do Electrum',
     electrum_settings_explain: 'Deixe em branco para usar o valor por omissão',
     save: 'Guardar',


### PR DESCRIPTION
A lot of i18n files have an error on settings.lightning_settings_explain:

1. It ends with `'ndHub\n (lndhub.io)',`
2. The english version has one more sentence

I translated it from the english version.