### PR TITLE
Fix npm install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11826,8 +11826,8 @@
       }
     },
     "react-native-secure-key-store": {
-      "version": "git+https://github.com/marcosrdz/react-native-secure-key-store.git#38332f629f577cdd57c69fc8cc971b3cbad193c9",
-      "from": "git+https://github.com/marcosrdz/react-native-secure-key-store.git#38332f629f577cdd57c69fc8cc971b3cbad193c9"
+      "version": "github:marcosrdz/react-native-secure-key-store#9813b3cb6049691c0f385cd90a5a18387617fd09",
+      "from": "github:marcosrdz/react-native-secure-key-store#9813b3cb6049691c0f385cd90a5a18387617fd09"
     },
     "react-native-share": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "react-native-quick-actions": "0.3.13",
     "react-native-randombytes": "3.5.3",
     "react-native-rate": "1.1.10",
-    "react-native-secure-key-store": "git+https://github.com/marcosrdz/react-native-secure-key-store.git#38332f629f577cdd57c69fc8cc971b3cbad193c9",
+    "react-native-secure-key-store": "github:marcosrdz/react-native-secure-key-store#9813b3cb6049691c0f385cd90a5a18387617fd09",
     "react-native-share": "2.0.0",
     "react-native-snap-carousel": "3.9.0",
     "react-native-sortable-list": "0.0.23",


### PR DESCRIPTION
Fixes:

```
npm ERR! code 128
npm ERR! Command failed: git checkout 38332f629f577cdd57c69fc8cc971b3cbad193c9
npm ERR! fatal: reference is not a tree: 38332f629f577cdd57c69fc8cc971b3cbad193c9
npm ERR!
```

Looks like the specified commit for `marcosrdz/react-native-secure-key-store` has been removed and now it can't be resolved.

I've done a quick check and the updated tip of master commit appears to still work ok. Not super familiar with how it's used though so would be good for someone more familiar to confirm.