### PR TITLE
Add support for zpub with fingerprint

### DIFF
--- a/class/wallets/abstract-wallet.js
+++ b/class/wallets/abstract-wallet.js
@@ -143,11 +143,11 @@ export class AbstractWallet {
     if (this.secret.startsWith('BC1')) this.secret = this.secret.toLowerCase();
 
     // [fingerprint/derivation]zpub
-    let re = /\[([^\]]+)\](.*)/;
-    let m = this.secret.match(re);
-    if(m && m.length==3){
-      let hexFingerprint = m[1].split("/")[0];
-      if(hexFingerprint.length == 8){
+    const re = /\[([^\]]+)\](.*)/;
+    const m = this.secret.match(re);
+    if (m && m.length === 3) {
+      let hexFingerprint = m[1].split('/')[0];
+      if (hexFingerprint.length === 8) {
         hexFingerprint = Buffer.from(hexFingerprint, 'hex').reverse().toString('hex');
         this.masterFingerprint = parseInt(hexFingerprint, 16);
       }

--- a/class/wallets/abstract-wallet.js
+++ b/class/wallets/abstract-wallet.js
@@ -142,6 +142,18 @@ export class AbstractWallet {
 
     if (this.secret.startsWith('BC1')) this.secret = this.secret.toLowerCase();
 
+    // [fingerprint/derivation]zpub
+    let re = /\[([^\]]+)\](.*)/;
+    let m = this.secret.match(re);
+    if(m && m.length==3){
+      let hexFingerprint = m[1].split("/")[0];
+      if(hexFingerprint.length == 8){
+        hexFingerprint = Buffer.from(hexFingerprint, 'hex').reverse().toString('hex');
+        this.masterFingerprint = parseInt(hexFingerprint, 16);
+      }
+      this.secret = m[2];
+    }
+
     try {
       const parsedSecret = JSON.parse(this.secret);
       if (parsedSecret && parsedSecret.keystore && parsedSecret.keystore.xpub) {

--- a/tests/unit/watch-only-wallet.test.js
+++ b/tests/unit/watch-only-wallet.test.js
@@ -120,7 +120,8 @@ describe('Watch only wallet', () => {
   });
 
   it('can import zpub with master fingerprint', async () => {
-    const zpub = "[8cce63f8/84h/0h/0h]zpub6s2RJ9qAEBW8Abhojs6LyDzF7gttcDr6EsR3Umu2aptZBb45e734rGtt4KqsCMmNyR1EEzUU2ugdVYez2VywQvAbBjUSKn8ho4Zk2c5otkk";
+    const zpub =
+      '[8cce63f8/84h/0h/0h]zpub6s2RJ9qAEBW8Abhojs6LyDzF7gttcDr6EsR3Umu2aptZBb45e734rGtt4KqsCMmNyR1EEzUU2ugdVYez2VywQvAbBjUSKn8ho4Zk2c5otkk';
     const w = new WatchOnlyWallet();
     w.setSecret(zpub);
     w.init();

--- a/tests/unit/watch-only-wallet.test.js
+++ b/tests/unit/watch-only-wallet.test.js
@@ -119,6 +119,20 @@ describe('Watch only wallet', () => {
     assert.strictEqual(w.getLabel(), 'Cobo Vault 5271c071');
   });
 
+  it('can import zpub with master fingerprint', async () => {
+    const zpub = "[8cce63f8/84h/0h/0h]zpub6s2RJ9qAEBW8Abhojs6LyDzF7gttcDr6EsR3Umu2aptZBb45e734rGtt4KqsCMmNyR1EEzUU2ugdVYez2VywQvAbBjUSKn8ho4Zk2c5otkk";
+    const w = new WatchOnlyWallet();
+    w.setSecret(zpub);
+    w.init();
+    assert.ok(w.valid());
+    assert.strictEqual(
+      w.getSecret(),
+      'zpub6s2RJ9qAEBW8Abhojs6LyDzF7gttcDr6EsR3Umu2aptZBb45e734rGtt4KqsCMmNyR1EEzUU2ugdVYez2VywQvAbBjUSKn8ho4Zk2c5otkk',
+    );
+    assert.strictEqual(w.getMasterFingerprint(), 4167290508);
+    assert.strictEqual(w.getMasterFingerprintHex(), '8cce63f8');
+  });
+
   it('can combine signed PSBT and prepare it for broadcast', async () => {
     const w = new WatchOnlyWallet();
     w.setSecret('zpub6rjLjQVqVnj7crz9E4QWj4WgczmEseJq22u2B6k2HZr6NE2PQx3ZYg8BnbjN9kCfHymSeMd2EpwpM5iiz5Nrb3TzvddxW2RMcE3VXdVaXHk');


### PR DESCRIPTION
Bitcoin Core uses an HD key format with maser fingerprint and derivation path in square brackets:
`[fingerprint/derivation]xpub`

In [Specter](https://github.com/cryptoadvance/specter-diy) we use a similar way to display xpubs. This PR adds support for this format of xpub and fills the master fingerprint.