### PR TITLE
Ops bump payjoin dep

### DIFF
--- a/class/deeplink-schema-match.js
+++ b/class/deeplink-schema-match.js
@@ -330,6 +330,7 @@ class DeeplinkSchemaMatch {
     let address = uri || '';
     let memo = '';
     let payjoinUrl = '';
+    let payjoinOutputSubstitutionDisabled = false;
     try {
       parsedBitcoinUri = DeeplinkSchemaMatch.bip21decode(uri);
       address = 'address' in parsedBitcoinUri ? parsedBitcoinUri.address : address;
@@ -344,9 +345,12 @@ class DeeplinkSchemaMatch {
         if ('pj' in parsedBitcoinUri.options) {
           payjoinUrl = parsedBitcoinUri.options.pj;
         }
+        if ('pjos' in parsedBitcoinUri.options) {
+          payjoinOutputSubstitutionDisabled = parsedBitcoinUri.options.pjos === "0";
+        }
       }
     } catch (_) {}
-    return { address, amount, memo, payjoinUrl };
+    return { address, amount, memo, payjoinUrl, payjoinOutputSubstitutionDisabled };
   }
 }
 

--- a/class/payjoin-transaction.js
+++ b/class/payjoin-transaction.js
@@ -1,6 +1,7 @@
 /* global alert */
 import * as bitcoin from 'bitcoinjs-lib';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
+import {getEndpointUrl} from "payjoin-client";
 
 const delay = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
 
@@ -76,4 +77,38 @@ export default class PayjoinTransaction {
       }
     });
   }
+}
+
+export function getEndpointUrlFunc(url, params){
+  function setParam(url, key, value) {
+    // adds or changes a ? or & parameter for a url string
+    // returns the changed string.
+    const split = url.split('?');
+    const qsValue = `${key}=${encodeURIComponent(value)}`;
+    if (split.length > 1) {
+      split[1] = removeParam(decodeURIComponent(split[1]), key);
+      split[1] += `${split[1].length === 0 ? '' : '&'}${qsValue}`;
+    } else {
+      split.push(qsValue);
+    }
+
+    return `${split[0]}?${split[1]}`;
+  }
+
+  function removeParam(queryString, key){
+    const matchedKeyIndex = queryString.indexOf(`${key}=`);
+    if (matchedKeyIndex !== -1) {
+      const endIndex = queryString.indexOf('&', matchedKeyIndex);
+      if (endIndex === -1) {
+        return queryString.substr(0, matchedKeyIndex);
+      } else {
+        return `${queryString.substr(0, matchedKeyIndex)}${queryString.substr(
+            endIndex,
+        )}`;
+      }
+    }
+    return queryString;
+  }
+
+  return getEndpointUrl(url, params, setParam)
 }

--- a/class/payjoin-transaction.js
+++ b/class/payjoin-transaction.js
@@ -76,10 +76,4 @@ export default class PayjoinTransaction {
       }
     });
   }
-
-  async isOwnOutputScript(outputScript) {
-    const address = bitcoin.address.fromOutputScript(outputScript);
-
-    return this._wallet.weOwnAddress(address);
-  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7634,15 +7634,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -10571,7 +10569,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       },
@@ -10580,15 +10577,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -17021,8 +17016,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
@@ -17109,9 +17103,8 @@
       }
     },
     "payjoin-client": {
-      "version": "1.0.0-beta",
-      "resolved": "https://registry.npmjs.org/payjoin-client/-/payjoin-client-1.0.0-beta.tgz",
-      "integrity": "sha512-y02eupH3eHC4ZXViJRDJROE6MBrngdunCia2e210oI1mJVL6y+Wl8d+q/ukiJO+XSy9UsomZRoUaUcEBWfIGBg==",
+      "version": "git+https://github.com/bitcoinjs/payjoin-client.git#b64156c5105ba641aa798e652d16b3ceeaee7eba",
+      "from": "git+https://github.com/bitcoinjs/payjoin-client.git#bip78",
       "requires": {
         "bitcoinjs-lib": "^5.2.0"
       }
@@ -18543,8 +18536,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7634,15 +7634,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -10571,7 +10569,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       },
@@ -10580,15 +10577,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -17021,8 +17016,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
@@ -17109,8 +17103,8 @@
       }
     },
     "payjoin-client": {
-      "version": "git+https://github.com/bitcoinjs/payjoin-client.git#31d2118a4c0d00192d975f3a6da2a96238f8f7a5",
-      "from": "git+https://github.com/bitcoinjs/payjoin-client.git#31d2118a4c0d00192d975f3a6da2a96238f8f7a5",
+      "version": "git+https://github.com/bitcoinjs/payjoin-client.git#b64156c5105ba641aa798e652d16b3ceeaee7eba",
+      "from": "git+https://github.com/bitcoinjs/payjoin-client.git#bip78",
       "requires": {
         "bitcoinjs-lib": "^5.2.0"
       }
@@ -18542,8 +18536,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7634,13 +7634,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -10569,6 +10571,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       },
@@ -10577,13 +10580,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -17016,7 +17021,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
@@ -17103,8 +17109,9 @@
       }
     },
     "payjoin-client": {
-      "version": "git+https://github.com/bitcoinjs/payjoin-client.git#b64156c5105ba641aa798e652d16b3ceeaee7eba",
-      "from": "git+https://github.com/bitcoinjs/payjoin-client.git#bip78",
+      "version": "1.0.0-beta",
+      "resolved": "https://registry.npmjs.org/payjoin-client/-/payjoin-client-1.0.0-beta.tgz",
+      "integrity": "sha512-y02eupH3eHC4ZXViJRDJROE6MBrngdunCia2e210oI1mJVL6y+Wl8d+q/ukiJO+XSy9UsomZRoUaUcEBWfIGBg==",
       "requires": {
         "bitcoinjs-lib": "^5.2.0"
       }
@@ -18536,7 +18543,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17103,7 +17103,7 @@
       }
     },
     "payjoin-client": {
-      "version": "git+https://github.com/bitcoinjs/payjoin-client.git#b64156c5105ba641aa798e652d16b3ceeaee7eba",
+      "version": "git+https://github.com/bitcoinjs/payjoin-client.git#3359dfac1f9264d44a25b7d183c77d2153f4353e",
       "from": "git+https://github.com/bitcoinjs/payjoin-client.git#bip78",
       "requires": {
         "bitcoinjs-lib": "^5.2.0"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "lottie-react-native": "3.5.0",
     "metro-react-native-babel-preset": "0.63.0",
     "path-browserify": "1.0.1",
-    "payjoin-client": "git+https://github.com/bitcoinjs/payjoin-client.git#bip78",
+    "payjoin-client": "^1.0.0-beta",
     "pbkdf2": "3.1.1",
     "prettier": "2.1.1",
     "process": "0.11.10",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "lottie-react-native": "3.5.0",
     "metro-react-native-babel-preset": "0.63.0",
     "path-browserify": "1.0.1",
-    "payjoin-client": "^1.0.0-beta",
+    "payjoin-client": "git+https://github.com/bitcoinjs/payjoin-client.git#bip78",
     "pbkdf2": "3.1.1",
     "prettier": "2.1.1",
     "process": "0.11.10",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "lottie-react-native": "3.5.0",
     "metro-react-native-babel-preset": "0.63.0",
     "path-browserify": "1.0.1",
-    "payjoin-client": "git+https://github.com/bitcoinjs/payjoin-client.git#31d2118a4c0d00192d975f3a6da2a96238f8f7a5",
+    "payjoin-client": "git+https://github.com/bitcoinjs/payjoin-client.git#bip78",
     "pbkdf2": "3.1.1",
     "prettier": "2.1.1",
     "process": "0.11.10",

--- a/screen/send/confirm.js
+++ b/screen/send/confirm.js
@@ -2,8 +2,8 @@
 import React, { Component } from 'react';
 import { ActivityIndicator, FlatList, TouchableOpacity, StyleSheet, Switch, View } from 'react-native';
 import { Text } from 'react-native-elements';
-import { PayjoinClient } from 'payjoin-client';
-import PayjoinTransaction from '../../class/payjoin-transaction';
+import {getEndpointUrl, PayjoinClient} from 'payjoin-client';
+import PayjoinTransaction, {getEndpointUrlFunc} from '../../class/payjoin-transaction';
 import { BlueButton, BlueText, SafeBlueArea, BlueCard, BlueSpacing40, BlueNavigationStyle } from '../../BlueComponents';
 import { BitcoinUnit } from '../../models/bitcoinUnits';
 import PropTypes from 'prop-types';
@@ -55,6 +55,7 @@ export default class Confirm extends Component {
     if (!this.state.recipients || !this.state.recipients.length) alert('Internal error: recipients list empty (this should never happen)');
     this.isBiometricUseCapableAndEnabled = await Biometric.isBiometricUseCapableAndEnabled();
   }
+ 
 
   send() {
     this.setState({ isLoading: true }, async () => {
@@ -71,7 +72,8 @@ export default class Confirm extends Component {
               payjoinVersion: 1,
               disableOutputSubstitution: this.state.payjoinOutputSubstitutionDisabled
             },
-            paymentScript: bitcoin.address.toOutputScript(this.state.recipients[0].address)
+            paymentScript: bitcoin.address.toOutputScript(this.state.recipients[0].address),
+            getEndpointUrl: getEndpointUrlFunc
           });
           await payjoinClient.run();
           const payjoinPsbt = wallet.getPayjoinPsbt();

--- a/screen/send/confirm.js
+++ b/screen/send/confirm.js
@@ -36,6 +36,7 @@ export default class Confirm extends Component {
       isLoading: false,
       isPayjoinEnabled: false,
       payjoinUrl: props.route.params.fromWallet.allowPayJoin() ? props.route.params?.payjoinUrl : false,
+      payjoinOutputSubstitutionDisabled: props.route.params.fromWallet.allowPayJoin() ? props.route.params?.payjoinOutputSubstitutionDisabled : false,
       psbt: props.route.params?.psbt,
       fee: props.route.params?.fee,
       feeSatoshi: new Bignumber(props.route.params.fee).multipliedBy(100000000).toNumber(),
@@ -66,6 +67,11 @@ export default class Confirm extends Component {
           const payjoinClient = new PayjoinClient({
             wallet,
             payjoinUrl: this.state.payjoinUrl,
+            payjoinParameters: {
+              payjoinVersion: 1,
+              disableOutputSubstitution: this.state.payjoinOutputSubstitutionDisabled
+            },
+            paymentScript: bitcoin.address.toOutputScript(this.state.recipients[0].address)
           });
           await payjoinClient.run();
           const payjoinPsbt = wallet.getPayjoinPsbt();

--- a/screen/send/details.js
+++ b/screen/send/details.js
@@ -318,6 +318,7 @@ export default class SendDetails extends Component {
             amountUnit: BitcoinUnit.BTC,
             units,
             payjoinUrl: options.pj || '',
+            payjoinOutputSubstitutionDisabled: options.pjos === "0"
           });
         } else {
           this.setState({ isLoading: false });
@@ -335,10 +336,10 @@ export default class SendDetails extends Component {
     if (this.props.route.params.uri) {
       const uri = this.props.route.params.uri;
       try {
-        const { address, amount, memo, payjoinUrl } = DeeplinkSchemaMatch.decodeBitcoinUri(uri);
+        const { address, amount, memo, payjoinUrl, payjoinOutputSubstitutionDisabled } = DeeplinkSchemaMatch.decodeBitcoinUri(uri);
         addresses.push(new BitcoinTransaction(address, amount, currency.btcToSatoshi(amount)));
         initialMemo = memo;
-        this.setState({ addresses, memo: initialMemo, isLoading: false, amountUnit: BitcoinUnit.BTC, payjoinUrl });
+        this.setState({ addresses, memo: initialMemo, isLoading: false, amountUnit: BitcoinUnit.BTC, payjoinUrl,payjoinOutputSubstitutionDisabled });
       } catch (error) {
         console.log(error);
         alert(loc.send.details_error_decode);
@@ -377,8 +378,8 @@ export default class SendDetails extends Component {
 
     if (this.props.route.params.uri) {
       try {
-        const { address, amount, memo, payjoinUrl } = DeeplinkSchemaMatch.decodeBitcoinUri(this.props.route.params.uri);
-        this.setState({ address, amount, memo, isLoading: false, payjoinUrl });
+        const { address, amount, memo, payjoinUrl, payjoinOutputSubstitutionDisabled } = DeeplinkSchemaMatch.decodeBitcoinUri(this.props.route.params.uri);
+        this.setState({ address, amount, memo, isLoading: false, payjoinUrl, payjoinOutputSubstitutionDisabled});
       } catch (error) {
         console.log(error);
         this.setState({ isLoading: false });
@@ -669,6 +670,7 @@ export default class SendDetails extends Component {
       recipients: targets,
       satoshiPerByte: requestedSatPerByte,
       payjoinUrl: this.state.payjoinUrl,
+      payjoinOutputSubstitutionDisabled: this.state.payjoinOutputSubstitutionDisabled,        
       psbt,
     });
     this.setState({ isLoading: false });
@@ -1200,7 +1202,7 @@ export default class SendDetails extends Component {
             onChangeText={async text => {
               text = text.trim();
               const transactions = this.state.addresses;
-              const { address, amount, memo, payjoinUrl } = DeeplinkSchemaMatch.decodeBitcoinUri(text);
+              const { address, amount, memo, payjoinUrl, payjoinOutputSubstitutionDisabled } = DeeplinkSchemaMatch.decodeBitcoinUri(text);
               item.address = address || text;
               item.amount = amount || item.amount;
               transactions[index] = item;
@@ -1209,6 +1211,7 @@ export default class SendDetails extends Component {
                 memo: memo || this.state.memo,
                 isLoading: false,
                 payjoinUrl,
+                payjoinOutputSubstitutionDisabled
               });
               this.reCalcTx();
             }}

--- a/tests/unit/deeplink-schema-match.test.js
+++ b/tests/unit/deeplink-schema-match.test.js
@@ -237,6 +237,7 @@ describe('unit - DeepLinkSchemaMatch', function () {
         amount: 0.0001,
         memo: '',
         payjoinUrl: 'https://btc.donate.kukks.org/BTC/pj',
+        payjoinOutputSubstitutionDisabled: false
       },
     );
 
@@ -245,6 +246,7 @@ describe('unit - DeepLinkSchemaMatch', function () {
       amount: 20.3,
       memo: 'Foobar',
       payjoinUrl: '',
+      payjoinOutputSubstitutionDisabled: false
     });
   });
 

--- a/tests/unit/payjoin-transaction.test.js
+++ b/tests/unit/payjoin-transaction.test.js
@@ -59,6 +59,7 @@ describe('PayjoinTransaction', () => {
     const payjoinClient = new PayjoinClient({
       wallet,
       payjoinRequester: payjoinRequesterMock,
+      paymentScript: bitcoin.address.toOutputScript("bc1qy0ydthpa35m37pvwl5tu76j0srcmcwtmaur3aw" )
     });
 
     await assert.rejects(payjoinClient.run());
@@ -106,6 +107,7 @@ describe('PayjoinTransaction', () => {
     const payjoinClient = new PayjoinClient({
       wallet,
       payjoinRequester: payjoinRequesterMock,
+      paymentScript: bitcoin.address.toOutputScript("bc1qy0ydthpa35m37pvwl5tu76j0srcmcwtmaur3aw" )
     });
 
     await payjoinClient.run();

--- a/tests/unit/payjoin-transaction.test.js
+++ b/tests/unit/payjoin-transaction.test.js
@@ -1,6 +1,6 @@
 /* global it, describe, jest */
 import { HDSegwitBech32Wallet } from '../../class';
-import PayjoinTransaction from '../../class/payjoin-transaction';
+import PayjoinTransaction, {getEndpointUrlFunc} from '../../class/payjoin-transaction';
 import { PayjoinClient } from 'payjoin-client';
 const bitcoin = require('bitcoinjs-lib');
 jest.useFakeTimers();
@@ -59,7 +59,8 @@ describe('PayjoinTransaction', () => {
     const payjoinClient = new PayjoinClient({
       wallet,
       payjoinRequester: payjoinRequesterMock,
-      paymentScript: bitcoin.address.toOutputScript("bc1qy0ydthpa35m37pvwl5tu76j0srcmcwtmaur3aw" )
+      paymentScript: bitcoin.address.toOutputScript("bc1qy0ydthpa35m37pvwl5tu76j0srcmcwtmaur3aw" ),
+      getEndpointUrl: getEndpointUrlFunc
     });
 
     await assert.rejects(payjoinClient.run());
@@ -107,7 +108,8 @@ describe('PayjoinTransaction', () => {
     const payjoinClient = new PayjoinClient({
       wallet,
       payjoinRequester: payjoinRequesterMock,
-      paymentScript: bitcoin.address.toOutputScript("bc1qy0ydthpa35m37pvwl5tu76j0srcmcwtmaur3aw" )
+      paymentScript: bitcoin.address.toOutputScript("bc1qy0ydthpa35m37pvwl5tu76j0srcmcwtmaur3aw" ),
+      getEndpointUrl: getEndpointUrlFunc
     });
 
     await payjoinClient.run();


### PR DESCRIPTION
Supersedes #1926 in that the tests now succeed, passes the payment script to the payjoin client and also checks if BIP21 signals that the server has output substitution disabled.