### PR TITLE
ADD: extend pull to close gesture area to full modal height

### DIFF
--- a/Navigation.js
+++ b/Navigation.js
@@ -1,6 +1,7 @@
 // import { createAppContainer } from '@react-navigation/native';
 import React from 'react';
 import { createStackNavigator, TransitionPresets } from '@react-navigation/stack';
+import { Platform, Dimensions } from 'react-native';
 
 import Settings from './screen/settings/settings';
 import About from './screen/settings/about';
@@ -54,12 +55,13 @@ import LappBrowser from './screen/lnd/browser';
 import LNDCreateInvoice from './screen/lnd/lndCreateInvoice';
 import LNDViewInvoice from './screen/lnd/lndViewInvoice';
 import LNDViewAdditionalInvoiceInformation from './screen/lnd/lndViewAdditionalInvoiceInformation';
-import { Platform } from 'react-native';
 
+const SCREEN_HEIGHT = Dimensions.get('window').height;
 const defaultScreenOptions =
   Platform.OS === 'ios'
     ? ({ route, navigation }) => ({
         gestureEnabled: true,
+        gestureResponseDistance: { vertical: SCREEN_HEIGHT, horizontal: 50 },
         cardOverlayEnabled: true,
         headerStatusBarHeight: navigation.dangerouslyGetState().routes.indexOf(route) > 0 ? 10 : undefined,
         ...TransitionPresets.ModalPresentationIOS,
@@ -73,6 +75,7 @@ const defaultStackScreenOptions =
         headerStatusBarHeight: 10,
       }
     : undefined;
+
 const WalletsStack = createStackNavigator();
 const WalletsRoot = () => (
   <WalletsStack.Navigator>
@@ -266,7 +269,11 @@ const Navigation = () => (
     <RootStack.Screen
       name="ScanQRCodeRoot"
       component={ScanQRCodeRoot}
-      options={{ ...TransitionPresets.ModalTransition, headerShown: false }}
+      options={{
+        ...TransitionPresets.ModalTransition,
+        headerShown: false,
+        gestureResponseDistance: { vertical: SCREEN_HEIGHT, horizontal: 50 },
+      }}
     />
     {/* screens */}
     <RootStack.Screen name="WalletExport" component={WalletExport} options={WalletExport.navigationOptions} />

--- a/screen/wallets/reorderWallets.js
+++ b/screen/wallets/reorderWallets.js
@@ -74,6 +74,7 @@ export default class ReorderWallets extends Component {
     ),
     headerTitle: loc.wallets.reorder.title,
     headerLeft: null,
+    gestureEnabled: false,
   });
 
   constructor(props) {

--- a/screen/wallets/selectWallet.js
+++ b/screen/wallets/selectWallet.js
@@ -160,6 +160,7 @@ const SelectWallet = () => {
 SelectWallet.navigationOptions = ({ navigation }) => ({
   ...BlueNavigationStyle(navigation, true, () => navigation.goBack(null)),
   title: loc.wallets.select_wallet,
+  gestureEnabled: false,
 });
 
 export default SelectWallet;


### PR DESCRIPTION
On the iOS you can close modal by pull down gesture.
It already works in BlueWallet on scanQRCore, import and other modals, but only if you grab them by Header. 
I'm extending grab area to the full height of the modals.
Unfortunately it doesn't work everywhere correctly. That's why I'm disabling gestures for reorderWallets and selectWallet screens.

On android gestures are disabled by default, so it is not affected. 
I'm only changing gestureResponseDistance.vertical, horizontal remains default - 50

It feels very cool on import or scanqrcode screens