### PR TITLE
REF: BottomModal component

### DIFF
--- a/components/BottomModal.js
+++ b/components/BottomModal.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { StyleSheet, useWindowDimensions } from 'react-native';
+import Modal from 'react-native-modal';
+
+const styles = StyleSheet.create({
+  root: {
+    justifyContent: 'flex-end',
+    margin: 0,
+  },
+});
+
+const BottomModal = ({ onBackButtonPress, onBackdropPress, onClose, windowHeight, windowWidth, ...props }) => {
+  const valueWindowHeight = useWindowDimensions().height;
+  const valueWindowWidth = useWindowDimensions().width;
+  const handleBackButtonPress = onBackButtonPress ?? onClose;
+  const handleBackdropPress = onBackdropPress ?? onClose;
+
+  return (
+    <Modal
+      style={styles.root}
+      deviceHeight={windowHeight ?? valueWindowHeight}
+      deviceWidth={windowWidth ?? valueWindowWidth}
+      onBackButtonPress={handleBackButtonPress}
+      onBackdropPress={handleBackdropPress}
+      {...props}
+    />
+  );
+};
+
+BottomModal.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.element), PropTypes.element]),
+  onBackButtonPress: PropTypes.func,
+  onBackdropPress: PropTypes.func,
+  onClose: PropTypes.func,
+  windowHeight: PropTypes.number,
+  windowWidth: PropTypes.number,
+};
+
+export default BottomModal;

--- a/screen/receive/details.js
+++ b/screen/receive/details.js
@@ -1,18 +1,20 @@
 import React, { useCallback, useContext, useState } from 'react';
 import {
-  View,
   InteractionManager,
-  StatusBar,
-  Platform,
-  TextInput,
-  KeyboardAvoidingView,
   Keyboard,
-  StyleSheet,
-  useWindowDimensions,
+  KeyboardAvoidingView,
+  Platform,
   ScrollView,
+  StatusBar,
+  StyleSheet,
+  TextInput,
+  View,
 } from 'react-native';
 import QRCode from 'react-native-qrcode-svg';
 import { useNavigation, useRoute, useTheme, useFocusEffect } from '@react-navigation/native';
+import Share from 'react-native-share';
+import Handoff from 'react-native-handoff';
+
 import {
   BlueLoadingHook,
   BlueCopyTextToClipboard,
@@ -26,13 +28,11 @@ import {
   BlueAlertWalletExportReminder,
   BlueNavigationStyle,
 } from '../../BlueComponents';
+import BottomModal from '../../components/BottomModal';
 import Privacy from '../../Privacy';
-import Share from 'react-native-share';
 import { Chain, BitcoinUnit } from '../../models/bitcoinUnits';
-import Modal from 'react-native-modal';
 import HandoffSettings from '../../class/handoff';
 import DeeplinkSchemaMatch from '../../class/deeplink-schema-match';
-import Handoff from 'react-native-handoff';
 import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import Notifications from '../../blue_modules/notifications';
@@ -53,7 +53,6 @@ const ReceiveDetails = () => {
   const [showAddress, setShowAddress] = useState(false);
   const { navigate, goBack } = useNavigation();
   const { colors } = useTheme();
-  const windowHeight = useWindowDimensions().height;
   const styles = StyleSheet.create({
     modalContent: {
       backgroundColor: colors.modal,
@@ -66,10 +65,6 @@ const ReceiveDetails = () => {
       borderWidth: colors.borderWidth,
       minHeight: 350,
       height: 350,
-    },
-    bottomModal: {
-      justifyContent: 'flex-end',
-      margin: 0,
     },
     customAmount: {
       flexDirection: 'row',
@@ -287,13 +282,7 @@ const ReceiveDetails = () => {
 
   const renderCustomAmountModal = () => {
     return (
-      <Modal
-        deviceHeight={windowHeight}
-        isVisible={isCustomModalVisible}
-        style={styles.bottomModal}
-        onBackdropPress={dismissCustomAmountModal}
-        onBackButtonPress={dismissCustomAmountModal}
-      >
+      <BottomModal isVisible={isCustomModalVisible} onClose={dismissCustomAmountModal}>
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContent}>
             <BlueBitcoinAmount
@@ -320,7 +309,7 @@ const ReceiveDetails = () => {
             <BlueSpacing20 />
           </View>
         </KeyboardAvoidingView>
-      </Modal>
+      </BottomModal>
     );
   };
 

--- a/screen/send/details.js
+++ b/screen/send/details.js
@@ -31,7 +31,6 @@ import {
   BlueListItem,
   BlueText,
 } from '../../BlueComponents';
-import Modal from 'react-native-modal';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import BigNumber from 'bignumber.js';
 import RNFS from 'react-native-fs';
@@ -45,6 +44,7 @@ import DocumentPicker from 'react-native-document-picker';
 import DeeplinkSchemaMatch from '../../class/deeplink-schema-match';
 import loc from '../../loc';
 import { BlueCurrentTheme } from '../../components/themes';
+import BottomModal from '../../components/BottomModal';
 import { AbstractHDElectrumWallet } from '../../class/wallets/abstract-hd-electrum-wallet';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 const currency = require('../../blue_modules/currency');
@@ -84,10 +84,6 @@ const styles = StyleSheet.create({
     borderTopColor: BlueCurrentTheme.colors.borderTopColor,
     borderWidth: BlueCurrentTheme.colors.borderWidth,
     minHeight: 130,
-  },
-  bottomModal: {
-    justifyContent: 'flex-end',
-    margin: 0,
   },
   feeModalItem: {
     paddingHorizontal: 16,
@@ -756,13 +752,10 @@ export default class SendDetails extends Component {
     ];
 
     return (
-      <Modal
-        deviceHeight={Dimensions.get('window').height}
+      <BottomModal
         deviceWidth={this.state.width + this.state.width / 2}
         isVisible={this.state.isFeeSelectionModalVisible}
-        style={styles.bottomModal}
-        onBackdropPress={this.hideFeeSelectionModal}
-        onBackButtonPress={this.hideFeeSelectionModal}
+        onClose={this.hideFeeSelectionModal}
       >
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContent}>
@@ -819,7 +812,7 @@ export default class SendDetails extends Component {
             </TouchableOpacity>
           </View>
         </KeyboardAvoidingView>
-      </Modal>
+      </BottomModal>
     );
   };
 
@@ -1004,13 +997,10 @@ export default class SendDetails extends Component {
   renderAdvancedTransactionOptionsModal = () => {
     const isSendMaxUsed = this.state.addresses.some(element => element.amount === BitcoinUnit.MAX);
     return (
-      <Modal
-        deviceHeight={Dimensions.get('window').height}
+      <BottomModal
         deviceWidth={this.state.width + this.state.width / 2}
         isVisible={this.state.isAdvancedTransactionOptionsVisible}
-        style={styles.bottomModal}
-        onBackdropPress={this.hideAdvancedTransactionOptionsModal}
-        onBackButtonPress={this.hideAdvancedTransactionOptionsModal}
+        onClose={this.hideAdvancedTransactionOptionsModal}
       >
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.advancedTransactionOptionsModalContent}>
@@ -1077,7 +1067,7 @@ export default class SendDetails extends Component {
             )}
           </View>
         </KeyboardAvoidingView>
-      </Modal>
+      </BottomModal>
     );
   };
 

--- a/screen/send/psbtMultisig.js
+++ b/screen/send/psbtMultisig.js
@@ -447,10 +447,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
     flexWrap: 'wrap',
   },
-  bottomModal: {
-    justifyContent: 'flex-end',
-    margin: 0,
-  },
   modalContentShort: {
     marginLeft: 20,
     marginRight: 20,

--- a/screen/wallets/addMultisig.js
+++ b/screen/wallets/addMultisig.js
@@ -1,23 +1,14 @@
 import React, { useState, useRef, useEffect, useContext } from 'react';
-import {
-  Keyboard,
-  KeyboardAvoidingView,
-  Platform,
-  StatusBar,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  useWindowDimensions,
-  View,
-} from 'react-native';
+import { Keyboard, KeyboardAvoidingView, Platform, StatusBar, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import LottieView from 'lottie-react-native';
 import { Icon } from 'react-native-elements';
-import { BlueButton, BlueListItem, BlueNavigationStyle, BlueSpacing20 } from '../../BlueComponents';
-import { MultisigHDWallet } from '../../class';
 import { useNavigation, useTheme } from '@react-navigation/native';
-import loc from '../../loc';
-import Modal from 'react-native-modal';
 import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { BlueButton, BlueListItem, BlueNavigationStyle, BlueSpacing20 } from '../../BlueComponents';
+import BottomModal from '../../components/BottomModal';
+import { MultisigHDWallet } from '../../class';
+import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 
 const WalletsAddMultisig = () => {
@@ -31,8 +22,6 @@ const WalletsAddMultisig = () => {
   const [format, setFormat] = useState(MultisigHDWallet.FORMAT_P2WSH);
   const { isAdancedModeEnabled } = useContext(BlueStorageContext);
   const [isAdvancedModeEnabledRender, setIsAdvancedModeEnabledRender] = useState(false);
-  const windowHeight = useWindowDimensions().height;
-  const windowWidth = useWindowDimensions().width;
 
   const stylesHook = StyleSheet.create({
     root: {
@@ -111,14 +100,7 @@ const WalletsAddMultisig = () => {
 
   const renderModal = () => {
     return (
-      <Modal
-        isVisible={isModalVisible}
-        style={styles.bottomModal}
-        deviceHeight={windowHeight}
-        deviceWidth={windowWidth}
-        onBackdropPress={closeModal}
-        onBackButtonPress={closeModal}
-      >
+      <BottomModal isVisible={isModalVisible} onClose={closeModal}>
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={[styles.modalContentShort, stylesHook.modalContentShort]}>
             <Text style={[styles.textHeader, stylesHook.textHeader]}>{loc.multisig.quorum_header}</Text>
@@ -181,7 +163,7 @@ const WalletsAddMultisig = () => {
             />
           </View>
         </KeyboardAvoidingView>
-      </Modal>
+      </BottomModal>
     );
   };
 
@@ -252,10 +234,6 @@ const styles = StyleSheet.create({
   filteTextWrapper: { right: 0, position: 'absolute' },
   filterText: { fontSize: 16, color: 'gray' },
   advancedOptionsContainer: {},
-  bottomModal: {
-    justifyContent: 'flex-end',
-    margin: 0,
-  },
   item: {
     paddingHorizontal: 0,
   },

--- a/screen/wallets/addMultisigStep2.js
+++ b/screen/wallets/addMultisigStep2.js
@@ -11,7 +11,6 @@ import {
   StyleSheet,
   Text,
   TouchableOpacity,
-  useWindowDimensions,
   View,
 } from 'react-native';
 import {
@@ -29,12 +28,12 @@ import { Icon } from 'react-native-elements';
 import { HDSegwitBech32Wallet, MultisigCosigner, MultisigHDWallet } from '../../class';
 import { useNavigation, useRoute, useTheme } from '@react-navigation/native';
 import loc from '../../loc';
-import Modal from 'react-native-modal';
 import { getSystemName } from 'react-native-device-info';
 import ImagePicker from 'react-native-image-picker';
 import ScanQRCode from '../send/ScanQRCode';
 import QRCode from 'react-native-qrcode-svg';
 import { SquareButton } from '../../components/SquareButton';
+import BottomModal from '../../components/BottomModal';
 import MultipleStepsListItem, {
   MultipleStepsListItemButtohType,
   MultipleStepsListItemDashType,
@@ -54,8 +53,6 @@ const staticCache = {};
 const WalletsAddMultisigStep2 = () => {
   const { addWallet, saveToDisk, setNewWalletAdded } = useContext(BlueStorageContext);
   const { colors } = useTheme();
-  const windowHeight = useWindowDimensions().height;
-  const windowWidth = useWindowDimensions().width;
 
   const navigation = useNavigation();
   const { m, n, format } = useRoute().params;
@@ -501,14 +498,7 @@ const WalletsAddMultisigStep2 = () => {
 
   const renderMnemonicsModal = () => {
     return (
-      <Modal
-        isVisible={isMnemonicsModalVisible}
-        style={styles.bottomModal}
-        onBackButtonPress={Keyboard.dismiss}
-        deviceHeight={windowHeight}
-        deviceWidth={windowWidth}
-        onBackdropPress={Keyboard.dismiss}
-      >
+      <BottomModal isVisible={isMnemonicsModalVisible} onClose={Keyboard.dismiss}>
         <View style={[styles.newKeyModalContent, stylesHook.modalContent]}>
           <View style={styles.itemKeyUnprovidedWrapper}>
             <View style={[styles.vaultKeyCircleSuccess, stylesHook.vaultKeyCircleSuccess]}>
@@ -529,7 +519,7 @@ const WalletsAddMultisigStep2 = () => {
           <BlueSpacing20 />
           <BlueButton title={loc.send.success_done} onPress={() => setIsMnemonicsModalVisible(false)} />
         </View>
-      </Modal>
+      </BottomModal>
     );
   };
 
@@ -541,14 +531,7 @@ const WalletsAddMultisigStep2 = () => {
 
   const renderProvideMnemonicsModal = () => {
     return (
-      <Modal
-        deviceHeight={windowHeight}
-        deviceWidth={windowWidth}
-        isVisible={isProvideMnemonicsModalVisible}
-        style={styles.bottomModal}
-        onBackdropPress={hideProvideMnemonicsModal}
-        onBackButtonPress={hideProvideMnemonicsModal}
-      >
+      <BottomModal isVisible={isProvideMnemonicsModalVisible} onClose={hideProvideMnemonicsModal}>
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={[styles.modalContent, stylesHook.modalContent]}>
             <BlueTextCenteredHooks>{loc.multisig.type_your_mnemonics}</BlueTextCenteredHooks>
@@ -563,7 +546,7 @@ const WalletsAddMultisigStep2 = () => {
             <BlueButtonLinkHook disabled={isLoading} onPress={scanOrOpenFile} title={loc.wallets.import_scan_qr} />
           </View>
         </KeyboardAvoidingView>
-      </Modal>
+      </BottomModal>
     );
   };
 
@@ -579,14 +562,7 @@ const WalletsAddMultisigStep2 = () => {
 
   const renderCosignersXpubModal = () => {
     return (
-      <Modal
-        deviceHeight={windowHeight}
-        deviceWidth={windowWidth}
-        isVisible={isRenderCosignersXpubModalVisible}
-        style={styles.bottomModal}
-        onBackdropPress={hideCosignersXpubModal}
-        onBackButtonPress={hideCosignersXpubModal}
-      >
+      <BottomModal isVisible={isRenderCosignersXpubModalVisible} onClose={hideCosignersXpubModal}>
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={[styles.modalContent, stylesHook.modalContent, styles.alignItemsCenter]}>
             <Text style={[styles.headerText, stylesHook.textDestination]}>{loc.multisig.this_is_cosigners_xpub}</Text>
@@ -611,7 +587,7 @@ const WalletsAddMultisigStep2 = () => {
             </View>
           </View>
         </KeyboardAvoidingView>
-      </Modal>
+      </BottomModal>
     );
   };
   const footer = isLoading ? (
@@ -690,10 +666,6 @@ const styles = StyleSheet.create({
   },
   provideKeyButtonText: { fontWeight: '600', fontSize: 15 },
   textDestination: { fontWeight: '600' },
-  bottomModal: {
-    justifyContent: 'flex-end',
-    margin: 0,
-  },
   modalContent: {
     paddingHorizontal: 22,
     paddingVertical: 32,

--- a/screen/wallets/hodlHodl.js
+++ b/screen/wallets/hodlHodl.js
@@ -1,31 +1,32 @@
 /* global alert */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Modal from 'react-native-modal';
 import { Icon } from 'react-native-elements';
 import {
   ActivityIndicator,
+  Dimensions,
   FlatList,
   Image,
   Keyboard,
   KeyboardAvoidingView,
-  Dimensions,
   Linking,
   Platform,
   SectionList,
+  StatusBar,
   StyleSheet,
   Text,
   TextInput,
   TouchableHighlight,
   TouchableOpacity,
   View,
-  StatusBar,
 } from 'react-native';
+import Geolocation from '@react-native-community/geolocation';
+
 import { BlueButtonLink, BlueNavigationStyle, SafeBlueArea } from '../../BlueComponents';
 import { HodlHodlApi } from '../../class/hodl-hodl-api';
 import * as NavigationService from '../../NavigationService';
-import Geolocation from '@react-native-community/geolocation';
 import { BlueCurrentTheme } from '../../components/themes';
+import BottomModal from '../../components/BottomModal';
 import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 const A = require('../../blue_modules/analytics');
@@ -36,6 +37,7 @@ const METHOD_ANY = '_any';
 const HodlHodlListSections = { OFFERS: 'OFFERS' };
 const windowHeight = Dimensions.get('window').height;
 Geolocation.setRNConfiguration({ authorizationLevel: 'whenInUse' });
+
 export default class HodlHodl extends Component {
   static contextType = BlueStorageContext;
   constructor(props) {
@@ -357,13 +359,7 @@ export default class HodlHodl extends Component {
 
   renderChooseSideModal = () => {
     return (
-      <Modal
-        isVisible={this.state.isChooseSideModalVisible}
-        style={styles.bottomModal}
-        deviceHeight={windowHeight}
-        onBackdropPress={this.hideChooseSideModal}
-        onBackButtonPress={this.hideChooseSideModal}
-      >
+      <BottomModal isVisible={this.state.isChooseSideModalVisible} onClose={this.hideChooseSideModal}>
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContentShort}>
             <FlatList
@@ -389,7 +385,7 @@ export default class HodlHodl extends Component {
             />
           </View>
         </KeyboardAvoidingView>
-      </Modal>
+      </BottomModal>
     );
   };
 
@@ -400,10 +396,9 @@ export default class HodlHodl extends Component {
 
   renderFiltersModal = () => {
     return (
-      <Modal
+      <BottomModal
         isVisible={this.state.isFiltersModalVisible}
-        style={styles.bottomModal}
-        deviceHeight={windowHeight}
+        onClose={this.hideFiltersModal}
         onModalHide={() => {
           if (this.state.openNextModal) {
             const openNextModal = this.state.openNextModal;
@@ -413,8 +408,6 @@ export default class HodlHodl extends Component {
             });
           }
         }}
-        onBackdropPress={this.hideFiltersModal}
-        onBackButtonPress={this.hideFiltersModal}
       >
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContentShort}>
@@ -464,7 +457,7 @@ export default class HodlHodl extends Component {
             />
           </View>
         </KeyboardAvoidingView>
-      </Modal>
+      </BottomModal>
     );
   };
 
@@ -510,13 +503,7 @@ export default class HodlHodl extends Component {
     }
 
     return (
-      <Modal
-        deviceHeight={windowHeight}
-        isVisible={this.state.isChooseCountryModalVisible}
-        style={styles.bottomModal}
-        onBackdropPress={this.hideChooseCountryModal}
-        onBackButtonPress={this.hideChooseCountryModal}
-      >
+      <BottomModal isVisible={this.state.isChooseCountryModalVisible} onClose={this.hideChooseCountryModal}>
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContent}>
             <View style={styles.searchInputContainer}>
@@ -555,7 +542,7 @@ export default class HodlHodl extends Component {
             />
           </View>
         </KeyboardAvoidingView>
-      </Modal>
+      </BottomModal>
     );
   };
 
@@ -590,13 +577,7 @@ export default class HodlHodl extends Component {
     }
 
     return (
-      <Modal
-        isVisible={this.state.isChooseCurrencyVisible}
-        style={styles.bottomModal}
-        deviceHeight={windowHeight}
-        onBackdropPress={this.hideChooseCurrencyModal}
-        onBackButtonPress={this.hideChooseCurrencyModal}
-      >
+      <BottomModal isVisible={this.state.isChooseCurrencyVisible} onClose={this.hideChooseCurrencyModal}>
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContent}>
             <View style={styles.searchInputContainer}>
@@ -635,7 +616,7 @@ export default class HodlHodl extends Component {
             />
           </View>
         </KeyboardAvoidingView>
-      </Modal>
+      </BottomModal>
     );
   };
 
@@ -670,13 +651,7 @@ export default class HodlHodl extends Component {
     }
 
     return (
-      <Modal
-        isVisible={this.state.isChooseMethodVisible}
-        style={styles.bottomModal}
-        deviceHeight={windowHeight}
-        onBackdropPress={this.hideChooseMethodModal}
-        onBackButtonPress={this.hideChooseMethodModal}
-      >
+      <BottomModal isVisible={this.state.isChooseMethodVisible} deviceHeight={windowHeight} onClose={this.hideChooseMethodModal}>
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContent}>
             <View style={styles.searchInputContainer}>
@@ -721,7 +696,7 @@ export default class HodlHodl extends Component {
             />
           </View>
         </KeyboardAvoidingView>
-      </Modal>
+      </BottomModal>
     );
   };
 
@@ -949,10 +924,6 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(0, 0, 0, 0.1)',
     minHeight: 200,
     height: 200,
-  },
-  bottomModal: {
-    justifyContent: 'flex-end',
-    margin: 0,
   },
   Title: {
     fontWeight: 'bold',

--- a/screen/wallets/hodlHodlMyContracts.js
+++ b/screen/wallets/hodlHodlMyContracts.js
@@ -8,12 +8,12 @@ import {
   Linking,
   Platform,
   StyleSheet,
-  Dimensions,
   Text,
   TouchableHighlight,
   TouchableOpacity,
   View,
 } from 'react-native';
+
 import {
   BlueButton,
   BlueCopyTextToClipboard,
@@ -24,12 +24,11 @@ import {
   BlueTextHooks,
 } from '../../BlueComponents';
 import { HodlHodlApi } from '../../class/hodl-hodl-api';
-import Modal from 'react-native-modal';
 import * as NavigationService from '../../NavigationService';
 import { BlueCurrentTheme } from '../../components/themes';
+import BottomModal from '../../components/BottomModal';
 import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
-const windowHeight = Dimensions.get('window').height;
 
 export default class HodlHodlMyContracts extends Component {
   static contextType = BlueStorageContext;
@@ -172,13 +171,7 @@ export default class HodlHodlMyContracts extends Component {
     if (!this.state.contractToDisplay) return;
 
     return (
-      <Modal
-        isVisible={this.state.isRenderContractVisible}
-        style={styles.bottomModal}
-        deviceHeight={windowHeight}
-        onBackdropPress={this.hideContractModal}
-        onBackButtonPress={this.hideContractModal}
-      >
+      <BottomModal isVisible={this.state.isRenderContractVisible} onClose={this.hideContractModal}>
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContent}>
             <View style={styles.modalContentCentered}>
@@ -256,7 +249,7 @@ export default class HodlHodlMyContracts extends Component {
             </Text>
           </View>
         </KeyboardAvoidingView>
-      </Modal>
+      </BottomModal>
     );
   };
 
@@ -350,10 +343,6 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     backgroundColor: BlueCurrentTheme.colors.elevated,
-  },
-  bottomModal: {
-    justifyContent: 'flex-end',
-    margin: 0,
   },
   modalContent: {
     backgroundColor: BlueCurrentTheme.colors.modal,

--- a/screen/wallets/transactions.js
+++ b/screen/wallets/transactions.js
@@ -1,43 +1,44 @@
 /* global alert */
 import React, { useEffect, useState, useCallback, useContext, useRef } from 'react';
-import { Chain } from '../../models/bitcoinUnits';
 import {
-  Text,
-  Platform,
-  StyleSheet,
-  View,
-  Keyboard,
   ActivityIndicator,
-  FlatList,
-  ScrollView,
-  TouchableOpacity,
-  StatusBar,
-  Linking,
-  KeyboardAvoidingView,
   Alert,
-  InteractionManager,
-  useWindowDimensions,
-  PixelRatio,
   Dimensions,
+  FlatList,
+  InteractionManager,
+  Keyboard,
+  KeyboardAvoidingView,
+  Linking,
+  PixelRatio,
+  Platform,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
 } from 'react-native';
 import ImagePicker from 'react-native-image-picker';
 import Clipboard from '@react-native-community/clipboard';
+import { Icon } from 'react-native-elements';
+import Handoff from 'react-native-handoff';
+import { getSystemName } from 'react-native-device-info';
+import { useRoute, useNavigation, useTheme, useFocusEffect } from '@react-navigation/native';
+
+import { Chain } from '../../models/bitcoinUnits';
 import { BlueTransactionListItem, BlueWalletNavigationHeader, BlueAlertWalletExportReminder, BlueListItem } from '../../BlueComponents';
 import WalletGradient from '../../class/wallet-gradient';
-import { Icon } from 'react-native-elements';
 import { LightningCustodianWallet, WatchOnlyWallet } from '../../class';
-import Modal from 'react-native-modal';
 import HandoffSettings from '../../class/handoff';
-import Handoff from 'react-native-handoff';
 import ActionSheet from '../ActionSheet';
 import loc from '../../loc';
 import { FContainer, FButton } from '../../components/FloatButtons';
-import { getSystemName } from 'react-native-device-info';
-import { useRoute, useNavigation, useTheme, useFocusEffect } from '@react-navigation/native';
+import BottomModal from '../../components/BottomModal';
 import BuyBitcoin from './buyBitcoin';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 const BlueElectrum = require('../../blue_modules/BlueElectrum');
 const LocalQRCode = require('@remobile/react-native-qrcode-local-image');
+
 const isDesktop = getSystemName() === 'Mac OS X';
 
 const buttonFontSize =
@@ -61,8 +62,6 @@ const WalletTransactions = () => {
   const { setParams, setOptions, navigate } = useNavigation();
   const { colors } = useTheme();
 
-  const windowHeight = useWindowDimensions().height;
-  const windowWidth = useWindowDimensions().width;
   const stylesHook = StyleSheet.create({
     advancedTransactionOptionsModalContent: {
       backgroundColor: colors.elevated,
@@ -255,14 +254,7 @@ const WalletTransactions = () => {
 
   const renderManageFundsModal = () => {
     return (
-      <Modal
-        deviceHeight={windowHeight}
-        deviceWidth={windowWidth}
-        isVisible={isManageFundsModalVisible}
-        style={styles.bottomModal}
-        onBackdropPress={hideManageFundsModal}
-        onBackButtonPress={hideManageFundsModal}
-      >
+      <BottomModal isVisible={isManageFundsModalVisible} onClose={hideManageFundsModal}>
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={[styles.advancedTransactionOptionsModalContent, stylesHook.advancedTransactionOptionsModalContent]}>
             <BlueListItem
@@ -313,7 +305,7 @@ const WalletTransactions = () => {
             />
           </View>
         </KeyboardAvoidingView>
-      </Modal>
+      </BottomModal>
     );
   };
 
@@ -728,10 +720,6 @@ const styles = StyleSheet.create({
     borderTopRightRadius: 16,
     borderColor: 'rgba(0, 0, 0, 0.1)',
     minHeight: 130,
-  },
-  bottomModal: {
-    justifyContent: 'flex-end',
-    margin: 0,
   },
   walletDetails: {
     marginHorizontal: 16,

--- a/screen/wallets/viewEditMultisigCosigners.js
+++ b/screen/wallets/viewEditMultisigCosigners.js
@@ -4,16 +4,22 @@ import {
   ActivityIndicator,
   Alert,
   FlatList,
+  InteractionManager,
   Keyboard,
   KeyboardAvoidingView,
+  LayoutAnimation,
   Platform,
   StatusBar,
   StyleSheet,
   Text,
-  InteractionManager,
   View,
-  LayoutAnimation,
 } from 'react-native';
+import { Icon } from 'react-native-elements';
+import { useFocusEffect, useNavigation, useRoute, useTheme } from '@react-navigation/native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { getSystemName } from 'react-native-device-info';
+import ImagePicker from 'react-native-image-picker';
+
 import {
   BlueButton,
   BlueButtonHook,
@@ -27,22 +33,18 @@ import {
   BlueTextCentered,
 } from '../../BlueComponents';
 import SquareEnumeratedWords, { SquareEnumeratedWordsContentAlign } from '../../components/SquareEnumeratedWords';
-import { Icon } from 'react-native-elements';
+import BottomModal from '../../components/BottomModal';
 import { HDSegwitBech32Wallet, MultisigHDWallet } from '../../class';
-import { useFocusEffect, useNavigation, useRoute, useTheme } from '@react-navigation/native';
 import loc from '../../loc';
-import Modal from 'react-native-modal';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import MultipleStepsListItem, {
   MultipleStepsListItemButtohType,
   MultipleStepsListItemDashType,
 } from '../../components/MultipleStepsListItem';
-import { getSystemName } from 'react-native-device-info';
-import ImagePicker from 'react-native-image-picker';
 import ScanQRCode from '../send/ScanQRCode';
-const isDesktop = getSystemName() === 'Mac OS X';
 const LocalQRCode = require('@remobile/react-native-qrcode-local-image');
+
+const isDesktop = getSystemName() === 'Mac OS X';
 
 const ViewEditMultisigCosigners = () => {
   const { colors } = useTheme();
@@ -159,12 +161,7 @@ const ViewEditMultisigCosigners = () => {
 
   const renderMnemonicsModal = () => {
     return (
-      <Modal
-        isVisible={isMnemonicsModalVisible}
-        style={styles.bottomModal}
-        onBackdropPress={hideMnemonicsModal}
-        onBackButtonPress={hideMnemonicsModal}
-      >
+      <BottomModal isVisible={isMnemonicsModalVisible} onClose={hideMnemonicsModal}>
         <View style={[styles.newKeyModalContent, stylesHook.modalContent]}>
           <View style={styles.itemKeyUnprovidedWrapper}>
             <View style={[styles.vaultKeyCircleSuccess, stylesHook.vaultKeyCircleSuccess]}>
@@ -203,7 +200,7 @@ const ViewEditMultisigCosigners = () => {
           <BlueSpacing20 />
           <BlueButton title={loc.send.success_done} onPress={() => setIsMnemonicsModalVisible(false)} />
         </View>
-      </Modal>
+      </BottomModal>
     );
   };
 
@@ -429,12 +426,7 @@ const ViewEditMultisigCosigners = () => {
 
   const renderProvideMnemonicsModal = () => {
     return (
-      <Modal
-        isVisible={isProvideMnemonicsModalVisible}
-        style={styles.bottomModal}
-        onBackdropPress={hideProvideMnemonicsModal}
-        onBackButtonPress={hideProvideMnemonicsModal}
-      >
+      <BottomModal isVisible={isProvideMnemonicsModalVisible} onClose={hideProvideMnemonicsModal}>
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={[styles.modalContent, stylesHook.modalContent]}>
             <BlueTextCentered>{loc.multisig.type_your_mnemonics}</BlueTextCentered>
@@ -453,7 +445,7 @@ const ViewEditMultisigCosigners = () => {
             <BlueButtonLinkHook disabled={isLoading} onPress={scanOrOpenFile} title={loc.wallets.import_scan_qr} />
           </View>
         </KeyboardAvoidingView>
-      </Modal>
+      </BottomModal>
     );
   };
 
@@ -531,10 +523,6 @@ const styles = StyleSheet.create({
     borderTopLeftRadius: 16,
     borderTopRightRadius: 16,
     borderColor: 'rgba(0, 0, 0, 0.1)',
-  },
-  bottomModal: {
-    justifyContent: 'flex-end',
-    margin: 0,
   },
   modalContent: {
     padding: 22,


### PR DESCRIPTION
Because `react-native-modal` is used in BW only for bottom modals it shares a lot of common logic. Like getting window height/width or duplication of onBackButtonPress/onBackdropPress. So I've moved this common logic to a separate component.