### PR TITLE
REF: improve wallet import speed

### DIFF
--- a/class/wallet-import.js
+++ b/class/wallet-import.js
@@ -17,7 +17,6 @@ import {
 } from '.';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import loc from '../loc';
-const EV = require('../blue_modules/events');
 const A = require('../blue_modules/analytics');
 const BlueApp: AppStorage = require('../BlueApp');
 const bip38 = require('../blue_modules/bip38');
@@ -34,36 +33,26 @@ export default class WalletImport {
    * @private
    */
   static async _saveWallet(w, additionalProperties) {
-    try {
-      const wallet = BlueApp.getWallets().some(
-        wallet => (wallet.getSecret() === w.secret || wallet.getID() === w.getID()) && wallet.type !== PlaceholderWallet.type,
-      );
-      if (wallet) {
-        alert('This wallet has been previously imported.');
-        WalletImport.removePlaceholderWallet();
-      } else {
-        const emptyWalletLabel = new LegacyWallet().getLabel();
-        ReactNativeHapticFeedback.trigger('notificationSuccess', { ignoreAndroidSystemSettings: false });
-        if (w.getLabel() === emptyWalletLabel) w.setLabel(loc.wallets.import_imported + ' ' + w.typeReadable);
-        w.setUserHasSavedExport(true);
-        if (additionalProperties) {
-          for (const [key, value] of Object.entries(additionalProperties)) {
-            w[key] = value;
-          }
+    const wallet = BlueApp.getWallets().some(
+      wallet => (wallet.getSecret() === w.secret || wallet.getID() === w.getID()) && wallet.type !== PlaceholderWallet.type,
+    );
+    if (wallet) {
+      alert('This wallet has been previously imported.');
+    } else {
+      const emptyWalletLabel = new LegacyWallet().getLabel();
+      ReactNativeHapticFeedback.trigger('notificationSuccess', { ignoreAndroidSystemSettings: false });
+      if (w.getLabel() === emptyWalletLabel) w.setLabel(loc.wallets.import_imported + ' ' + w.typeReadable);
+      w.setUserHasSavedExport(true);
+      if (additionalProperties) {
+        for (const [key, value] of Object.entries(additionalProperties)) {
+          w[key] = value;
         }
-        WalletImport.removePlaceholderWallet();
-        BlueApp.wallets.push(w);
-        await BlueApp.saveToDisk();
-        A(A.ENUM.CREATED_WALLET);
-        alert(loc.wallets.import_success);
-        notifications.majorTomToGroundControl(w.getAllExternalAddresses(), [], []);
       }
-      EV(EV.enum.WALLETS_COUNT_CHANGED);
-    } catch (e) {
-      alert(e);
-      console.log(e);
-      WalletImport.removePlaceholderWallet();
-      EV(EV.enum.WALLETS_COUNT_CHANGED);
+      BlueApp.wallets.push(w);
+      await BlueApp.saveToDisk();
+      A(A.ENUM.CREATED_WALLET);
+      alert(loc.wallets.import_success);
+      notifications.majorTomToGroundControl(w.getAllExternalAddresses(), [], []);
     }
   }
 
@@ -79,7 +68,6 @@ export default class WalletImport {
     wallet.setSecret(importText);
     wallet.setIsFailure(isFailure);
     BlueApp.wallets.push(wallet);
-    EV(EV.enum.WALLETS_COUNT_CHANGED);
     return wallet;
   }
 
@@ -94,10 +82,6 @@ export default class WalletImport {
    * @returns {Promise<void>}
    */
   static async processImportText(importText, additionalProperties) {
-    if (WalletImport.isCurrentlyImportingWallet()) {
-      return;
-    }
-    const placeholderWallet = WalletImport.addPlaceholderWallet(importText);
     // Plan:
     // -2. check if BIP38 encrypted
     // -1a. check if multisig
@@ -113,209 +97,200 @@ export default class WalletImport {
     // 7. check if its private key (segwit address P2SH) TODO
     // 7. check if its private key (legacy address) TODO
 
+    if (importText.startsWith('6P')) {
+      let password = false;
+      do {
+        password = await prompt('This looks like password-protected private key (BIP38)', 'Enter password to decrypt', false);
+      } while (!password);
+
+      const decryptedKey = await bip38.decrypt(importText, password, status => {
+        console.warn(status.percent + '%');
+      });
+
+      if (decryptedKey) {
+        importText = wif.encode(0x80, decryptedKey.privateKey, decryptedKey.compressed);
+      }
+    }
+
+    // is it multisig?
     try {
-      if (importText.startsWith('6P')) {
-        let password = false;
-        do {
-          password = await prompt('This looks like password-protected private key (BIP38)', 'Enter password to decrypt', false);
-        } while (!password);
-
-        const decryptedKey = await bip38.decrypt(importText, password, status => {
-          console.warn(status.percent + '%');
-        });
-
-        if (decryptedKey) {
-          importText = wif.encode(0x80, decryptedKey.privateKey, decryptedKey.compressed);
-        }
+      const ms = new MultisigHDWallet();
+      ms.setSecret(importText);
+      if (ms.getN() > 0 && ms.getM() > 0) {
+        await ms.fetchBalance();
+        return WalletImport._saveWallet(ms);
       }
+    } catch (e) {
+      console.log(e);
+    }
 
-      // is it multisig?
-      try {
-        const ms = new MultisigHDWallet();
-        ms.setSecret(importText);
-        if (ms.getN() > 0 && ms.getM() > 0) {
-          await ms.fetchBalance();
-          return WalletImport._saveWallet(ms);
-        }
-      } catch (e) {
-        console.log(e);
+    // is it lightning custodian?
+    if (importText.indexOf('blitzhub://') !== -1 || importText.indexOf('lndhub://') !== -1) {
+      const lnd = new LightningCustodianWallet();
+      if (importText.includes('@')) {
+        const split = importText.split('@');
+        lnd.setBaseURI(split[1]);
+        lnd.setSecret(split[0]);
+      } else {
+        lnd.setBaseURI(LightningCustodianWallet.defaultBaseUri);
+        lnd.setSecret(importText);
       }
+      lnd.init();
+      await lnd.authorize();
+      await lnd.fetchTransactions();
+      await lnd.fetchUserInvoices();
+      await lnd.fetchPendingTransactions();
+      await lnd.fetchBalance();
+      return WalletImport._saveWallet(lnd);
+    }
 
-      // is it lightning custodian?
-      if (importText.indexOf('blitzhub://') !== -1 || importText.indexOf('lndhub://') !== -1) {
-        const lnd = new LightningCustodianWallet();
-        if (importText.includes('@')) {
-          const split = importText.split('@');
-          lnd.setBaseURI(split[1]);
-          lnd.setSecret(split[0]);
-        } else {
-          lnd.setBaseURI(LightningCustodianWallet.defaultBaseUri);
-          lnd.setSecret(importText);
-        }
-        lnd.init();
-        await lnd.authorize();
-        await lnd.fetchTransactions();
-        await lnd.fetchUserInvoices();
-        await lnd.fetchPendingTransactions();
-        await lnd.fetchBalance();
-        return WalletImport._saveWallet(lnd);
+    // trying other wallet types
+
+    const hd4 = new HDSegwitBech32Wallet();
+    hd4.setSecret(importText);
+    if (hd4.validateMnemonic()) {
+      await hd4.fetchBalance();
+      if (hd4.getBalance() > 0) {
+        // await hd4.fetchTransactions(); // experiment: dont fetch tx now. it will import faster. user can refresh his wallet later
+        return WalletImport._saveWallet(hd4);
       }
+    }
 
-      // trying other wallet types
-
-      const hd4 = new HDSegwitBech32Wallet();
-      hd4.setSecret(importText);
-      if (hd4.validateMnemonic()) {
-        await hd4.fetchBalance();
-        if (hd4.getBalance() > 0) {
-          // await hd4.fetchTransactions(); // experiment: dont fetch tx now. it will import faster. user can refresh his wallet later
-          return WalletImport._saveWallet(hd4);
-        }
-      }
-
-      const segwitWallet = new SegwitP2SHWallet();
-      segwitWallet.setSecret(importText);
-      if (segwitWallet.getAddress()) {
-        // ok its a valid WIF
-
-        const legacyWallet = new LegacyWallet();
-        legacyWallet.setSecret(importText);
-
-        const segwitBech32Wallet = new SegwitBech32Wallet();
-        segwitBech32Wallet.setSecret(importText);
-
-        await legacyWallet.fetchBalance();
-        await segwitBech32Wallet.fetchBalance();
-        if (legacyWallet.getBalance() > 0) {
-          // yep, its legacy we're importing
-          await legacyWallet.fetchTransactions();
-          return WalletImport._saveWallet(legacyWallet);
-        } else if (segwitBech32Wallet.getBalance() > 0) {
-          // yep, its single-address bech32 wallet
-          await segwitBech32Wallet.fetchTransactions();
-          return WalletImport._saveWallet(segwitBech32Wallet);
-        } else {
-          // by default, we import wif as Segwit P2SH
-          await segwitWallet.fetchBalance();
-          await segwitWallet.fetchTransactions();
-          return WalletImport._saveWallet(segwitWallet);
-        }
-      }
-
-      // case - WIF is valid, just has uncompressed pubkey
+    const segwitWallet = new SegwitP2SHWallet();
+    segwitWallet.setSecret(importText);
+    if (segwitWallet.getAddress()) {
+      // ok its a valid WIF
 
       const legacyWallet = new LegacyWallet();
       legacyWallet.setSecret(importText);
-      if (legacyWallet.getAddress()) {
-        await legacyWallet.fetchBalance();
+
+      const segwitBech32Wallet = new SegwitBech32Wallet();
+      segwitBech32Wallet.setSecret(importText);
+
+      await legacyWallet.fetchBalance();
+      await segwitBech32Wallet.fetchBalance();
+      if (legacyWallet.getBalance() > 0) {
+        // yep, its legacy we're importing
         await legacyWallet.fetchTransactions();
         return WalletImport._saveWallet(legacyWallet);
+      } else if (segwitBech32Wallet.getBalance() > 0) {
+        // yep, its single-address bech32 wallet
+        await segwitBech32Wallet.fetchTransactions();
+        return WalletImport._saveWallet(segwitBech32Wallet);
+      } else {
+        // by default, we import wif as Segwit P2SH
+        await segwitWallet.fetchBalance();
+        await segwitWallet.fetchTransactions();
+        return WalletImport._saveWallet(segwitWallet);
       }
+    }
 
-      // if we're here - nope, its not a valid WIF
+    // case - WIF is valid, just has uncompressed pubkey
 
-      const hd1 = new HDLegacyBreadwalletWallet();
-      hd1.setSecret(importText);
-      if (hd1.validateMnemonic()) {
-        await hd1.fetchBalance();
-        if (hd1.getBalance() > 0) {
-          // await hd1.fetchTransactions(); // experiment: dont fetch tx now. it will import faster. user can refresh his wallet later
-          return WalletImport._saveWallet(hd1);
-        }
+    const legacyWallet = new LegacyWallet();
+    legacyWallet.setSecret(importText);
+    if (legacyWallet.getAddress()) {
+      await legacyWallet.fetchBalance();
+      await legacyWallet.fetchTransactions();
+      return WalletImport._saveWallet(legacyWallet);
+    }
+
+    // if we're here - nope, its not a valid WIF
+
+    const hd1 = new HDLegacyBreadwalletWallet();
+    hd1.setSecret(importText);
+    if (hd1.validateMnemonic()) {
+      await hd1.fetchBalance();
+      if (hd1.getBalance() > 0) {
+        // await hd1.fetchTransactions(); // experiment: dont fetch tx now. it will import faster. user can refresh his wallet later
+        return WalletImport._saveWallet(hd1);
       }
+    }
 
-      try {
-        const hdElectrumSeedLegacy = new HDSegwitElectrumSeedP2WPKHWallet();
-        hdElectrumSeedLegacy.setSecret(importText);
-        if (await hdElectrumSeedLegacy.wasEverUsed()) {
-          // not fetching txs or balances, fuck it, yolo, life is too short
-          return WalletImport._saveWallet(hdElectrumSeedLegacy);
-        }
-      } catch (_) {}
-
-      try {
-        const hdElectrumSeedLegacy = new HDLegacyElectrumSeedP2PKHWallet();
-        hdElectrumSeedLegacy.setSecret(importText);
-        if (await hdElectrumSeedLegacy.wasEverUsed()) {
-          // not fetching txs or balances, fuck it, yolo, life is too short
-          return WalletImport._saveWallet(hdElectrumSeedLegacy);
-        }
-      } catch (_) {}
-
-      const hd2 = new HDSegwitP2SHWallet();
-      hd2.setSecret(importText);
-      if (hd2.validateMnemonic()) {
-        await hd2.fetchBalance();
-        if (hd2.getBalance() > 0) {
-          // await hd2.fetchTransactions(); // experiment: dont fetch tx now. it will import faster. user can refresh his wallet later
-          return WalletImport._saveWallet(hd2);
-        }
+    try {
+      const hdElectrumSeedLegacy = new HDSegwitElectrumSeedP2WPKHWallet();
+      hdElectrumSeedLegacy.setSecret(importText);
+      if (await hdElectrumSeedLegacy.wasEverUsed()) {
+        // not fetching txs or balances, fuck it, yolo, life is too short
+        return WalletImport._saveWallet(hdElectrumSeedLegacy);
       }
+    } catch (_) {}
 
-      const hd3 = new HDLegacyP2PKHWallet();
-      hd3.setSecret(importText);
-      if (hd3.validateMnemonic()) {
-        await hd3.fetchBalance();
-        if (hd3.getBalance() > 0) {
-          // await hd3.fetchTransactions(); // experiment: dont fetch tx now. it will import faster. user can refresh his wallet later
-          return WalletImport._saveWallet(hd3);
-        }
+    try {
+      const hdElectrumSeedLegacy = new HDLegacyElectrumSeedP2PKHWallet();
+      hdElectrumSeedLegacy.setSecret(importText);
+      if (await hdElectrumSeedLegacy.wasEverUsed()) {
+        // not fetching txs or balances, fuck it, yolo, life is too short
+        return WalletImport._saveWallet(hdElectrumSeedLegacy);
       }
+    } catch (_) {}
 
-      // no balances? how about transactions count?
+    const hd2 = new HDSegwitP2SHWallet();
+    hd2.setSecret(importText);
+    if (hd2.validateMnemonic()) {
+      await hd2.fetchBalance();
+      if (hd2.getBalance() > 0) {
+        // await hd2.fetchTransactions(); // experiment: dont fetch tx now. it will import faster. user can refresh his wallet later
+        return WalletImport._saveWallet(hd2);
+      }
+    }
 
-      if (hd1.validateMnemonic()) {
-        await hd1.fetchTransactions();
-        if (hd1.getTransactions().length !== 0) {
-          return WalletImport._saveWallet(hd1);
-        }
+    const hd3 = new HDLegacyP2PKHWallet();
+    hd3.setSecret(importText);
+    if (hd3.validateMnemonic()) {
+      await hd3.fetchBalance();
+      if (hd3.getBalance() > 0) {
+        // await hd3.fetchTransactions(); // experiment: dont fetch tx now. it will import faster. user can refresh his wallet later
+        return WalletImport._saveWallet(hd3);
       }
-      if (hd2.validateMnemonic()) {
-        await hd2.fetchTransactions();
-        if (hd2.getTransactions().length !== 0) {
-          return WalletImport._saveWallet(hd2);
-        }
-      }
-      if (hd3.validateMnemonic()) {
-        await hd3.fetchTransactions();
-        if (hd3.getTransactions().length !== 0) {
-          return WalletImport._saveWallet(hd3);
-        }
-      }
-      if (hd4.validateMnemonic()) {
-        await hd4.fetchTransactions();
-        if (hd4.getTransactions().length !== 0) {
-          return WalletImport._saveWallet(hd4);
-        }
-      }
+    }
 
-      // is it even valid? if yes we will import as:
-      if (hd4.validateMnemonic()) {
+    // no balances? how about transactions count?
+
+    if (hd1.validateMnemonic()) {
+      await hd1.fetchTransactions();
+      if (hd1.getTransactions().length !== 0) {
+        return WalletImport._saveWallet(hd1);
+      }
+    }
+    if (hd2.validateMnemonic()) {
+      await hd2.fetchTransactions();
+      if (hd2.getTransactions().length !== 0) {
+        return WalletImport._saveWallet(hd2);
+      }
+    }
+    if (hd3.validateMnemonic()) {
+      await hd3.fetchTransactions();
+      if (hd3.getTransactions().length !== 0) {
+        return WalletImport._saveWallet(hd3);
+      }
+    }
+    if (hd4.validateMnemonic()) {
+      await hd4.fetchTransactions();
+      if (hd4.getTransactions().length !== 0) {
         return WalletImport._saveWallet(hd4);
       }
-
-      // not valid? maybe its a watch-only address?
-
-      const watchOnly = new WatchOnlyWallet();
-      watchOnly.setSecret(importText);
-      if (watchOnly.valid()) {
-        // await watchOnly.fetchTransactions(); // experiment: dont fetch tx now. it will import faster. user can refresh his wallet later
-        await watchOnly.fetchBalance();
-        return WalletImport._saveWallet(watchOnly, additionalProperties);
-      }
-
-      // nope?
-
-      // TODO: try a raw private key
-    } catch (Err) {
-      WalletImport.removePlaceholderWallet(placeholderWallet);
-      EV(EV.enum.WALLETS_COUNT_CHANGED);
-      console.warn(Err);
     }
-    WalletImport.removePlaceholderWallet();
-    WalletImport.addPlaceholderWallet(importText, true);
-    ReactNativeHapticFeedback.trigger('notificationError', { ignoreAndroidSystemSettings: false });
-    EV(EV.enum.WALLETS_COUNT_CHANGED);
-    alert(loc.wallets.import_error);
+
+    // is it even valid? if yes we will import as:
+    if (hd4.validateMnemonic()) {
+      return WalletImport._saveWallet(hd4);
+    }
+
+    // not valid? maybe its a watch-only address?
+
+    const watchOnly = new WatchOnlyWallet();
+    watchOnly.setSecret(importText);
+    if (watchOnly.valid()) {
+      // await watchOnly.fetchTransactions(); // experiment: dont fetch tx now. it will import faster. user can refresh his wallet later
+      await watchOnly.fetchBalance();
+      return WalletImport._saveWallet(watchOnly, additionalProperties);
+    }
+
+    // nope?
+
+    // TODO: try a raw private key
+
+    throw new Error('Could not recognize format');
   }
 }

--- a/class/wallet-import.js
+++ b/class/wallet-import.js
@@ -38,22 +38,23 @@ export default class WalletImport {
     );
     if (wallet) {
       alert('This wallet has been previously imported.');
-    } else {
-      const emptyWalletLabel = new LegacyWallet().getLabel();
-      ReactNativeHapticFeedback.trigger('notificationSuccess', { ignoreAndroidSystemSettings: false });
-      if (w.getLabel() === emptyWalletLabel) w.setLabel(loc.wallets.import_imported + ' ' + w.typeReadable);
-      w.setUserHasSavedExport(true);
-      if (additionalProperties) {
-        for (const [key, value] of Object.entries(additionalProperties)) {
-          w[key] = value;
-        }
-      }
-      BlueApp.wallets.push(w);
-      await BlueApp.saveToDisk();
-      A(A.ENUM.CREATED_WALLET);
-      alert(loc.wallets.import_success);
-      notifications.majorTomToGroundControl(w.getAllExternalAddresses(), [], []);
+      return;
     }
+
+    const emptyWalletLabel = new LegacyWallet().getLabel();
+    ReactNativeHapticFeedback.trigger('notificationSuccess', { ignoreAndroidSystemSettings: false });
+    if (w.getLabel() === emptyWalletLabel) w.setLabel(loc.wallets.import_imported + ' ' + w.typeReadable);
+    w.setUserHasSavedExport(true);
+    if (additionalProperties) {
+      for (const [key, value] of Object.entries(additionalProperties)) {
+        w[key] = value;
+      }
+    }
+    BlueApp.wallets.push(w);
+    await BlueApp.saveToDisk();
+    A(A.ENUM.CREATED_WALLET);
+    alert(loc.wallets.import_success);
+    notifications.majorTomToGroundControl(w.getAllExternalAddresses(), [], []);
   }
 
   static removePlaceholderWallet() {
@@ -100,7 +101,7 @@ export default class WalletImport {
     if (importText.startsWith('6P')) {
       let password = false;
       do {
-        password = await prompt('This looks like password-protected private key (BIP38)', 'Enter password to decrypt', false);
+        password = await prompt(loc.wallets.looks_like_bip38, loc.wallets.enter_bip38_password, false);
       } while (!password);
 
       const decryptedKey = await bip38.decrypt(importText, password, status => {

--- a/loc/en.json
+++ b/loc/en.json
@@ -358,6 +358,8 @@
     "import_imported": "Imported",
     "import_scan_qr": "Scan or import a file",
     "import_success": "Your wallet has been successfully imported.",
+    "looks_like_bip38": "This looks like password-protected private key (BIP38)",
+    "enter_bip38_password": "Enter password to decrypt",
     "import_title": "import",
     "list_create_a_button": "Add now",
     "list_create_a_wallet": "Add a wallet",

--- a/screen/wallets/import.js
+++ b/screen/wallets/import.js
@@ -10,7 +10,6 @@ import {
   SafeBlueArea,
   BlueSpacing20,
   BlueNavigationStyle,
-  BlueLoadingHook,
 } from '../../BlueComponents';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import Privacy from '../../Privacy';
@@ -26,13 +25,13 @@ import DocumentPicker from 'react-native-document-picker';
 import ScanQRCode from '../send/ScanQRCode';
 const LocalQRCode = require('@remobile/react-native-qrcode-local-image');
 const isDesktop = getSystemName() === 'Mac OS X';
+const EV = require('../../blue_modules/events');
 
 const WalletsImport = () => {
   const [isToolbarVisibleForAndroid, setIsToolbarVisibleForAndroid] = useState(false);
   const route = useRoute();
   const label = (route.params && route.params.label) || '';
   const [importText, setImportText] = useState(label);
-  const [isLoading, setIsLoading] = useState(false);
   const navigation = useNavigation();
   const { colors } = useTheme();
   const styles = StyleSheet.create({
@@ -71,15 +70,27 @@ const WalletsImport = () => {
    * @param importText
    * @param additionalProperties key-values passed from outside. Used only to set up `masterFingerprint` property for watch-only wallet
    */
-  const importMnemonic = (importText, additionalProperties) => {
-    setIsLoading(true);
+  const importMnemonic = async (importText, additionalProperties) => {
+    if (WalletImport.isCurrentlyImportingWallet()) {
+      return;
+    }
+
+    WalletImport.addPlaceholderWallet(importText);
+    navigation.dangerouslyGetParent().pop();
+    await new Promise(resolve => setTimeout(resolve, 500)); // giving some time to animations
+    EV(EV.enum.WALLETS_COUNT_CHANGED);
     try {
-      WalletImport.processImportText(importText, additionalProperties);
-      navigation.dangerouslyGetParent().pop();
+      await WalletImport.processImportText(importText, additionalProperties);
+      WalletImport.removePlaceholderWallet();
     } catch (error) {
+      WalletImport.removePlaceholderWallet();
+      WalletImport.addPlaceholderWallet(importText, true);
+      console.warn(error);
+
       alert(loc.wallets.import_error);
       ReactNativeHapticFeedback.trigger('notificationError', { ignoreAndroidSystemSettings: false });
-      setIsLoading(false);
+    } finally {
+      EV(EV.enum.WALLETS_COUNT_CHANGED);
     }
   };
 
@@ -91,7 +102,7 @@ const WalletsImport = () => {
   const onBarScanned = (value, additionalProperties) => {
     if (value && value.data) value = value.data + ''; // no objects here, only strings
     setImportText(value);
-    importMnemonic(value, additionalProperties);
+    setTimeout(() => importMnemonic(value, additionalProperties), 500);
   };
 
   const importScan = () => {
@@ -215,27 +226,22 @@ const WalletsImport = () => {
         testID="MnemonicInput"
         value={importText}
         contextMenuHidden={getSystemName() !== 'Mac OS X'}
-        editable={!isLoading}
         onChangeText={setImportText}
         inputAccessoryViewID={BlueDoneAndDismissKeyboardInputAccessory.InputAccessoryViewID}
       />
 
       <BlueSpacing20 />
       <View style={styles.center}>
-        {!isLoading ? (
-          <>
-            <BlueButton
-              testID="DoImport"
-              disabled={importText.trim().length === 0}
-              title={loc.wallets.import_do_import}
-              onPress={importButtonPressed}
-            />
-            <BlueSpacing20 />
-            <BlueButtonLink title={loc.wallets.import_scan_qr} onPress={importScan} />
-          </>
-        ) : (
-          <BlueLoadingHook />
-        )}
+        <>
+          <BlueButton
+            testID="DoImport"
+            disabled={importText.trim().length === 0}
+            title={loc.wallets.import_do_import}
+            onPress={importButtonPressed}
+          />
+          <BlueSpacing20 />
+          <BlueButtonLink title={loc.wallets.import_scan_qr} onPress={importScan} />
+        </>
       </View>
       {Platform.select({
         ios: (


### PR DESCRIPTION
In this PR I tried to improve the subjective speed of wallet import:

* camera should close instantly as soon as QR is read
* operations like closing camera, adding placeholder wallet, are moved one level up & added sleeps to give animations 
 & UI some time to re-render
* simplified a bit