### PR TITLE
fixes bug where in pt_PT 'Save' ('Guardar') appears broken.

### DIFF
--- a/screen/wallets/details.js
+++ b/screen/wallets/details.js
@@ -33,7 +33,7 @@ export default class WalletDetails extends Component {
     headerRight: (
       <TouchableOpacity
         disabled={navigation.getParam('isLoading') === true}
-        style={{ marginHorizontal: 16, height: 40, width: 40, justifyContent: 'center', alignItems: 'center' }}
+        style={{ marginHorizontal: 16, height: 40, width: 120, justifyContent: 'center', alignItems: 'center' }}
         onPress={() => {
           if (navigation.state.params.saveAction) {
             navigation.getParam('saveAction')();


### PR DESCRIPTION
Width of 40 was not sufficient for bigger words, and it was breaking (see screenshot):

![Screenshot](https://user-images.githubusercontent.com/9318412/66939848-bf04a480-f03b-11e9-93e4-e63a8b5b56f5.jpg)

Looking to all the translations of wallets.details.save, 120 seemed like a good choice for a new width value.