### PR TITLE
FIX: round fiat currencies to 2 significant digits

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -108,7 +108,7 @@ def enableProguardInReleaseBuilds = false
  * give correct results when using with locales other than en-US.  Note that
  * this variant is about 6MiB larger per architecture than default.
  */
-def jscFlavor = 'org.webkit:android-jsc:+'
+def jscFlavor = 'org.webkit:android-jsc-intl:+'
 
 /**
  * Whether to enable the Hermes VM.

--- a/currency.js
+++ b/currency.js
@@ -88,7 +88,7 @@ function satoshiToLocalCurrency(satoshi) {
 
   let b = new BigNumber(satoshi).dividedBy(100000000).multipliedBy(exchangeRates['BTC_' + preferredFiatCurrency.endPointKey]);
 
-  if (b.isGreaterThanOrEqualTo(1) || b.isLessThanOrEqualTo(-1)) {
+  if (b.isGreaterThanOrEqualTo(0.005) || b.isLessThanOrEqualTo(-0.005)) {
     b = b.toFixed(2);
   } else {
     b = b.toPrecision(2);

--- a/currency.js
+++ b/currency.js
@@ -86,20 +86,21 @@ function satoshiToLocalCurrency(satoshi) {
     return '...';
   }
 
-  let b = new BigNumber(satoshi);
-  b = b
-    .dividedBy(100000000)
-    .multipliedBy(exchangeRates['BTC_' + preferredFiatCurrency.endPointKey])
-    .toString(10);
-  b = parseFloat(b).toFixed(2);
+  let b = new BigNumber(satoshi).dividedBy(100000000).multipliedBy(exchangeRates['BTC_' + preferredFiatCurrency.endPointKey]);
+
+  if (b.isGreaterThanOrEqualTo(1) || b.isLessThanOrEqualTo(-1)) {
+    b = b.toFixed(2);
+  } else {
+    b = b.toPrecision(2);
+  }
 
   let formatter;
-
   try {
     formatter = new Intl.NumberFormat(preferredFiatCurrency.locale, {
       style: 'currency',
       currency: preferredFiatCurrency.endPointKey,
       minimumFractionDigits: 2,
+      maximumFractionDigits: 8,
     });
   } catch (error) {
     console.warn(error);
@@ -108,6 +109,7 @@ function satoshiToLocalCurrency(satoshi) {
       style: 'currency',
       currency: preferredFiatCurrency.endPointKey,
       minimumFractionDigits: 2,
+      maximumFractionDigits: 8,
     });
   }
 
@@ -135,3 +137,4 @@ module.exports.satoshiToBTC = satoshiToBTC;
 module.exports.BTCToLocalCurrency = BTCToLocalCurrency;
 module.exports.setPrefferedCurrency = setPrefferedCurrency;
 module.exports.getPreferredCurrency = getPreferredCurrency;
+module.exports.exchangeRates = exchangeRates; // export it to mock data in tests

--- a/currency.js
+++ b/currency.js
@@ -138,3 +138,4 @@ module.exports.BTCToLocalCurrency = BTCToLocalCurrency;
 module.exports.setPrefferedCurrency = setPrefferedCurrency;
 module.exports.getPreferredCurrency = getPreferredCurrency;
 module.exports.exchangeRates = exchangeRates; // export it to mock data in tests
+module.exports.preferredFiatCurrency = preferredFiatCurrency; // export it to mock data in tests

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-import 'intl';
-import 'intl/locale-data/jsonp/en';
 import React from 'react';
 import './shim.js';
 import { AppRegistry } from 'react-native';

--- a/package-lock.json
+++ b/package-lock.json
@@ -8010,11 +8010,6 @@
         "side-channel": "^1.0.2"
       }
     },
-    "intl": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/intl/-/intl-1.2.5.tgz",
-      "integrity": "sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94="
-    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "eslint-plugin-standard": "4.0.0",
     "events": "1.1.1",
     "frisbee": "3.1.2",
-    "intl": "1.2.5",
     "lottie-react-native": "3.1.1",
     "metro-react-native-babel-preset": "0.59.0",
     "node-libs-react-native": "1.2.0",

--- a/tests/integration/Currency.test.js
+++ b/tests/integration/Currency.test.js
@@ -30,32 +30,4 @@ describe('currency', () => {
     cur = JSON.parse(await AsyncStorage.getItem(AppStorage.EXCHANGE_RATES));
     assert.ok(cur['BTC_EUR'] > 0);
   });
-
-  it('formats everything correctly', async () => {
-    const currency = require('../../currency');
-    await currency.setPrefferedCurrency(FiatUnit.USD);
-    await currency.startUpdater();
-    currency.exchangeRates.BTC_USD = 10000;
-    assert.strictEqual(currency.satoshiToLocalCurrency(1), '$0.0001');
-    assert.strictEqual(currency.satoshiToLocalCurrency(-1), '-$0.0001');
-    assert.strictEqual(currency.satoshiToLocalCurrency(123), '$0.012');
-    assert.strictEqual(currency.satoshiToLocalCurrency(146), '$0.015');
-    assert.strictEqual(currency.satoshiToLocalCurrency(123456789), '$12,345.68');
-
-    assert.strictEqual(currency.BTCToLocalCurrency(1), '$10,000.00');
-    assert.strictEqual(currency.BTCToLocalCurrency(-1), '-$10,000.00');
-    assert.strictEqual(currency.BTCToLocalCurrency(1.00000001), '$10,000.00');
-    assert.strictEqual(currency.BTCToLocalCurrency(1.0000123), '$10,000.12');
-    assert.strictEqual(currency.BTCToLocalCurrency(1.0000146), '$10,000.15');
-
-    assert.strictEqual(currency.satoshiToBTC(1), '0.00000001');
-    assert.strictEqual(currency.satoshiToBTC(-1), '-0.00000001');
-    assert.strictEqual(currency.satoshiToBTC(100000000), '1');
-    assert.strictEqual(currency.satoshiToBTC(123456789123456789), '1234567891.2345678');
-
-    await currency.setPrefferedCurrency(FiatUnit.JPY);
-    await currency.startUpdater();
-    currency.exchangeRates.BTC_JPY = 1043740.8614;
-    assert.strictEqual(currency.satoshiToLocalCurrency(1), '¥0.01');
-  });
 });

--- a/tests/integration/Currency.test.js
+++ b/tests/integration/Currency.test.js
@@ -30,4 +30,32 @@ describe('currency', () => {
     cur = JSON.parse(await AsyncStorage.getItem(AppStorage.EXCHANGE_RATES));
     assert.ok(cur['BTC_EUR'] > 0);
   });
+
+  it('formats everything correctly', async () => {
+    const currency = require('../../currency');
+    await currency.setPrefferedCurrency(FiatUnit.USD);
+    await currency.startUpdater();
+    currency.exchangeRates.BTC_USD = 10000;
+    assert.strictEqual(currency.satoshiToLocalCurrency(1), '$0.0001');
+    assert.strictEqual(currency.satoshiToLocalCurrency(-1), '-$0.0001');
+    assert.strictEqual(currency.satoshiToLocalCurrency(123), '$0.012');
+    assert.strictEqual(currency.satoshiToLocalCurrency(146), '$0.015');
+    assert.strictEqual(currency.satoshiToLocalCurrency(123456789), '$12,345.68');
+
+    assert.strictEqual(currency.BTCToLocalCurrency(1), '$10,000.00');
+    assert.strictEqual(currency.BTCToLocalCurrency(-1), '-$10,000.00');
+    assert.strictEqual(currency.BTCToLocalCurrency(1.00000001), '$10,000.00');
+    assert.strictEqual(currency.BTCToLocalCurrency(1.0000123), '$10,000.12');
+    assert.strictEqual(currency.BTCToLocalCurrency(1.0000146), '$10,000.15');
+
+    assert.strictEqual(currency.satoshiToBTC(1), '0.00000001');
+    assert.strictEqual(currency.satoshiToBTC(-1), '-0.00000001');
+    assert.strictEqual(currency.satoshiToBTC(100000000), '1');
+    assert.strictEqual(currency.satoshiToBTC(123456789123456789), '1234567891.2345678');
+
+    await currency.setPrefferedCurrency(FiatUnit.JPY);
+    await currency.startUpdater();
+    currency.exchangeRates.BTC_JPY = 1043740.8614;
+    assert.strictEqual(currency.satoshiToLocalCurrency(1), '¥0.01');
+  });
 });

--- a/tests/unit/Currency.test.js
+++ b/tests/unit/Currency.test.js
@@ -6,10 +6,13 @@ describe('currency', () => {
   it('formats everything correctly', async () => {
     const currency = require('../../currency');
     currency.exchangeRates.BTC_USD = 10000;
+
     assert.strictEqual(currency.satoshiToLocalCurrency(1), '$0.0001');
     assert.strictEqual(currency.satoshiToLocalCurrency(-1), '-$0.0001');
-    assert.strictEqual(currency.satoshiToLocalCurrency(123), '$0.012');
-    assert.strictEqual(currency.satoshiToLocalCurrency(146), '$0.015');
+    assert.strictEqual(currency.satoshiToLocalCurrency(123), '$0.01');
+    assert.strictEqual(currency.satoshiToLocalCurrency(156), '$0.02');
+    assert.strictEqual(currency.satoshiToLocalCurrency(51), '$0.01');
+    assert.strictEqual(currency.satoshiToLocalCurrency(45), '$0.0045');
     assert.strictEqual(currency.satoshiToLocalCurrency(123456789), '$12,345.68');
 
     assert.strictEqual(currency.BTCToLocalCurrency(1), '$10,000.00');
@@ -27,6 +30,7 @@ describe('currency', () => {
     currency.preferredFiatCurrency.symbol = FiatUnit.JPY.symbol;
     currency.preferredFiatCurrency.locale = FiatUnit.JPY.locale;
     currency.exchangeRates.BTC_JPY = 1043740.8614;
+
     assert.strictEqual(currency.satoshiToLocalCurrency(1), '¥0.01');
   });
 });

--- a/tests/unit/Currency.test.js
+++ b/tests/unit/Currency.test.js
@@ -1,0 +1,32 @@
+/* global describe, it */
+import { FiatUnit } from '../../models/fiatUnit';
+let assert = require('assert');
+
+describe('currency', () => {
+  it('formats everything correctly', async () => {
+    const currency = require('../../currency');
+    currency.exchangeRates.BTC_USD = 10000;
+    assert.strictEqual(currency.satoshiToLocalCurrency(1), '$0.0001');
+    assert.strictEqual(currency.satoshiToLocalCurrency(-1), '-$0.0001');
+    assert.strictEqual(currency.satoshiToLocalCurrency(123), '$0.012');
+    assert.strictEqual(currency.satoshiToLocalCurrency(146), '$0.015');
+    assert.strictEqual(currency.satoshiToLocalCurrency(123456789), '$12,345.68');
+
+    assert.strictEqual(currency.BTCToLocalCurrency(1), '$10,000.00');
+    assert.strictEqual(currency.BTCToLocalCurrency(-1), '-$10,000.00');
+    assert.strictEqual(currency.BTCToLocalCurrency(1.00000001), '$10,000.00');
+    assert.strictEqual(currency.BTCToLocalCurrency(1.0000123), '$10,000.12');
+    assert.strictEqual(currency.BTCToLocalCurrency(1.0000146), '$10,000.15');
+
+    assert.strictEqual(currency.satoshiToBTC(1), '0.00000001');
+    assert.strictEqual(currency.satoshiToBTC(-1), '-0.00000001');
+    assert.strictEqual(currency.satoshiToBTC(100000000), '1');
+    assert.strictEqual(currency.satoshiToBTC(123456789123456789), '1234567891.2345678');
+
+    currency.preferredFiatCurrency.endPointKey = FiatUnit.JPY.endPointKey;
+    currency.preferredFiatCurrency.symbol = FiatUnit.JPY.symbol;
+    currency.preferredFiatCurrency.locale = FiatUnit.JPY.locale;
+    currency.exchangeRates.BTC_JPY = 1043740.8614;
+    assert.strictEqual(currency.satoshiToLocalCurrency(1), '¥0.01');
+  });
+});


### PR DESCRIPTION
In my lightning wallet I have transactions with very small amounts, like 1 Satoshi.
When I'm switching wallet to show values in USD it shows me transaction amount of *$0.00*
I've changed `Currency.satoshiToLocalCurrency` function so: 

if value is more than 1, it renders 2  digits after decimal point.

1.123 -> 1.12

If value less than 1, it renders 2 significant digits after decimal point

0.123 -> 0.12

0.00000567 -> 0.0000057

More examples at [tests](https://github.com/BlueWallet/BlueWallet/commit/f120bc95fbcbef3985334c35f684e3da8c9e5e67#diff-6d0d8e8ba20fdcb5559fec2003df241a) 

Because current version uses `Intl` polyfill which doesn't supports modern `Intl.NumberFormat` API, I've removed it and used `Intl` wich comes with react-native. Starting 0.60 it comes with it
 