### PR TITLE
OPS: github-actions for e2e and jest tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+name: Tests
+
+# https://dev.to/edvinasbartkus/running-react-native-detox-tests-for-ios-and-android-on-github-actions-2ekn
+# https://medium.com/@reime005/the-best-ci-cd-for-react-native-with-e2e-support-4860b4aaab29
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v2
+
+    - name: Specify node version
+      uses: actions/setup-node@v2-beta
+      with:
+        node-version: 12
+
+    - name: Use npm caches
+      uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-npm-
+
+    - name: Use node_modules caches
+      id: cache-nm
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-nm-${{ hashFiles('package-lock.json') }}
+
+    - name: Install node_modules
+      if: steps.cache-nm.outputs.cache-hit != 'true'
+      run: npm install
+
+    - name: Run tests
+      run: npm test || npm test || npm test
+      env:
+        HD_MNEMONIC: ${{ secrets.HD_MNEMONIC }}
+        HD_MNEMONIC_BIP49: ${{ secrets.HD_MNEMONIC_BIP49 }}
+        HD_MNEMONIC_BIP49_MANY_TX: ${{ secrets.HD_MNEMONIC_BIP49_MANY_TX }}
+        HD_MNEMONIC_BIP84: ${{ secrets.HD_MNEMONIC_BIP84 }}
+        HD_MNEMONIC_BREAD: ${{ secrets.HD_MNEMONIC_BREAD }}
+
+  e2e:
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v2
+
+    - name: Specify node version
+      uses: actions/setup-node@v2-beta
+      with:
+        node-version: 12
+
+    - name: Use gradle caches
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    - name: Use npm caches
+      uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-npm-
+
+    - name: Use specific Java version for sdkmanager to work
+      uses: joschi/setup-jdk@v2
+      with:
+        java-version: '8'
+        architecture: 'x64'
+
+    - name: Install node_modules
+      run: npm install
+
+    - name: Build
+      run: npm run e2e:release-build
+
+    - name: Run tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 29
+        target: google_apis
+        avd-name: Pixel_API_29_AOSP
+        script: npm run e2e:release-test || npm run e2e:release-test
+      env:
+        HD_MNEMONIC: ${{ secrets.HD_MNEMONIC }}
+        HD_MNEMONIC_BIP84: ${{ secrets.HD_MNEMONIC_BIP84 }}
+
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: e2e-test-videos
+        path: ./artifacts/

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,8 @@ script:
   - echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
   - npm i
   - npm i -g detox-cli
-  - npm run e2e:release || npm run e2e:release-no-build
+  - npm run e2e:release-build
+  - npm run e2e:release-test || npm run e2e:release-test
 
 after_failure: ./tests/e2e/upload-artifacts.sh
 

--- a/package.json
+++ b/package.json
@@ -37,9 +37,10 @@
     "postinstall": "rn-nodeify --install buffer,events,process,stream,util,inherits,fs,path,assert --hack; npm run releasenotes2json; npm run podinstall; npx jetify",
     "test": "npm run lint && npm run unit && npm run jest",
     "jest": "jest -b -w 1 tests/integration/*",
-    "e2e:release": "detox build -c android.emu.release; npm run e2e:release-no-build",
-    "e2e:release-no-build": "detox test -c android.emu.release --record-videos all --take-screenshots all --headless",
-    "e2e:debug": "(test -f android/app/build/outputs/apk/debug/app-debug.apk && test -f android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk) || detox build -c android.emu.debug; detox test -c android.emu.debug",
+    "e2e:debug-build": "detox build -c android.emu.debug",
+    "e2e:debug-test": "detox test -c android.emu.debug",
+    "e2e:release-build": "npx detox build -c android.emu.release",
+    "e2e:release-test": "detox test -c android.emu.release --record-videos all --take-screenshots all --headless",
     "lint": "eslint *.js screen/**/*.js blue_modules/crypto.js class/**/*.js models/ loc/ tests/**/*.js",
     "lint:fix": "npm run lint -- --fix",
     "lint:quickfix": "git status --porcelain | grep -v '\\.json' | grep '\\.js' --color=never |  awk '{print $2}' | xargs eslint --fix; exit 0",
@@ -164,7 +165,7 @@
     "configurations": {
       "ios.sim.release": {
         "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/BlueWallet.app",
-        "build": "xcodebuild clean build -workspace ios/BlueWallet.xcworkspace -scheme BlueWallet -configuration Release -derivedDataPath ios/build  -sdk iphonesimulator13.2",
+        "build": "xcodebuild clean build -workspace ios/BlueWallet.xcworkspace -scheme BlueWallet -configuration Release -derivedDataPath ios/build -sdk iphonesimulator13.2",
         "type": "ios.simulator",
         "device": {
           "type": "iPhone 11"


### PR DESCRIPTION
After endless amount of attempts this is the best option to run e2e tests on github-actions. **30** min. Not much of a win. But config much simpler than travis. It caches `~/.npm` and `~/.gradle/caches`

If test is failing, recorded video is saved as artifacts.

I've also moved circleci tests to github actions because why not?

All you need to do is to create Secrets for this repository.

Also, I've renamed scripts in package.json because their names were confusing.

What I've tried and it didn't work:
- running tests against android debug build. It just freezes for unknown reason
- running tests against iOS sim build. It is possible in theory, but right now `npx detox build -c ios.sim.release` is broken and I can't fix it
- caching node_modues - breaks detox

You can see some examples here:
https://github.com/limpbrains/BlueWallet/actions

For #1217