### PR TITLE
FIX: Improve wallet description translation

### DIFF
--- a/loc/en.json
+++ b/loc/en.json
@@ -345,7 +345,7 @@
     "list_empty_txs1_lightning": "Lightning wallet should be used for your daily transactions. Fees are unfairly cheap and speed is blazing fast.",
     "list_empty_txs2": "Start with your wallet",
     "list_empty_txs2_lightning": "\nTo start using it tap on \"manage funds\" and topup your balance.",
-    "list_header": "A wallet represents a pair of a secret (private key) and an addressyou can share to receive coins.",
+    "list_header": "A wallet represents a pair of keys, one private and one you can share to receive coins.",
     "list_import_error": "An error was encountered when attempting to import this wallet.",
     "list_import_problem": "There was a problem importing this wallet",
     "list_latest_transaction": "latest transaction",


### PR DESCRIPTION
Changed
"A wallet represents a pair of a secret (private key) and an addressyou can share to receive coins"
to
"A wallet represents a pair of keys, one private and one you can share to receive coins"