### PR TITLE
OPS: Update gradle settings and versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ node --version && npm --version
 git clone https://github.com/BlueWallet/BlueWallet.git
 cd BlueWallet
 npm install
-``` 
+```
 
 Please make sure that your console is running the most stable versions of npm and node (even-numbered versions).
 
@@ -53,7 +53,8 @@ You will now need to either connect an Android device to your computer or run an
 1. Download and run Android Studio
 2. Click on "Open an existing Android Studio Project"
 3. Open `build.gradle` file under `BlueWallet/android/` folder
-4. Android Studio will take some time to set things up. Once everything is set up, go to `Tools` -> `AVD Manager`
+4. Android Studio will take some time to set things up. Once everything is set up, go to `Tools` -> `AVD Manager`.
+    * 📝 This option [may take some time to appear in the menu](https://stackoverflow.com/questions/47173708/why-avd-manager-options-are-not-showing-in-android-studio) if you're opening the project in a freshly-installed version of Android Studio.
 5. Click on "Create Virtual Device..." and go through the steps to create a virtual device
 6. Launch your newly created virtual device by clicking the `Play` button under `Actions` column
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     }
     ext.kotlinVersion = '1.3.+'
     dependencies {
-        classpath('com.android.tools.build:gradle:3.6.3')
+        classpath('com.android.tools.build:gradle:4.0.1')
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.google.gms:google-services:4.3.3'  // Google Services plugin
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Jul 21 23:04:55 CDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.10.4.tgz",
-      "integrity": "sha512-t+rjExOrSVvjQQXNp5zAIYDp00KjdvGl/TpDX5REPr0S9IAIPQMTilcfG6q8c0QFmj9lSTVySV2VTsyggvtNIw==",
+      "version": "7.10.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.10.5.tgz",
+      "integrity": "sha512-mPVoWNzIpYJHbWje0if7Ck36bpbtTvIxOi9+6WSK9wjGEXearAqlwBoTQvVjsAY2VIwgcs8V940geY3okzRCEw==",
       "requires": {
         "browserslist": "^4.12.0",
         "invariant": "^2.2.4",
@@ -318,9 +318,9 @@
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.4.tgz",
-      "integrity": "sha512-MJbxGSmejEFVOANAezdO39SObkURO5o/8b6fSH6D1pi9RZQt+ldppKPXfqgUWpSQ9asM6xaSaSJIaeWMDRP0Zg==",
+      "version": "7.10.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
+      "integrity": "sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/helper-remap-async-to-generator": "^7.10.4",
@@ -336,13 +336,12 @@
           }
         },
         "@babel/generator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-          "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
+          "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
           "requires": {
-            "@babel/types": "^7.10.4",
+            "@babel/types": "^7.10.5",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           }
         },
@@ -424,9 +423,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-          "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
+          "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ=="
         },
         "@babel/template": {
           "version": "7.10.4",
@@ -439,30 +438,35 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-          "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
+          "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
           "requires": {
             "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.10.4",
+            "@babel/generator": "^7.10.5",
             "@babel/helper-function-name": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.10.4",
-            "@babel/parser": "^7.10.4",
-            "@babel/types": "^7.10.4",
+            "@babel/parser": "^7.10.5",
+            "@babel/types": "^7.10.5",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.13"
+            "lodash": "^4.17.19"
           }
         },
         "@babel/types": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-          "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.13",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
         }
       }
     },
@@ -606,23 +610,22 @@
           }
         },
         "@babel/generator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-          "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
+          "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
           "requires": {
-            "@babel/types": "^7.10.4",
+            "@babel/types": "^7.10.5",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           }
         },
         "@babel/helper-create-class-features-plugin": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.4.tgz",
-          "integrity": "sha512-9raUiOsXPxzzLjCXeosApJItoMnX3uyT4QdM2UldffuGApNrF8e938MwNpDCK9CPoyxrEoCgT+hObJc3mZa6lQ==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
+          "integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
           "requires": {
             "@babel/helper-function-name": "^7.10.4",
-            "@babel/helper-member-expression-to-functions": "^7.10.4",
+            "@babel/helper-member-expression-to-functions": "^7.10.5",
             "@babel/helper-optimise-call-expression": "^7.10.4",
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/helper-replace-supers": "^7.10.4",
@@ -648,11 +651,11 @@
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
-          "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
+          "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
           "requires": {
-            "@babel/types": "^7.10.4"
+            "@babel/types": "^7.10.5"
           }
         },
         "@babel/helper-optimise-call-expression": {
@@ -703,9 +706,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-          "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
+          "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ=="
         },
         "@babel/template": {
           "version": "7.10.4",
@@ -718,30 +721,35 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-          "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
+          "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
           "requires": {
             "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.10.4",
+            "@babel/generator": "^7.10.5",
             "@babel/helper-function-name": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.10.4",
-            "@babel/parser": "^7.10.4",
-            "@babel/types": "^7.10.4",
+            "@babel/parser": "^7.10.5",
+            "@babel/types": "^7.10.5",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.13"
+            "lodash": "^4.17.19"
           }
         },
         "@babel/types": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-          "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.13",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
         }
       }
     },
@@ -778,11 +786,11 @@
           "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
         },
         "@babel/helper-regex": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.4.tgz",
-          "integrity": "sha512-inWpnHGgtg5NOF0eyHlC0/74/VkdRITY9dtTpB2PrxKKn+AkVMRiZz/Adrx+Ssg+MLDesi2zohBW6MVq6b4pOQ==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+          "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
           "requires": {
-            "lodash": "^4.17.13"
+            "lodash": "^4.17.19"
           }
         },
         "@babel/helper-validator-identifier": {
@@ -791,14 +799,19 @@
           "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
         },
         "@babel/types": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-          "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.13",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
         }
       }
     },
@@ -1046,11 +1059,11 @@
           "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
         },
         "@babel/helper-regex": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.4.tgz",
-          "integrity": "sha512-inWpnHGgtg5NOF0eyHlC0/74/VkdRITY9dtTpB2PrxKKn+AkVMRiZz/Adrx+Ssg+MLDesi2zohBW6MVq6b4pOQ==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+          "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
           "requires": {
-            "lodash": "^4.17.13"
+            "lodash": "^4.17.19"
           }
         },
         "@babel/helper-validator-identifier": {
@@ -1059,14 +1072,19 @@
           "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
         },
         "@babel/types": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-          "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.13",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
         }
       }
     },
@@ -1147,11 +1165,11 @@
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.4.tgz",
-      "integrity": "sha512-3Fw+H3WLUrTlzi3zMiZWp3AR4xadAEMv6XRCYnd5jAlLM61Rn+CRJaZMaNvIpcJpQ3vs1kyifYvEVPFfoSkKOA==",
+      "version": "7.10.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
+      "integrity": "sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==",
       "requires": {
-        "@babel/helper-module-transforms": "^7.10.4",
+        "@babel/helper-module-transforms": "^7.10.5",
         "@babel/helper-plugin-utils": "^7.10.4",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       },
@@ -1165,13 +1183,12 @@
           }
         },
         "@babel/generator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-          "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
+          "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
           "requires": {
-            "@babel/types": "^7.10.4",
+            "@babel/types": "^7.10.5",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           }
         },
@@ -1194,11 +1211,11 @@
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
-          "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
+          "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
           "requires": {
-            "@babel/types": "^7.10.4"
+            "@babel/types": "^7.10.5"
           }
         },
         "@babel/helper-module-imports": {
@@ -1210,17 +1227,17 @@
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz",
-          "integrity": "sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
+          "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
           "requires": {
             "@babel/helper-module-imports": "^7.10.4",
             "@babel/helper-replace-supers": "^7.10.4",
             "@babel/helper-simple-access": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.10.4",
             "@babel/template": "^7.10.4",
-            "@babel/types": "^7.10.4",
-            "lodash": "^4.17.13"
+            "@babel/types": "^7.10.5",
+            "lodash": "^4.17.19"
           }
         },
         "@babel/helper-optimise-call-expression": {
@@ -1280,9 +1297,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-          "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
+          "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ=="
         },
         "@babel/template": {
           "version": "7.10.4",
@@ -1295,30 +1312,35 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-          "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
+          "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
           "requires": {
             "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.10.4",
+            "@babel/generator": "^7.10.5",
             "@babel/helper-function-name": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.10.4",
-            "@babel/parser": "^7.10.4",
-            "@babel/types": "^7.10.4",
+            "@babel/parser": "^7.10.5",
+            "@babel/types": "^7.10.5",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.13"
+            "lodash": "^4.17.19"
           }
         },
         "@babel/types": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-          "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.13",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
         }
       }
     },
@@ -1334,12 +1356,12 @@
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.4.tgz",
-      "integrity": "sha512-Tb28LlfxrTiOTGtZFsvkjpyjCl9IoaRI52AEU/VIwOwvDQWtbNJsAqTXzh+5R7i74e/OZHH2c2w2fsOqAfnQYQ==",
+      "version": "7.10.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz",
+      "integrity": "sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==",
       "requires": {
         "@babel/helper-hoist-variables": "^7.10.4",
-        "@babel/helper-module-transforms": "^7.10.4",
+        "@babel/helper-module-transforms": "^7.10.5",
         "@babel/helper-plugin-utils": "^7.10.4",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       },
@@ -1353,13 +1375,12 @@
           }
         },
         "@babel/generator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-          "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
+          "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
           "requires": {
-            "@babel/types": "^7.10.4",
+            "@babel/types": "^7.10.5",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           }
         },
@@ -1390,11 +1411,11 @@
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
-          "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
+          "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
           "requires": {
-            "@babel/types": "^7.10.4"
+            "@babel/types": "^7.10.5"
           }
         },
         "@babel/helper-module-imports": {
@@ -1406,17 +1427,17 @@
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz",
-          "integrity": "sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
+          "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
           "requires": {
             "@babel/helper-module-imports": "^7.10.4",
             "@babel/helper-replace-supers": "^7.10.4",
             "@babel/helper-simple-access": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.10.4",
             "@babel/template": "^7.10.4",
-            "@babel/types": "^7.10.4",
-            "lodash": "^4.17.13"
+            "@babel/types": "^7.10.5",
+            "lodash": "^4.17.19"
           }
         },
         "@babel/helper-optimise-call-expression": {
@@ -1476,9 +1497,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-          "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
+          "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ=="
         },
         "@babel/template": {
           "version": "7.10.4",
@@ -1491,30 +1512,35 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-          "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
+          "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
           "requires": {
             "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.10.4",
+            "@babel/generator": "^7.10.5",
             "@babel/helper-function-name": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.10.4",
-            "@babel/parser": "^7.10.4",
-            "@babel/types": "^7.10.4",
+            "@babel/parser": "^7.10.5",
+            "@babel/types": "^7.10.5",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.13"
+            "lodash": "^4.17.19"
           }
         },
         "@babel/types": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-          "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.13",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
         }
       }
     },
@@ -1536,13 +1562,12 @@
           }
         },
         "@babel/generator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-          "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
+          "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
           "requires": {
-            "@babel/types": "^7.10.4",
+            "@babel/types": "^7.10.5",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           }
         },
@@ -1565,11 +1590,11 @@
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
-          "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
+          "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
           "requires": {
-            "@babel/types": "^7.10.4"
+            "@babel/types": "^7.10.5"
           }
         },
         "@babel/helper-module-imports": {
@@ -1581,17 +1606,17 @@
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz",
-          "integrity": "sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
+          "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
           "requires": {
             "@babel/helper-module-imports": "^7.10.4",
             "@babel/helper-replace-supers": "^7.10.4",
             "@babel/helper-simple-access": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.10.4",
             "@babel/template": "^7.10.4",
-            "@babel/types": "^7.10.4",
-            "lodash": "^4.17.13"
+            "@babel/types": "^7.10.5",
+            "lodash": "^4.17.19"
           }
         },
         "@babel/helper-optimise-call-expression": {
@@ -1651,9 +1676,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-          "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
+          "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ=="
         },
         "@babel/template": {
           "version": "7.10.4",
@@ -1666,30 +1691,35 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-          "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
+          "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
           "requires": {
             "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.10.4",
+            "@babel/generator": "^7.10.5",
             "@babel/helper-function-name": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.10.4",
-            "@babel/parser": "^7.10.4",
-            "@babel/types": "^7.10.4",
+            "@babel/parser": "^7.10.5",
+            "@babel/types": "^7.10.5",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.13"
+            "lodash": "^4.17.19"
           }
         },
         "@babel/types": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-          "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.13",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
         }
       }
     },
@@ -1720,11 +1750,11 @@
           }
         },
         "@babel/helper-regex": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.4.tgz",
-          "integrity": "sha512-inWpnHGgtg5NOF0eyHlC0/74/VkdRITY9dtTpB2PrxKKn+AkVMRiZz/Adrx+Ssg+MLDesi2zohBW6MVq6b4pOQ==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+          "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
           "requires": {
-            "lodash": "^4.17.13"
+            "lodash": "^4.17.19"
           }
         },
         "@babel/helper-validator-identifier": {
@@ -1733,14 +1763,19 @@
           "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
         },
         "@babel/types": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-          "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.13",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
         }
       }
     },
@@ -2163,23 +2198,23 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.10.2",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.10.2.tgz",
-      "integrity": "sha512-MjqhX0RZaEgK/KueRzh+3yPSk30oqDKJ5HP5tqTSB1e2gzGS3PLy7K0BIpnp78+0anFuSwOeuCf1zZO7RzRvEA==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.10.3.tgz",
+      "integrity": "sha512-jHaSUgiewTmly88bJtMHbOd1bJf2ocYxb5BWKSDQIP5tmgFuS/n0gl+nhSrYDhT33m0vPxp+rP8oYYgPgMNQlg==",
       "requires": {
-        "@babel/compat-data": "^7.10.1",
+        "@babel/compat-data": "^7.10.3",
         "@babel/helper-compilation-targets": "^7.10.2",
-        "@babel/helper-module-imports": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1",
-        "@babel/plugin-proposal-async-generator-functions": "^7.10.1",
+        "@babel/helper-module-imports": "^7.10.3",
+        "@babel/helper-plugin-utils": "^7.10.3",
+        "@babel/plugin-proposal-async-generator-functions": "^7.10.3",
         "@babel/plugin-proposal-class-properties": "^7.10.1",
         "@babel/plugin-proposal-dynamic-import": "^7.10.1",
         "@babel/plugin-proposal-json-strings": "^7.10.1",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.1",
         "@babel/plugin-proposal-numeric-separator": "^7.10.1",
-        "@babel/plugin-proposal-object-rest-spread": "^7.10.1",
+        "@babel/plugin-proposal-object-rest-spread": "^7.10.3",
         "@babel/plugin-proposal-optional-catch-binding": "^7.10.1",
-        "@babel/plugin-proposal-optional-chaining": "^7.10.1",
+        "@babel/plugin-proposal-optional-chaining": "^7.10.3",
         "@babel/plugin-proposal-private-methods": "^7.10.1",
         "@babel/plugin-proposal-unicode-property-regex": "^7.10.1",
         "@babel/plugin-syntax-async-generators": "^7.8.0",
@@ -2196,8 +2231,8 @@
         "@babel/plugin-transform-async-to-generator": "^7.10.1",
         "@babel/plugin-transform-block-scoped-functions": "^7.10.1",
         "@babel/plugin-transform-block-scoping": "^7.10.1",
-        "@babel/plugin-transform-classes": "^7.10.1",
-        "@babel/plugin-transform-computed-properties": "^7.10.1",
+        "@babel/plugin-transform-classes": "^7.10.3",
+        "@babel/plugin-transform-computed-properties": "^7.10.3",
         "@babel/plugin-transform-destructuring": "^7.10.1",
         "@babel/plugin-transform-dotall-regex": "^7.10.1",
         "@babel/plugin-transform-duplicate-keys": "^7.10.1",
@@ -2208,24 +2243,24 @@
         "@babel/plugin-transform-member-expression-literals": "^7.10.1",
         "@babel/plugin-transform-modules-amd": "^7.10.1",
         "@babel/plugin-transform-modules-commonjs": "^7.10.1",
-        "@babel/plugin-transform-modules-systemjs": "^7.10.1",
+        "@babel/plugin-transform-modules-systemjs": "^7.10.3",
         "@babel/plugin-transform-modules-umd": "^7.10.1",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.10.3",
         "@babel/plugin-transform-new-target": "^7.10.1",
         "@babel/plugin-transform-object-super": "^7.10.1",
         "@babel/plugin-transform-parameters": "^7.10.1",
         "@babel/plugin-transform-property-literals": "^7.10.1",
-        "@babel/plugin-transform-regenerator": "^7.10.1",
+        "@babel/plugin-transform-regenerator": "^7.10.3",
         "@babel/plugin-transform-reserved-words": "^7.10.1",
         "@babel/plugin-transform-shorthand-properties": "^7.10.1",
         "@babel/plugin-transform-spread": "^7.10.1",
         "@babel/plugin-transform-sticky-regex": "^7.10.1",
-        "@babel/plugin-transform-template-literals": "^7.10.1",
+        "@babel/plugin-transform-template-literals": "^7.10.3",
         "@babel/plugin-transform-typeof-symbol": "^7.10.1",
         "@babel/plugin-transform-unicode-escapes": "^7.10.1",
         "@babel/plugin-transform-unicode-regex": "^7.10.1",
         "@babel/preset-modules": "^0.1.3",
-        "@babel/types": "^7.10.2",
+        "@babel/types": "^7.10.3",
         "browserslist": "^4.12.0",
         "core-js-compat": "^3.6.2",
         "invariant": "^2.2.2",
@@ -2242,26 +2277,13 @@
           }
         },
         "@babel/generator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-          "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
+          "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
           "requires": {
-            "@babel/types": "^7.10.4",
+            "@babel/types": "^7.10.5",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
         "@babel/helper-annotate-as-pure": {
@@ -2270,18 +2292,6 @@
           "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
           "requires": {
             "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
         "@babel/helper-create-regexp-features-plugin": {
@@ -2295,25 +2305,13 @@
           }
         },
         "@babel/helper-define-map": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.4.tgz",
-          "integrity": "sha512-nIij0oKErfCnLUCWaCaHW0Bmtl2RO9cN7+u2QT8yqTywgALKlyUVOvHDElh+b5DwVC6YB1FOYFOTWcN/+41EDA==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+          "integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
           "requires": {
             "@babel/helper-function-name": "^7.10.4",
-            "@babel/types": "^7.10.4",
-            "lodash": "^4.17.13"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
+            "@babel/types": "^7.10.5",
+            "lodash": "^4.17.19"
           }
         },
         "@babel/helper-function-name": {
@@ -2324,18 +2322,6 @@
             "@babel/helper-get-function-arity": "^7.10.4",
             "@babel/template": "^7.10.4",
             "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
         "@babel/helper-get-function-arity": {
@@ -2344,72 +2330,36 @@
           "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
           "requires": {
             "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
         "@babel/helper-member-expression-to-functions": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
+          "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
+          "requires": {
+            "@babel/types": "^7.10.5"
+          }
+        },
+        "@babel/helper-module-imports": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
-          "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+          "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
           "requires": {
             "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz",
-          "integrity": "sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
+          "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
           "requires": {
             "@babel/helper-module-imports": "^7.10.4",
             "@babel/helper-replace-supers": "^7.10.4",
             "@babel/helper-simple-access": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.10.4",
             "@babel/template": "^7.10.4",
-            "@babel/types": "^7.10.4",
-            "lodash": "^4.17.13"
-          },
-          "dependencies": {
-            "@babel/helper-module-imports": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-              "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
+            "@babel/types": "^7.10.5",
+            "lodash": "^4.17.19"
           }
         },
         "@babel/helper-optimise-call-expression": {
@@ -2418,26 +2368,19 @@
           "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
           "requires": {
             "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
-        "@babel/helper-regex": {
+        "@babel/helper-plugin-utils": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.4.tgz",
-          "integrity": "sha512-inWpnHGgtg5NOF0eyHlC0/74/VkdRITY9dtTpB2PrxKKn+AkVMRiZz/Adrx+Ssg+MLDesi2zohBW6MVq6b4pOQ==",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
+        },
+        "@babel/helper-regex": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+          "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
           "requires": {
-            "lodash": "^4.17.13"
+            "lodash": "^4.17.19"
           }
         },
         "@babel/helper-remap-async-to-generator": {
@@ -2450,18 +2393,6 @@
             "@babel/template": "^7.10.4",
             "@babel/traverse": "^7.10.4",
             "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
         "@babel/helper-replace-supers": {
@@ -2473,18 +2404,6 @@
             "@babel/helper-optimise-call-expression": "^7.10.4",
             "@babel/traverse": "^7.10.4",
             "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
         "@babel/helper-simple-access": {
@@ -2494,18 +2413,6 @@
           "requires": {
             "@babel/template": "^7.10.4",
             "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
         "@babel/helper-split-export-declaration": {
@@ -2514,18 +2421,6 @@
           "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
           "requires": {
             "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
         "@babel/helper-validator-identifier": {
@@ -2542,18 +2437,6 @@
             "@babel/template": "^7.10.4",
             "@babel/traverse": "^7.10.4",
             "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
         "@babel/highlight": {
@@ -2567,9 +2450,28 @@
           }
         },
         "@babel/parser": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
+          "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ=="
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-          "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.4.tgz",
+          "integrity": "sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+            "@babel/plugin-transform-parameters": "^7.10.4"
+          }
+        },
+        "@babel/plugin-proposal-optional-chaining": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.4.tgz",
+          "integrity": "sha512-ZIhQIEeavTgouyMSdZRap4VPPHqJJ3NEs2cuHs5p0erH+iz6khB0qfgU8g7UuJkG88+fBMy23ZiU+nuHvekJeQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+          }
         },
         "@babel/plugin-syntax-class-properties": {
           "version": "7.10.4",
@@ -2577,13 +2479,6 @@
           "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            }
           }
         },
         "@babel/plugin-syntax-numeric-separator": {
@@ -2592,13 +2487,6 @@
           "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            }
           }
         },
         "@babel/plugin-transform-arrow-functions": {
@@ -2607,13 +2495,6 @@
           "integrity": "sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            }
           }
         },
         "@babel/plugin-transform-async-to-generator": {
@@ -2624,31 +2505,6 @@
             "@babel/helper-module-imports": "^7.10.4",
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/helper-remap-async-to-generator": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-module-imports": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-              "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
-              "requires": {
-                "@babel/types": "^7.10.4"
-              }
-            },
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            },
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
         "@babel/plugin-transform-block-scoped-functions": {
@@ -2657,29 +2513,14 @@
           "integrity": "sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            }
           }
         },
         "@babel/plugin-transform-block-scoping": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.4.tgz",
-          "integrity": "sha512-J3b5CluMg3hPUii2onJDRiaVbPtKFPLEaV5dOPY5OeAbDi1iU/UbbFFTgwb7WnanaDy7bjU35kc26W3eM5Qa0A==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.5.tgz",
+          "integrity": "sha512-6Ycw3hjpQti0qssQcA6AMSFDHeNJ++R6dIMnpRqUjFeBBTmTDPa8zgF90OVfTvAo11mXZTlVUViY1g8ffrURLg==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "lodash": "^4.17.13"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            }
+            "@babel/helper-plugin-utils": "^7.10.4"
           }
         },
         "@babel/plugin-transform-classes": {
@@ -2695,13 +2536,14 @@
             "@babel/helper-replace-supers": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.10.4",
             "globals": "^11.1.0"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            }
+          }
+        },
+        "@babel/plugin-transform-computed-properties": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
+          "integrity": "sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
           }
         },
         "@babel/plugin-transform-modules-commonjs": {
@@ -2713,13 +2555,6 @@
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/helper-simple-access": "^7.10.4",
             "babel-plugin-dynamic-import-node": "^2.3.3"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            }
           }
         },
         "@babel/plugin-transform-object-super": {
@@ -2729,29 +2564,15 @@
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/helper-replace-supers": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            }
           }
         },
         "@babel/plugin-transform-parameters": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.4.tgz",
-          "integrity": "sha512-RurVtZ/D5nYfEg0iVERXYKEgDFeesHrHfx8RT05Sq57ucj2eOYAP6eu5fynL4Adju4I/mP/I6SO0DqNWAXjfLQ==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
+          "integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
           "requires": {
             "@babel/helper-get-function-arity": "^7.10.4",
             "@babel/helper-plugin-utils": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            }
           }
         },
         "@babel/plugin-transform-property-literals": {
@@ -2760,13 +2581,6 @@
           "integrity": "sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            }
           }
         },
         "@babel/plugin-transform-regenerator": {
@@ -2783,13 +2597,6 @@
           "integrity": "sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            }
           }
         },
         "@babel/plugin-transform-spread": {
@@ -2798,13 +2605,6 @@
           "integrity": "sha512-1e/51G/Ni+7uH5gktbWv+eCED9pP8ZpRhZB3jOaI3mmzfvJTWHkuyYTv0Z5PYtyM+Tr2Ccr9kUdQxn60fI5WuQ==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            }
           }
         },
         "@babel/plugin-transform-sticky-regex": {
@@ -2814,29 +2614,15 @@
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/helper-regex": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            }
           }
         },
         "@babel/plugin-transform-template-literals": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.4.tgz",
-          "integrity": "sha512-4NErciJkAYe+xI5cqfS8pV/0ntlY5N5Ske/4ImxAVX7mk9Rxt2bwDTGv1Msc2BRJvWQcmYEC+yoMLdX22aE4VQ==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
+          "integrity": "sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==",
           "requires": {
             "@babel/helper-annotate-as-pure": "^7.10.4",
             "@babel/helper-plugin-utils": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            }
           }
         },
         "@babel/plugin-transform-unicode-regex": {
@@ -2846,13 +2632,6 @@
           "requires": {
             "@babel/helper-create-regexp-features-plugin": "^7.10.4",
             "@babel/helper-plugin-utils": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-              "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-            }
           }
         },
         "@babel/template": {
@@ -2863,47 +2642,38 @@
             "@babel/code-frame": "^7.10.4",
             "@babel/parser": "^7.10.4",
             "@babel/types": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
         "@babel/traverse": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-          "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
+          "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
           "requires": {
             "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.10.4",
+            "@babel/generator": "^7.10.5",
             "@babel/helper-function-name": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.10.4",
-            "@babel/parser": "^7.10.4",
-            "@babel/types": "^7.10.4",
+            "@babel/parser": "^7.10.5",
+            "@babel/types": "^7.10.5",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.13"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-              "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
+            "lodash": "^4.17.19"
           }
+        },
+        "@babel/types": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
         }
       }
     },
@@ -4664,14 +4434,14 @@
       "integrity": "sha512-deNc3JHBHz24YN+0DTAocXfrYFIFc1DvsIriMJSsJlR/MvsLzoq2+qwaEN+0/LJ37pstv85wZWY0pNugk4e41g=="
     },
     "@react-navigation/core": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-5.10.0.tgz",
-      "integrity": "sha512-cVQTj5FtZHWuymjZMP50RVXYpkQUbo1zQPjxJl+UfBUh7u9nKexknajBhjYbZq61uDE4MmPE8qAqIEJHKeR4Hg==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-5.12.1.tgz",
+      "integrity": "sha512-/0IQ/MzsLHD1JthTPd1AwpIEWMejPksh0qAloynEwL+ILLZMq9jJF3b7T8rFxHVbsBuaM7lKOWUcULDvnOxksQ==",
       "requires": {
-        "@react-navigation/routers": "^5.4.7",
+        "@react-navigation/routers": "^5.4.9",
         "escape-string-regexp": "^4.0.0",
-        "nanoid": "^3.1.5",
-        "query-string": "^6.12.1",
+        "nanoid": "^3.1.9",
+        "query-string": "^6.13.1",
         "react-is": "^16.13.0",
         "use-subscription": "^1.4.0"
       },
@@ -4684,26 +4454,26 @@
       }
     },
     "@react-navigation/native": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-5.5.1.tgz",
-      "integrity": "sha512-5pzsfvLdnvqfrWgTMCLDFaGK6Sj30p7tAMhUGneV2oGlx0OIbhgc6/04UUMpKEmAS2PaC/GZa1LQIsSVWDewvw==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-5.6.1.tgz",
+      "integrity": "sha512-jnSNEnuRzqLvG+7QcMthfB8eCZIzAE0Wku7HDgzfjFS2iA7Oa9ugeX/1qdP9heT2Mp0t9BDQ4XX4boJma9Z/xg==",
       "requires": {
-        "@react-navigation/core": "^5.10.0",
+        "@react-navigation/core": "^5.11.1",
         "nanoid": "^3.1.9"
       }
     },
     "@react-navigation/routers": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-5.4.7.tgz",
-      "integrity": "sha512-J+lQYDbEsyhAjcPpWY6ZJYEkGiZcPX62hNtySruShjbIEnI9gm3rC+BHdcrP/lufeWxWGFhI8CN7NSJGgP/Nmg==",
+      "version": "5.4.9",
+      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-5.4.9.tgz",
+      "integrity": "sha512-dYD5qrIKUmuBEp+O98hB0tDYpEsGQgCQFQgMEoFKBmVVhx2JnJJ1zxRjU7xWcCU4VdBA8IOowgHQHJsVNKYyrg==",
       "requires": {
-        "nanoid": "^3.1.5"
+        "nanoid": "^3.1.9"
       }
     },
     "@react-navigation/stack": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/stack/-/stack-5.5.1.tgz",
-      "integrity": "sha512-oU2FEm+Ba6jMd5VA2WnuNfCO2HlZmGhrEX9yjBCyFj7fFCG1SB7WJdKLhZShtx3KxG/qWKphICeTLlYvkHdSpQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/stack/-/stack-5.6.2.tgz",
+      "integrity": "sha512-51Aasxg8j2eKxz4mhA0ajJXrhAyJQkk2iiNE511zcqJ3tlfxv/h70Eej3PetnbbHFMOwNsEwc2GjB3OnfQcxjQ==",
       "requires": {
         "color": "^3.1.2",
         "react-native-iphone-x-helper": "^1.2.1"
@@ -6410,12 +6180,12 @@
       }
     },
     "browserslist": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.2.tgz",
-      "integrity": "sha512-MfZaeYqR8StRZdstAK9hCKDd2StvePCYp5rHzQCPicUjfFliDgmuaBNPHYUTpAywBN8+Wc/d7NYVFkO0aqaBUw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.13.0.tgz",
+      "integrity": "sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001088",
-        "electron-to-chromium": "^1.3.483",
+        "caniuse-lite": "^1.0.30001093",
+        "electron-to-chromium": "^1.3.488",
         "escalade": "^3.0.1",
         "node-releases": "^1.1.58"
       }
@@ -6562,9 +6332,9 @@
       "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001091",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001091.tgz",
-      "integrity": "sha512-ECd8gfBBpv0GKsEYY5052+8PBjExiugDoi3dfkJcxujh2mf7kiuDvb1o27GXlOOGopKiIPYEX8XDPYj7eo3E9w=="
+      "version": "1.0.30001104",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001104.tgz",
+      "integrity": "sha512-pkpCg7dmI/a7WcqM2yfdOiT4Xx5tzyoHAXWsX5/HxZ3TemwDZs0QXdqbE0UPLPVy/7BeK7693YfzfRYfu1YVpg=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -7761,9 +7531,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.483",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.483.tgz",
-      "integrity": "sha512-+05RF8S9rk8S0G8eBCqBRBaRq7+UN3lDs2DAvnG8SBSgQO3hjy0+qt4CmRk5eiuGbTcaicgXfPmBi31a+BD3lg=="
+      "version": "1.3.502",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.502.tgz",
+      "integrity": "sha512-TIeXOaHAvfP7FemGUtAJxStmOc1YFGWFNqdey/4Nk41L9b1nMmDVDGNMIWhZJvOfJxix6Cv5FGEnBK+yvw3UTg=="
     },
     "electrum-client": {
       "version": "git+https://github.com/BlueWallet/rn-electrum-client.git#cc018effafd2256272f348953500c4d27cef0d2f",
@@ -7908,9 +7678,9 @@
       }
     },
     "escalade": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.1.tgz",
-      "integrity": "sha512-DR6NO3h9niOT+MZs7bjxlj2a1k+POu5RN8CLTPX2+i78bRi9eLe7+0zXgUHMnGXWybYcL61E9hGhPKqedy8tQA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
+      "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -13409,9 +13179,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.58",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.58.tgz",
-      "integrity": "sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg=="
+      "version": "1.1.59",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.59.tgz",
+      "integrity": "sha512-H3JrdUczbdiwxN5FuJPyCHnGHIFqQ0wWxo+9j1kAXAzqNMAHlo+4I/sYYxpyK0irQ73HgdiyzD32oqQDcU2Osw=="
     },
     "node-stream-zip": {
       "version": "1.11.2",


### PR DESCRIPTION
Solves the issue described [here](https://stackoverflow.com/questions/60844245/how-solve-could-not-initialize-class-org-codehaus-groovy-reflection-reflectionc).

I encountered this while attempting to build and run the latest master locally on MacOS using the latest version of Android Studio (4.0.1).