### PR TITLE
FIX: following onchain+offchain invoice

### DIFF
--- a/Navigation.js
+++ b/Navigation.js
@@ -225,18 +225,6 @@ const ScanLndInvoiceRoot = () => (
   </ScanLndInvoiceStack.Navigator>
 );
 
-const HandleOffchainAndOnChainStack = createStackNavigator();
-const HandleOffchainAndOnChain = () => (
-  <HandleOffchainAndOnChainStack.Navigator screenOptions={{ headerBackTitleVisible: false, ...defaultStackScreenOptions }}>
-    {/* screens */}
-    <HandleOffchainAndOnChainStack.Screen name="SelectWallet" component={SelectWallet} options={SelectWallet.navigationOptions} />
-    <HandleOffchainAndOnChainStack.Screen name="ScanQRCode" component={ScanQRCodeRoot} />
-    {/* stacks */}
-    <HandleOffchainAndOnChainStack.Screen name="ScanLndInvoice" component={ScanLndInvoiceRoot} options={{ headerShown: false }} />
-    <HandleOffchainAndOnChainStack.Screen name="SendDetails" component={SendDetailsRoot} options={{ headerShown: false }} />
-  </HandleOffchainAndOnChainStack.Navigator>
-);
-
 const AztecoRedeemStack = createStackNavigator();
 const AztecoRedeemRoot = () => (
   <AztecoRedeemStack.Navigator screenOptions={defaultStackScreenOptions}>
@@ -261,7 +249,6 @@ const Navigation = () => (
     <RootStack.Screen name="SendDetailsRoot" component={SendDetailsRoot} options={{ headerShown: false }} />
     <RootStack.Screen name="LNDCreateInvoiceRoot" component={LNDCreateInvoiceRoot} options={{ headerShown: false }} />
     <RootStack.Screen name="ScanLndInvoiceRoot" component={ScanLndInvoiceRoot} options={{ headerShown: false }} />
-    <RootStack.Screen name="HandleOffchainAndOnChain" component={HandleOffchainAndOnChain} options={{ headerShown: false }} />
     <RootStack.Screen name="AztecoRedeemRoot" component={AztecoRedeemRoot} options={{ headerShown: false }} />
     <RootStack.Screen
       name="ScanQRCodeRoot"

--- a/class/deeplink-schema-match.js
+++ b/class/deeplink-schema-match.js
@@ -68,12 +68,11 @@ class DeeplinkSchemaMatch {
     }
     if (isBothBitcoinAndLightning) {
       completionHandler([
-        'HandleOffchainAndOnChain',
+        'SelectWallet',
         {
-          screen: 'SelectWallet',
-          params: {
-            onWalletSelect: wallet =>
-              completionHandler(DeeplinkSchemaMatch.isBothBitcoinAndLightningOnWalletSelect(wallet, isBothBitcoinAndLightning)),
+          onWalletSelect: (wallet, { navigation }) => {
+            navigation.pop(); // close select wallet screen
+            navigation.navigate(...DeeplinkSchemaMatch.isBothBitcoinAndLightningOnWalletSelect(wallet, isBothBitcoinAndLightning));
           },
         },
       ]);
@@ -206,18 +205,24 @@ class DeeplinkSchemaMatch {
   static isBothBitcoinAndLightningOnWalletSelect(wallet, uri) {
     if (wallet.chain === Chain.ONCHAIN) {
       return [
-        'SendDetails',
+        'SendDetailsRoot',
         {
-          uri: uri.bitcoin,
-          fromWallet: wallet,
+          screen: 'SendDetails',
+          params: {
+            uri: uri.bitcoin,
+            fromWallet: wallet,
+          },
         },
       ];
     } else if (wallet.chain === Chain.OFFCHAIN) {
       return [
-        'ScanLndInvoice',
+        'ScanLndInvoiceRoot',
         {
-          uri: uri.lndInvoice,
-          fromSecret: wallet.getSecret(),
+          screen: 'ScanLndInvoice',
+          params: {
+            uri: uri.lndInvoice,
+            fromSecret: wallet.getSecret(),
+          },
         },
       ];
     }

--- a/screen/wallets/selectWallet.js
+++ b/screen/wallets/selectWallet.js
@@ -75,7 +75,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const SelectWallet = () => {
+const SelectWallet = ({ navigation }) => {
   const { chainType, onWalletSelect, availableWallets } = useRoute().params;
   const [isLoading, setIsLoading] = useState(true);
   let data = chainType
@@ -96,7 +96,7 @@ const SelectWallet = () => {
       <TouchableOpacity
         onPress={() => {
           ReactNativeHapticFeedback.trigger('selection', { ignoreAndroidSystemSettings: false });
-          onWalletSelect(item);
+          onWalletSelect(item, { navigation });
         }}
       >
         <View shadowOpacity={40 / 100} shadowOffset={{ width: 0, height: 0 }} shadowRadius={5} style={styles.itemRoot}>

--- a/tests/unit/deeplink-schema-match.test.js
+++ b/tests/unit/deeplink-schema-match.test.js
@@ -165,6 +165,17 @@ describe('unit - DeepLinkSchemaMatch', function () {
       const navValue = await asyncNavigationRouteFor(event.argument);
       assert.deepStrictEqual(navValue, event.expected);
     }
+
+    // BIP21 w/BOLT11 support
+    assert.equal(
+      (
+        await asyncNavigationRouteFor({
+          url:
+            'bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001&lightning=lnbc1u1pwry044pp53xlmkghmzjzm3cljl6729cwwqz5hhnhevwfajpkln850n7clft4sdqlgfy4qv33ypmj7sj0f32rzvfqw3jhxaqcqzysxq97zvuq5zy8ge6q70prnvgwtade0g2k5h2r76ws7j2926xdjj2pjaq6q3r4awsxtm6k5prqcul73p3atveljkn6wxdkrcy69t6k5edhtc6q7lgpe4m5k4',
+        })
+      )[0],
+      'SelectWallet',
+    );
   });
 
   it('decodes bip21', () => {


### PR DESCRIPTION
Originally Success screen was 2 levels deep and when `navigation.dangerouslyGetParent().pop()` was called in it, it didn't close the SelectWallet screen.

I've fixed it by dismissing SelectWallet after wallet is selected.
Also I've discovered that all screen that are needed for this workflow to works are already exists inside RootStack. So I've removed HandleOffchainAndOnChain completely to simplify the code.

Less code - better!