### PR TITLE
FIX: create interval for tx list in useEffect hook

### DIFF
--- a/screen/wallets/transactions.js
+++ b/screen/wallets/transactions.js
@@ -213,7 +213,6 @@ const WalletTransactions = () => {
       backgroundColor: colors.background,
     },
   });
-  const interval = setInterval(() => setTimeElapsed(prev => ({ timeElapsed: prev.timeElapsed + 1 })), 60000);
 
   /**
    * Simple wrapper for `wallet.getTransactions()`, where `wallet` is current wallet.
@@ -237,6 +236,7 @@ const WalletTransactions = () => {
   useEffect(() => {
     EV(EV.enum.REMOTE_TRANSACTIONS_COUNT_CHANGED, refreshTransactionsFunction, true);
     HandoffSettings.isHandoffUseEnabled().then(setIsHandOffUseEnabled);
+    const interval = setInterval(() => setTimeElapsed(prev => prev + 1), 60000);
     return () => {
       clearInterval(interval);
       navigate('DrawerRoot', { selectedWallet: '' });


### PR DESCRIPTION
- each render of `WalletTransactions` creates new interval
- in `setInterval` the state is changing which triggers render
- after a few cycles we have hundreds re-renders each of them triggers `wallet.getTransactions`
- app freezes

I've moved interval creation to `useEffect`, now it will be executed only once on component mount.
