### PR TITLE
ADD: Hide Manage Funds button if wallet doesn't allow onchain refill.

### DIFF
--- a/BlueComponents.js
+++ b/BlueComponents.js
@@ -163,18 +163,31 @@ export class BlueWalletNavigationHeader extends Component {
     onWalletUnitChange: PropTypes.func,
   };
 
-  static getDerivedStateFromProps(props, _state) {
-    return { wallet: props.wallet, onWalletUnitChange: props.onWalletUnitChange };
+  static getDerivedStateFromProps(props, state) {
+    return { wallet: props.wallet, onWalletUnitChange: props.onWalletUnitChange, allowOnchainAddress: state.allowOnchainAddress };
   }
 
   constructor(props) {
     super(props);
-    this.state = { wallet: props.wallet, walletPreviousPreferredUnit: props.wallet.getPreferredBalanceUnit() };
+    this.state = {
+      wallet: props.wallet,
+      walletPreviousPreferredUnit: props.wallet.getPreferredBalanceUnit(),
+      showManageFundsButton: false,
+    };
   }
 
   handleCopyPress = _item => {
     Clipboard.setString(loc.formatBalance(this.state.wallet.getBalance(), this.state.wallet.getPreferredBalanceUnit()).toString());
   };
+
+  componentDidMount() {
+    if (this.state.wallet.type === LightningCustodianWallet.type) {
+      this.state.wallet
+        .allowOnchainAddress()
+        .then(value => this.setState({ allowOnchainAddress: value }))
+        .catch(e => console.log('This Lndhub wallet does not have an onchain address API.'));
+    }
+  }
 
   handleBalanceVisibility = async _item => {
     const wallet = this.state.wallet;
@@ -311,7 +324,7 @@ export class BlueWalletNavigationHeader extends Component {
             </Text>
           )}
         </TouchableOpacity>
-        {this.state.wallet.type === LightningCustodianWallet.type && (
+        {this.state.wallet.type === LightningCustodianWallet.type && this.state.allowOnchainAddress && (
           <TouchableOpacity onPress={this.manageFundsPressed}>
             <View
               style={{

--- a/class/lightning-custodian-wallet.js
+++ b/class/lightning-custodian-wallet.js
@@ -366,6 +366,15 @@ export class LightningCustodianWallet extends LegacyWallet {
     return this.fetchBtcAddress();
   }
 
+  async allowOnchainAddress() {
+    if (this.getAddress() !== undefined) {
+      return true;
+    } else {
+      await this.fetchBtcAddress();
+      return this.getAddress() !== undefined;
+    }
+  }
+
   getTransactions() {
     let txs = [];
     this.pending_transactions_raw = this.pending_transactions_raw || [];


### PR DESCRIPTION
![Simulator Screen Shot - iPhone 11 - 2019-12-14 at 01 51 25](https://user-images.githubusercontent.com/4793122/70844817-80f5e800-1e14-11ea-97f5-59f3d3ef515a.png)

Allow Hiding manage funds button since some lndhubs disable onchain address receive. leading to an empty receive UI.