### PR TITLE
FIX: for legacy-wallet.fetchTransactions() to not crash when vout for transaction is missing addresses.

### DIFF
--- a/class/legacy-wallet.js
+++ b/class/legacy-wallet.js
@@ -193,7 +193,7 @@ export class LegacyWallet extends AbstractWallet {
         }
       }
       for (let vout of tx.vout) {
-        if (vout.scriptPubKey.addresses.indexOf(this.getAddress()) !== -1) {
+        if (vout.scriptPubKey.addresses && vout.scriptPubKey.addresses.indexOf(this.getAddress()) !== -1) {
           // this TX is related to our address
           let clonedTx = Object.assign({}, tx);
           clonedTx.inputs = tx.vin.slice(0);

--- a/tests/integration/legacy-wallet.test.js
+++ b/tests/integration/legacy-wallet.test.js
@@ -67,6 +67,21 @@ describe('LegacyWallet', function() {
       assert.ok(tx.confirmations > 1);
     }
   });
+  
+  it('can fetch TXs when addresses for vout are missing', async () => {
+    // Transaction with missing address output https://www.blockchain.com/btc/tx/d45818ae11a584357f7b74da26012d2becf4ef064db015a45bdfcd9cb438929d
+    let w = new LegacyWallet();
+    w._address = '1PVfrmbn1vSMoFZB2Ga7nDuXLFDyJZHrHK';
+    await w.fetchTransactions();
+
+    assert.ok(w.getTransactions().length > 0);
+    for (let tx of w.getTransactions()) {
+      assert.ok(tx.hash);
+      assert.ok(tx.value);
+      assert.ok(tx.received);
+      assert.ok(tx.confirmations > 1);
+    }
+  });
 
   it('can fetch UTXO', async () => {
     let w = new LegacyWallet();


### PR DESCRIPTION
Was unable to view transactions for the following bitcoin address without this fix - [1PVfrmbn1vSMoFZB2Ga7nDuXLFDyJZHrHK](https://www.blockchain.com/btc/address/1PVfrmbn1vSMoFZB2Ga7nDuXLFDyJZHrHK)