### PR TITLE
FIX: bump frisbee package to 3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2053,6 +2053,11 @@
         "event-target-shim": "^5.0.0"
       }
     },
+    "abortcontroller-polyfill": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.4.0.tgz",
+      "integrity": "sha512-3ZFfCRfDzx3GFjO6RAkYx81lPGpUS20ISxux9gLxuKnqafNcFQo59+IoZqpO2WvQlyc287B62HDnDdNYRmlvWA=="
+    },
     "absolute-path": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/absolute-path/-/absolute-path-0.0.0.tgz",
@@ -3194,6 +3199,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "boolean": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
+      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA=="
     },
     "boolify": {
       "version": "1.0.1",
@@ -6104,15 +6114,20 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "frisbee": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/frisbee/-/frisbee-2.0.9.tgz",
-      "integrity": "sha512-k2YrtBki5iw0p2Wsee5KW0cQBpzvDAOcAXMcunNCwM31XCj4RFpa1WGA4541JY9wFz8QhTHBQXb2rE3ERvbr9w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/frisbee/-/frisbee-3.1.2.tgz",
+      "integrity": "sha512-qkhtfxUsTFS2BfWJcSKXWAMYPq9RhJkcrikOGPxvzhklI+RAM8tWd1V7n3t6V1uwPNjfPegNG5q1r5Yp3zXOFw==",
       "requires": {
+        "@babel/runtime": "^7.7.4",
+        "abortcontroller-polyfill": "^1.4.0",
+        "boolean": "^3.0.0",
         "caseless": "^0.12.0",
         "common-tags": "^1.8.0",
-        "cross-fetch": "^3.0.2",
-        "qs": "^6.7.0",
-        "url-join": "^4.0.0"
+        "cross-fetch": "^3.0.4",
+        "debug": "^4.1.1",
+        "qs": "6.9.1",
+        "url-join": "^4.0.1",
+        "url-parse": "^1.4.7"
       }
     },
     "fs-copy-file-sync": {
@@ -11278,6 +11293,11 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
+    "querystringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+    },
     "quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -12538,6 +12558,11 @@
       "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
       "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
       "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.15.1",
@@ -14007,6 +14032,15 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+    },
+    "url-parse": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "eslint-plugin-prettier": "3.1.2",
     "eslint-plugin-standard": "4.0.0",
     "events": "1.1.1",
-    "frisbee": "2.0.9",
+    "frisbee": "3.1.2",
     "intl": "1.2.5",
     "lottie-react-native": "3.1.1",
     "node-libs-react-native": "1.0.3",


### PR DESCRIPTION
Fixing #905 
upgraded frisbee version from v2.0.9 to v3.1.2
- tests work
- checked lightning network screen
- checked hodlhodl screen
Everything works fine