### PR TITLE
ADD: multisig can cosign for other coordinator; REF: BC-UR is now dec…

### DIFF
--- a/loc/en.json
+++ b/loc/en.json
@@ -9,6 +9,7 @@
     "ok": "OK",
     "storage_is_encrypted": "Your storage is encrypted. Password is required to decrypt it",
     "yes": "Yes",
+    "no": "No",
     "invalid_animated_qr_code_fragment" : "Invalid animated QRCode fragment, please try again",
     "file_saved": "File ({filePath}) has been saved in your Downloads folder ."
   },
@@ -385,6 +386,8 @@
     "share": "Share",
     "how_many_signatures_can_bluewallet_make": "how many signatures can bluewallet make",
     "scan_or_import_file": "Scan or import file",
-    "export_coordination_setup": "export coordination setup"
+    "export_coordination_setup": "export coordination setup",
+    "cosign_this_transaction": "Co-sign this transaction?",
+    "co_sign_transaction": "Co-sign transaction"
   }
 }

--- a/screen/send/psbtMultisig.js
+++ b/screen/send/psbtMultisig.js
@@ -5,7 +5,6 @@ import { BlueButton, BlueButtonLink, BlueCard, BlueNavigationStyle, BlueSpacing2
 import { DynamicQRCode } from '../../components/DynamicQRCode';
 import { SquareButton } from '../../components/SquareButton';
 import { getSystemName } from 'react-native-device-info';
-import { decodeUR, extractSingleWorkload } from 'bc-ur/dist';
 import loc from '../../loc';
 import { Icon } from 'react-native-elements';
 import ImagePicker from 'react-native-image-picker';
@@ -36,7 +35,6 @@ const PsbtMultisig = () => {
   const memo = route.params.memo;
 
   const [psbt, setPsbt] = useState(bitcoin.Psbt.fromBase64(psbtBase64));
-  const [animatedQRCodeData, setAnimatedQRCodeData] = useState({});
   const [isModalVisible, setIsModalVisible] = useState(false);
   const stylesHook = StyleSheet.create({
     root: {
@@ -163,22 +161,6 @@ const PsbtMultisig = () => {
     );
   };
 
-  const _onReadUniformResource = ur => {
-    try {
-      const [index, total] = extractSingleWorkload(ur);
-      animatedQRCodeData[index + 'of' + total] = ur;
-      if (Object.values(animatedQRCodeData).length === total) {
-        const payload = decodeUR(Object.values(animatedQRCodeData));
-        const psbtB64 = Buffer.from(payload, 'hex').toString('base64');
-        _combinePSBT(psbtB64);
-      } else {
-        setAnimatedQRCodeData(animatedQRCodeData);
-      }
-    } catch (Err) {
-      alert(loc._.invalid_animated_qr_code_fragment);
-    }
-  };
-
   const _combinePSBT = receivedPSBTBase64 => {
     const receivedPSBT = bitcoin.Psbt.fromBase64(receivedPSBTBase64);
     try {
@@ -194,7 +176,7 @@ const PsbtMultisig = () => {
   const onBarScanned = ret => {
     if (!ret.data) ret = { data: ret };
     if (ret.data.toUpperCase().startsWith('UR')) {
-      return _onReadUniformResource(ret.data);
+      alert('BC-UR not decoded. This should never happen');
     } else if (ret.data.indexOf('+') === -1 && ret.data.indexOf('=') === -1 && ret.data.indexOf('=') === -1) {
       // this looks like NOT base64, so maybe its transaction's hex
       // we dont support it in this flow

--- a/screen/send/psbtWithHardwareWallet.js
+++ b/screen/send/psbtWithHardwareWallet.js
@@ -33,7 +33,6 @@ import { getSystemName } from 'react-native-device-info';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import RNFS from 'react-native-fs';
 import DocumentPicker from 'react-native-document-picker';
-import { decodeUR, extractSingleWorkload } from 'bc-ur/dist';
 import loc from '../../loc';
 import { BlueCurrentTheme } from '../../components/themes';
 import ScanQRCode from './ScanQRCode';
@@ -126,44 +125,6 @@ const styles = StyleSheet.create({
 export default class PsbtWithHardwareWallet extends Component {
   cameraRef = null;
 
-  _onReadUniformResource = ur => {
-    try {
-      const [index, total] = extractSingleWorkload(ur);
-      const { animatedQRCodeData } = this.state;
-      if (animatedQRCodeData.length > 0) {
-        const currentTotal = animatedQRCodeData[0].total;
-        if (total !== currentTotal) {
-          alert('invalid animated QRCode');
-        }
-      }
-      if (!animatedQRCodeData.find(i => i.index === index)) {
-        this.setState(
-          state => ({
-            animatedQRCodeData: [
-              ...state.animatedQRCodeData,
-              {
-                index,
-                total,
-                data: ur,
-              },
-            ],
-          }),
-          () => {
-            if (this.state.animatedQRCodeData.length === total) {
-              const payload = decodeUR(this.state.animatedQRCodeData.map(i => i.data));
-              const psbtB64 = Buffer.from(payload, 'hex').toString('base64');
-              const Tx = this._combinePSBT(psbtB64);
-              this.setState({ txhex: Tx.toHex() });
-              this.props.navigation.dangerouslyGetParent().pop();
-            }
-          },
-        );
-      }
-    } catch (Err) {
-      alert('invalid animated QRCode fragment, please try again');
-    }
-  };
-
   _combinePSBT = receivedPSBT => {
     return this.state.fromWallet.combinePsbt(this.state.psbt, receivedPSBT);
   };
@@ -171,7 +132,7 @@ export default class PsbtWithHardwareWallet extends Component {
   onBarScanned = ret => {
     if (ret && !ret.data) ret = { data: ret };
     if (ret.data.toUpperCase().startsWith('UR')) {
-      return this._onReadUniformResource(ret.data);
+      alert('BC-UR not decoded. This should never happen');
     }
     if (ret.data.indexOf('+') === -1 && ret.data.indexOf('=') === -1 && ret.data.indexOf('=') === -1) {
       // this looks like NOT base64, so maybe its transaction's hex

--- a/screen/wallets/import.js
+++ b/screen/wallets/import.js
@@ -89,6 +89,7 @@ const WalletsImport = () => {
    * @param additionalProperties key-values passed from outside. Used only to set up `masterFingerprint` property for watch-only wallet
    */
   const onBarScanned = (value, additionalProperties) => {
+    if (value && value.data) value = value.data + ''; // no objects here, only strings
     setImportText(value);
     importMnemonic(value, additionalProperties);
   };


### PR DESCRIPTION
…oded centrally



With this PR it is now possible for BW to join consigning if its being coordinated by someone else:

![image](https://user-images.githubusercontent.com/1913337/95481535-012da100-0985-11eb-91d0-3f56fc672276.png)


see "Co-sign transaction". It opens a camera and reads PSBT from camera. TBH this is almost the same as just 'import transaction', but 'import transaction' is opening file browser, while in real life transaction can be on Cobo on QR, and its not handy  to save it as file.
If BW has any keys, it will offer to additionally cosign this transaction:

![image](https://user-images.githubusercontent.com/1913337/95481823-58cc0c80-0985-11eb-857d-e96725766c57.png)

this should allow for example, to have 3 iphones with BW, and coordinate and sign transaction via QR-airgapped flow.


ALSO, BC-UR decode was refactored, and this potentially could break everything we have with camera: import wallet, import tx etc etc, so should be carefully tested