### PR TITLE
Fix Electrum recovery bug

### DIFF
--- a/class/hd-legacy-electrum-seed-p2pkh-wallet.js
+++ b/class/hd-legacy-electrum-seed-p2pkh-wallet.js
@@ -4,6 +4,13 @@ const bitcoin = require('bitcoinjs-lib');
 const mn = require('electrum-mnemonic');
 const HDNode = require('bip32');
 
+// This type of wallet should only accept a valid standard prefix
+const MNEMONIC_TO_SEED_OPTS = {
+  validPrefixes: [
+    mn.PREFIXES.standard,
+  ],
+};
+
 /**
  * ElectrumSeed means that instead of BIP39 seed format it works with the format invented by Electrum wallet. Otherwise
  * its a regular HD wallet that has all the properties of parent class.
@@ -16,7 +23,8 @@ export class HDLegacyElectrumSeedP2PKHWallet extends HDLegacyP2PKHWallet {
 
   validateMnemonic() {
     try {
-      mn.mnemonicToSeedSync(this.secret);
+      // This type of wallet should only accept a valid standard prefix
+      mn.mnemonicToSeedSync(this.secret, MNEMONIC_TO_SEED_OPTS);
       return true;
     } catch (_) {
       return false;
@@ -31,7 +39,7 @@ export class HDLegacyElectrumSeedP2PKHWallet extends HDLegacyP2PKHWallet {
     if (this._xpub) {
       return this._xpub; // cache hit
     }
-    const root = bitcoin.bip32.fromSeed(mn.mnemonicToSeedSync(this.secret));
+    const root = bitcoin.bip32.fromSeed(mn.mnemonicToSeedSync(this.secret, MNEMONIC_TO_SEED_OPTS));
     this._xpub = root.toBase58();
     return this._xpub;
   }
@@ -61,7 +69,7 @@ export class HDLegacyElectrumSeedP2PKHWallet extends HDLegacyP2PKHWallet {
   }
 
   _getWIFByIndex(internal, index) {
-    const root = bitcoin.bip32.fromSeed(mn.mnemonicToSeedSync(this.secret));
+    const root = bitcoin.bip32.fromSeed(mn.mnemonicToSeedSync(this.secret, MNEMONIC_TO_SEED_OPTS));
     const path = `m/${internal ? 1 : 0}/${index}`;
     const child = root.derivePath(path);
 

--- a/class/hd-legacy-electrum-seed-p2pkh-wallet.js
+++ b/class/hd-legacy-electrum-seed-p2pkh-wallet.js
@@ -4,11 +4,9 @@ const bitcoin = require('bitcoinjs-lib');
 const mn = require('electrum-mnemonic');
 const HDNode = require('bip32');
 
-// This type of wallet should only accept a valid standard prefix
+const PREFIX = mn.PREFIXES.standard;
 const MNEMONIC_TO_SEED_OPTS = {
-  validPrefixes: [
-    mn.PREFIXES.standard,
-  ],
+  prefix: PREFIX,
 };
 
 /**
@@ -22,13 +20,7 @@ export class HDLegacyElectrumSeedP2PKHWallet extends HDLegacyP2PKHWallet {
   static typeReadable = 'HD Legacy Electrum (BIP32 P2PKH)';
 
   validateMnemonic() {
-    try {
-      // This type of wallet should only accept a valid standard prefix
-      mn.mnemonicToSeedSync(this.secret, MNEMONIC_TO_SEED_OPTS);
-      return true;
-    } catch (_) {
-      return false;
-    }
+    return mn.validateMnemonic(this.secret, PREFIX);
   }
 
   async generate() {

--- a/class/hd-legacy-electrum-seed-p2pkh-wallet.js
+++ b/class/hd-legacy-electrum-seed-p2pkh-wallet.js
@@ -32,7 +32,7 @@ export class HDLegacyElectrumSeedP2PKHWallet extends HDLegacyP2PKHWallet {
       return this._xpub; // cache hit
     }
     const root = bitcoin.bip32.fromSeed(mn.mnemonicToSeedSync(this.secret, MNEMONIC_TO_SEED_OPTS));
-    this._xpub = root.toBase58();
+    this._xpub = root.neutered().toBase58();
     return this._xpub;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4683,9 +4683,9 @@
       "from": "git+https://github.com/BlueWallet/rn-electrum-client.git#2a5bb11dd9a8d89f328049d9ed59bce49d88a15d"
     },
     "electrum-mnemonic": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/electrum-mnemonic/-/electrum-mnemonic-1.0.7.tgz",
-      "integrity": "sha512-qi53UYOr+yxCBDVYzKm6a6yzomhHiZR43EuH2I3+teqizj2fapMDh0AyixB3id7ZnFCsiGnOxFqN4TzuzQy5dQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/electrum-mnemonic/-/electrum-mnemonic-2.0.0.tgz",
+      "integrity": "sha512-egooI/RRX31y1LUbvv2OJf0eptrJjc5/lFv6txgDZx91g6JdZrQeQp+5AqlcfDUdsl2aDkeHk1a79J6bt3v8SA==",
       "requires": {
         "create-hmac": "^1.1.7",
         "pbkdf2": "^3.0.17",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "dayjs": "1.8.23",
     "ecurve": "1.0.6",
     "electrum-client": "git+https://github.com/BlueWallet/rn-electrum-client.git#2a5bb11dd9a8d89f328049d9ed59bce49d88a15d",
-    "electrum-mnemonic": "1.0.7",
+    "electrum-mnemonic": "2.0.0",
     "eslint-config-prettier": "6.10.0",
     "eslint-config-standard": "12.0.0",
     "eslint-config-standard-react": "7.0.2",


### PR DESCRIPTION
Note: This can be a potentially breaking change in the following scenario:

1. User creates segwit wallet in Electrum.
2. User imports the seed into BlueWallet.
3. BlueWallet will use the seed to generate a legacy wallet when the seed's version prefix is not legacy.
4. Patched version will suddenly break it for them.

TBH I think the number of users using this is small enough to just patch it and help them out when they create an issue.