### PR TITLE
FIX: remove padding causing text concealment

### DIFF
--- a/screen/wallets/transactions.js
+++ b/screen/wallets/transactions.js
@@ -50,7 +50,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     paddingHorizontal: 16,
-    paddingVertical: 40,
+    paddingBottom: 40,
   },
   modalContent: {
     backgroundColor: '#FFFFFF',


### PR DESCRIPTION
Padding is causing text being concealed by the Receive/Send buttons like this:
![Screenshot_20201020-230022](https://user-images.githubusercontent.com/4103710/96641454-67bfa100-132d-11eb-8b22-9c4c25b6c43f.png)

I removed the padding from the text container `scrollViewContent` to save some space and contain the text:
![Screenshot_20201020-230853](https://user-images.githubusercontent.com/4103710/96641491-77d78080-132d-11eb-88cb-1dc64d33606d.png)

Of course you can fix it decreasing the font size, or make it scroll-able.

It's also [affect](https://user-images.githubusercontent.com/4103710/96641540-8a51ba00-132d-11eb-9eb1-030d6ee140da.png) the bitcoin [transactions screen](https://user-images.githubusercontent.com/4103710/96641534-89208d00-132d-11eb-8dce-f09deb9778fb.png), but I think it's not critical.
