### PR TITLE
FIX: Reduced batchsize to prevent "undefined" error when retrieving transactions

### DIFF
--- a/BlueElectrum.js
+++ b/BlueElectrum.js
@@ -339,7 +339,7 @@ module.exports.multiGetHistoryByAddress = async function(addresses, batchsize) {
 };
 
 module.exports.multiGetTransactionByTxid = async function(txids, batchsize, verbose) {
-  batchsize = batchsize || 40;
+  batchsize = batchsize || 49;
   // this value is fine-tuned so althrough wallets in test suite will occasionally
   // throw 'response too large (over 1,000,000 bytes', test suite will pass
   verbose = verbose !== false;

--- a/BlueElectrum.js
+++ b/BlueElectrum.js
@@ -339,7 +339,7 @@ module.exports.multiGetHistoryByAddress = async function(addresses, batchsize) {
 };
 
 module.exports.multiGetTransactionByTxid = async function(txids, batchsize, verbose) {
-  batchsize = batchsize || 61;
+  batchsize = batchsize || 40;
   // this value is fine-tuned so althrough wallets in test suite will occasionally
   // throw 'response too large (over 1,000,000 bytes', test suite will pass
   verbose = verbose !== false;

--- a/class/legacy-wallet.js
+++ b/class/legacy-wallet.js
@@ -193,7 +193,7 @@ export class LegacyWallet extends AbstractWallet {
         }
       }
       for (let vout of tx.vout) {
-        if (vout.scriptPubKey.addresses.indexOf(this.getAddress()) !== -1) {
+        if (vout.scriptPubKey.addresses && vout.scriptPubKey.addresses.indexOf(this.getAddress()) !== -1) {
           // this TX is related to our address
           let clonedTx = Object.assign({}, tx);
           clonedTx.inputs = tx.vin.slice(0);

--- a/tests/integration/legacy-wallet.test.js
+++ b/tests/integration/legacy-wallet.test.js
@@ -67,6 +67,21 @@ describe('LegacyWallet', function() {
       assert.ok(tx.confirmations > 1);
     }
   });
+  
+  it('can fetch TXs when addresses for vout are missing', async () => {
+    // Transaction with missing address output https://www.blockchain.com/btc/tx/d45818ae11a584357f7b74da26012d2becf4ef064db015a45bdfcd9cb438929d
+    let w = new LegacyWallet();
+    w._address = '1PVfrmbn1vSMoFZB2Ga7nDuXLFDyJZHrHK';
+    await w.fetchTransactions();
+
+    assert.ok(w.getTransactions().length > 0);
+    for (let tx of w.getTransactions()) {
+      assert.ok(tx.hash);
+      assert.ok(tx.value);
+      assert.ok(tx.received);
+      assert.ok(tx.confirmations > 1);
+    }
+  });
 
   it('can fetch UTXO', async () => {
     let w = new LegacyWallet();

--- a/tests/integration/legacy-wallet.test.js
+++ b/tests/integration/legacy-wallet.test.js
@@ -67,21 +67,27 @@ describe('LegacyWallet', function() {
       assert.ok(tx.confirmations > 1);
     }
   });
-  
-  it('can fetch TXs when addresses for vout are missing', async () => {
-    // Transaction with missing address output https://www.blockchain.com/btc/tx/d45818ae11a584357f7b74da26012d2becf4ef064db015a45bdfcd9cb438929d
-    let w = new LegacyWallet();
-    w._address = '1PVfrmbn1vSMoFZB2Ga7nDuXLFDyJZHrHK';
-    await w.fetchTransactions();
 
-    assert.ok(w.getTransactions().length > 0);
-    for (let tx of w.getTransactions()) {
-      assert.ok(tx.hash);
-      assert.ok(tx.value);
-      assert.ok(tx.received);
-      assert.ok(tx.confirmations > 1);
-    }
-  });
+  it.each([
+    ['addresses for vout missing', '1PVfrmbn1vSMoFZB2Ga7nDuXLFDyJZHrHK'],
+    ['txdatas were coming back null from BlueElectrum because of high batchsize', '34xp4vRoCGJym3xR7yCVPFHoCNxv4Twseo'],
+  ])(
+    'can fetch TXs when %s',
+    async (useCase, address) => {
+      let w = new LegacyWallet();
+      w._address = address;
+      await w.fetchTransactions();
+
+      assert.ok(w.getTransactions().length > 0);
+      for (let tx of w.getTransactions()) {
+        assert.ok(tx.hash);
+        assert.ok(tx.value);
+        assert.ok(tx.received);
+        assert.ok(tx.confirmations > 1);
+      }
+    },
+    240000,
+  );
 
   it('can fetch UTXO', async () => {
     let w = new LegacyWallet();


### PR DESCRIPTION
This batchsize change allowed me to retrieve transactions for the following 2 wallet addresses without receiving an undefined exception.
34xp4vRoCGJym3xR7yCVPFHoCNxv4Twseo
18rnfoQgGo1HqvVQaAN4QnxjYE7Sez9eca