### PR TITLE
Add Payjoin support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     }
     ext.kotlinVersion = '1.3.+'
     dependencies {
-        classpath("com.android.tools.build:gradle:3.4.2")
+        classpath('com.android.tools.build:gradle:3.6.2')
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/screen/send/confirm.js
+++ b/screen/send/confirm.js
@@ -71,6 +71,7 @@ export default class Confirm extends Component {
           }
           return null;
         });
+        //TODO: sign proposedPayjoinPsbt
         await this.broadcastTransaction(proposedPayjoinPsbt.extractTransaction())
       } 
       catch{

--- a/screen/send/payjoinClient.js
+++ b/screen/send/payjoinClient.js
@@ -52,5 +52,15 @@ export function requestPayjoin(psbt, remoteCall) {
         payjoinPsbt.updateOutput(index, originalOutput)
     })
   }
-  //
+  //TODO: check payjoinPsbt.version == psbt.version
+  //TODO: check payjoinPsbt.locktime == psbt.locktime
+  //TODO: check payjoinPsbt.inputs where input belongs to us, that it is not finalized
+  //TODO: check payjoinPsbt.inputs where input belongs to us, that it is was included in psbt.inputs
+  //TODO: check payjoinPsbt.inputs where input belongs to us, that its sequence has not changed from that of psbt.inputs
+  //TODO: check payjoinPsbt.inputs where input is new, that it is finalized
+  //TODO: check payjoinPsbt.inputs where input is new, that it is the same type as all other inputs from psbt.inputs (all==P2WPKH || all = P2SH-P2WPKH)
+  //TODO: check psbt.inputs that payjoinPsbt.inputs contains them all
+  //TODO: check payjoinPsbt.inputs > psbt.inputs
+  //TODO: check that if spend amount of payjoinPsbt > spend amount of psbt:
+  //TODO: * check if the difference is due to adjusting fee to increase transaction size
 }

--- a/screen/send/payjoinClient.js
+++ b/screen/send/payjoinClient.js
@@ -1,0 +1,46 @@
+const bitcoin = require("bitcoinjs-lib");
+
+export function requestPayjoin(psbt, remoteCall) {
+  var clonedPsbt = new bitcoin.Psbt(); //= psbt.clone();
+  clonedPsbt.finalizeAllInputs();
+
+  // We make sure we don't send unnecessary information to the receiver
+  for (let index = 0; index < clonedPsbt.inputCount; index++) {
+    clonedPsbt.clearFinalizedInput(index);
+  }
+  clonedPsbt.data.outputs.forEach(output => {
+    output.bip32Derivation = [];
+  });
+  clonedPsbt.data.globalMap.globalXpub = [];
+
+  var payjoinPsbt = new bitcoin.Psbt(); //await remoteCall(clonedPsbt.toHex());
+  if (!payjoinPsbt) return null;
+
+  // We make sure we don't sign things what should not be signed
+  for (let index = 0; index < payjoinPsbt.inputCount; index++) {
+    //Is Finalized
+    if (
+      payjoinPsbt.data.inputs[i].finalScriptSig != null &&
+      payjoinPsbt.data.inputs[i].finalScriptWitness != null
+    )
+      payjoinPsbt.clearFinalizedInput(index);
+  }
+  for (let index = 0; index < payjoinPsbt.data.outputs.length; index++) {
+    const output = payjoinPsbt.data.outputs[index];
+    // Make sure only the only our output have any information
+    output.bip32Derivation = [];
+    psbt.data.outputs.forEach(originalOutput => {
+      //update the payjoin outputs 
+      //TODO how to get scriptpubkey in bitcoinjs psbt outputs?
+      if (output.ScriptPubKey == originalOutput.bip32Derivation.pubkey)
+        payjoinPsbt.updateOutput(index, originalOutput);
+    });
+  }
+
+  // no inputs were added?
+  if(clonedPsbt.inputCount <= payjoinPsbt.inputCount){
+      return null;
+  }
+  //
+
+}


### PR DESCRIPTION
Payjoin specification: https://github.com/btcpayserver/btcpayserver-doc/pull/469
Payjoin c# client reference: https://github.com/btcpayserver/btcpayserver/blob/03458efea4846e458c73041110ae96a94fd8bc15/BTCPayServer/Services/PayjoinClient.cs#L65

High-level explanation:
* Decode a BIP21
* Check if `pj` option is provided ( it should be a url)
* Create and finalize PSBT that pays BIP21
* Clean PSBT of any confidential data, like xpub information
* Send to url and receive a success status response with a psbt in the body
* validate psbt 
* sign psbt
* broadcast

This is my first time dealing with React and BitcoinJS, so please bear with me :) 