### PR TITLE
FIX: textAlign: left for custom fee in CPFP/RBF form

### DIFF
--- a/BlueComponents.js
+++ b/BlueComponents.js
@@ -2418,7 +2418,7 @@ export class BlueReplaceFeeSuggestions extends Component {
                 marginRight: 10,
                 minHeight: 33,
                 paddingRight: 5,
-                textAlign: 'right',
+                paddingLeft: 5,
               }}
               onFocus={() => this.onCustomFeeTextChange(this.state.customFeeValue)}
               defaultValue={`${this.props.transactionMinimum}`}


### PR DESCRIPTION
Fixing #1801

change textAlign from right to left