### PR TITLE
FIX: recieve button for watch-only wallets

### DIFF
--- a/BlueComponents.js
+++ b/BlueComponents.js
@@ -1374,7 +1374,7 @@ const sendReceiveScanButtonFontSize =
 export class BlueReceiveButtonIcon extends Component {
   render() {
     return (
-      <TouchableOpacity {...this.props} style={{ flex: 0.5 }}>
+      <TouchableOpacity {...this.props} style={{ flex: 1 }}>
         <View
           style={{
             flex: 1,
@@ -1462,7 +1462,7 @@ export class BlueScanButton extends Component {
 export class BlueSendButtonIcon extends Component {
   render() {
     return (
-      <TouchableOpacity {...this.props} testID="SendButton" style={{ flex: 0.5 }}>
+      <TouchableOpacity {...this.props} testID="SendButton" style={{ flex: 1 }}>
         <View
           style={{
             flex: 1,


### PR DESCRIPTION
When wallet is watch-only we need to show one button - Receive and it should take all the space in floatButtons container
Before:

![image](https://user-images.githubusercontent.com/155891/91169939-d5aa6c00-e6e0-11ea-8b01-eb36c9bbad83.png)

After

![image](https://user-images.githubusercontent.com/155891/91169971-dfcc6a80-e6e0-11ea-9c14-e81579b19ffe.png)
