### PR TITLE
FIX: local trader: when user is not logged in, clicking 'accept offer…

### DIFF
--- a/screen/wallets/hodlHodl.js
+++ b/screen/wallets/hodlHodl.js
@@ -109,7 +109,10 @@ export default class HodlHodl extends Component {
 
     const sort = {
       [HodlHodlApi.SORT_BY]: HodlHodlApi.SORT_BY_VALUE_PRICE,
-      [HodlHodlApi.SORT_DIRECTION]: HodlHodlApi.SORT_DIRECTION_VALUE_ASC,
+      [HodlHodlApi.SORT_DIRECTION]:
+        this.state.side === HodlHodlApi.FILTERS_SIDE_VALUE_SELL
+          ? HodlHodlApi.SORT_DIRECTION_VALUE_ASC
+          : HodlHodlApi.SORT_DIRECTION_VALUE_DESC,
     };
     const offers = await this.state.HodlApi.getOffers(pagination, filters, sort);
 
@@ -156,8 +159,25 @@ export default class HodlHodl extends Component {
     this.setState({ methods });
   }
 
+  onFocus = async () => {
+    const hodlApiKey = await BlueApp.getHodlHodlApiKey();
+    const displayLoginButton = !hodlApiKey;
+
+    if (hodlApiKey && !this.state.hodlApiKey) {
+      // only if we had no key, and now we do, we update state
+      // (means user logged in)
+      this.setState({ hodlApiKey });
+      this.props.navigation.setParams({ displayLoginButton });
+    }
+  };
+
+  componentWillUnmount() {
+    this._unsubscribeFocus();
+  }
+
   async componentDidMount() {
     console.log('wallets/hodlHodl - componentDidMount');
+    this._unsubscribeFocus = this.props.navigation.addListener('focus', this.onFocus);
     A(A.ENUM.NAVIGATED_TO_WALLETS_HODLHODL);
 
     const hodlApiKey = await BlueApp.getHodlHodlApiKey();
@@ -819,6 +839,7 @@ export default class HodlHodl extends Component {
 
 HodlHodl.propTypes = {
   navigation: PropTypes.shape({
+    addListener: PropTypes.func,
     navigate: PropTypes.func,
     setParams: PropTypes.func,
   }),

--- a/screen/wallets/hodlHodlViewOffer.js
+++ b/screen/wallets/hodlHodlViewOffer.js
@@ -69,9 +69,19 @@ export default class HodlHodlViewOffer extends Component {
     });
   }
 
+  doLogin = () => {
+    const handleLoginCallback = (hodlApiKey, hodlHodlSignatureKey) => {
+      BlueApp.setHodlHodlApiKey(hodlApiKey, hodlHodlSignatureKey);
+      const HodlApi = new HodlHodlApi(hodlApiKey);
+      this.setState({ HodlApi, hodlApiKey });
+    };
+    NavigationService.navigate('HodlHodlRoot', { params: { cb: handleLoginCallback }, screen: 'HodlHodlLogin' });
+  };
+
   async _onAcceptOfferPress(offer) {
     if (!this.state.hodlApiKey) {
       alert('Please login to HodlHodl to accept offers');
+      this.doLogin();
       return;
     }
     const myself = await this.state.hodlApi.getMyself();
@@ -100,6 +110,13 @@ export default class HodlHodlViewOffer extends Component {
         cancelable: true,
       });
       return;
+    }
+
+    // lets refetch offer to avoid errors 'version mismatch'
+    const newOffer = await this.state.hodlApi.getOffer(offer.id);
+    if (newOffer.id && newOffer.version && offer.version !== newOffer.version) {
+      offer = newOffer;
+      this.setState({ offerToDisplay: newOffer });
     }
 
     let fiatValue;


### PR DESCRIPTION
…' should not just throw alert, but open login screen

FIX: local trader: before accepting offer, refetch it and use fresh id and version so there are no 'outdated' errors
FIX: local trader: when 'I am selling', sort order should be reversed

(closes #1280)