### PR TITLE
REF: no autconnect in BlueElectrum

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,13 +3,15 @@ import React, { useContext, useEffect, useRef, useState } from 'react';
 import { AppState, DeviceEventEmitter, KeyboardAvoidingView, Linking, Platform, StyleSheet, useColorScheme, View } from 'react-native';
 import { NavigationContainer, CommonActions } from '@react-navigation/native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
+import QuickActions from 'react-native-quick-actions';
+import * as Sentry from '@sentry/react-native';
+import changeNavigationBarColor from 'react-native-navigation-bar-color';
+
 import { navigationRef } from './NavigationService';
 import * as NavigationService from './NavigationService';
 import { BlueTextCentered, BlueButton, SecondButton } from './BlueComponents';
-import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import { Chain } from './models/bitcoinUnits';
-import QuickActions from 'react-native-quick-actions';
-import * as Sentry from '@sentry/react-native';
 import OnAppLaunch from './class/on-app-launch';
 import DeeplinkSchemaMatch from './class/deeplink-schema-match';
 import loc from './loc';
@@ -24,7 +26,7 @@ import Notifications from './blue_modules/notifications';
 import WalletImport from './class/wallet-import';
 import Biometric from './class/biometrics';
 import WidgetCommunication from './blue_modules/WidgetCommunication';
-import changeNavigationBarColor from 'react-native-navigation-bar-color';
+import BlueElectrum from './blue_modules/BlueElectrum';
 const A = require('./blue_modules/analytics');
 
 if (process.env.NODE_ENV !== 'development') {
@@ -37,6 +39,8 @@ const ClipboardContentType = Object.freeze({
   BITCOIN: 'BITCOIN',
   LIGHTNING: 'LIGHTNING',
 });
+
+BlueElectrum.connectMain();
 
 const App = () => {
   const { walletsInitialized, wallets, addWallet, saveToDisk, fetchAndSaveWalletTransactions } = useContext(BlueStorageContext);

--- a/blue_modules/BlueElectrum.js
+++ b/blue_modules/BlueElectrum.js
@@ -100,8 +100,6 @@ async function connectMain() {
   }
 }
 
-connectMain();
-
 /**
  * Returns random hardcoded electrum server guaranteed to work
  * at the time of writing.
@@ -148,6 +146,8 @@ async function getRandomDynamicPeer() {
     return defaultPeer; // smth went wrong, using default
   }
 }
+
+module.exports.connectMain = connectMain;
 
 /**
  *
@@ -454,6 +454,29 @@ module.exports.waitTillConnected = async function () {
         reject(new Error('Waiting for Electrum connection timeout'));
       }
     }, 500);
+  });
+};
+
+/**
+ * Simple waiter till socket `mainClient.conn` becomes undefined or timeout 30 sec.
+ *
+ * @returns {Promise<Promise<*> | Promise<*>>}
+ */
+module.exports.waitTillDisconnected = async function () {
+  let waitTillConnectedInterval = false;
+  let retriesCounter = 0;
+  return new Promise((resolve, reject) => {
+    waitTillConnectedInterval = setInterval(() => {
+      if (mainConnected.conn === undefined) {
+        clearInterval(waitTillConnectedInterval);
+        resolve(true);
+      }
+
+      if (retriesCounter++ >= 30) {
+        clearInterval(waitTillConnectedInterval);
+        reject(new Error('Waiting for Electrum socket destruction timeout'));
+      }
+    }, 100);
   });
 };
 

--- a/class/wallets/hd-legacy-breadwallet-wallet.js
+++ b/class/wallets/hd-legacy-breadwallet-wallet.js
@@ -1,7 +1,10 @@
 import bip39 from 'bip39';
+import * as bip32 from 'bip32';
+import * as bitcoinjs from 'bitcoinjs-lib';
+
+import BlueElectrum from '../../blue_modules/BlueElectrum';
 import { HDLegacyP2PKHWallet } from './hd-legacy-p2pkh-wallet';
-const bip32 = require('bip32');
-const bitcoinjs = require('bitcoinjs-lib');
+import { AbstractHDElectrumWallet } from './abstract-hd-electrum-wallet';
 
 /**
  * HD Wallet (BIP39).
@@ -10,6 +13,14 @@ const bitcoinjs = require('bitcoinjs-lib');
 export class HDLegacyBreadwalletWallet extends HDLegacyP2PKHWallet {
   static type = 'HDLegacyBreadwallet';
   static typeReadable = 'HD Legacy Breadwallet (P2PKH)';
+
+  // track address index at which wallet switched to segwit
+  _external_segwit_index = null; // eslint-disable-line camelcase
+  _internal_segwit_index = null; // eslint-disable-line camelcase
+
+  allowSendMax() {
+    return true;
+  }
 
   /**
    * @see https://github.com/bitcoinjs/bitcoinjs-lib/issues/584
@@ -31,28 +42,58 @@ export class HDLegacyBreadwalletWallet extends HDLegacyP2PKHWallet {
     return this._xpub;
   }
 
-  _getExternalAddressByIndex(index) {
+  // we need a separate function without external_addresses_cache to use in binarySearch
+  _calcNodeAddressByIndex(node, index, p2wpkh = false) {
+    let _node;
+    if (node === 0) {
+      _node = this._node0 || (this._node0 = bitcoinjs.bip32.fromBase58(this.getXpub()).derive(node));
+    }
+    if (node === 1) {
+      _node = this._node1 || (this._node1 = bitcoinjs.bip32.fromBase58(this.getXpub()).derive(node));
+    }
+    const pubkey = _node.derive(index).publicKey;
+    const address = p2wpkh ? bitcoinjs.payments.p2wpkh({ pubkey }).address : bitcoinjs.payments.p2pkh({ pubkey }).address;
+    return address;
+  }
+
+  // this function is different from HDLegacyP2PKHWallet._getNodeAddressByIndex.
+  // It takes _external_segwit_index _internal_segwit_index for account
+  // and starts to generate segwit addresses if index more than them
+  _getNodeAddressByIndex(node, index) {
     index = index * 1; // cast to int
-    if (this.external_addresses_cache[index]) return this.external_addresses_cache[index]; // cache hit
+    if (node === 0) {
+      if (this.external_addresses_cache[index]) return this.external_addresses_cache[index]; // cache hit
+    }
 
-    const node = bitcoinjs.bip32.fromBase58(this.getXpub());
-    const address = bitcoinjs.payments.p2pkh({
-      pubkey: node.derive(0).derive(index).publicKey,
-    }).address;
+    if (node === 1) {
+      if (this.internal_addresses_cache[index]) return this.internal_addresses_cache[index]; // cache hit
+    }
 
-    return (this.external_addresses_cache[index] = address);
+    let p2wpkh = false;
+    if (
+      (node === 0 && this._external_segwit_index !== null && index >= this._external_segwit_index) ||
+      (node === 1 && this._internal_segwit_index !== null && index >= this._internal_segwit_index)
+    ) {
+      p2wpkh = true;
+    }
+
+    const address = this._calcNodeAddressByIndex(node, index, p2wpkh);
+
+    if (node === 0) {
+      return (this.external_addresses_cache[index] = address);
+    }
+
+    if (node === 1) {
+      return (this.internal_addresses_cache[index] = address);
+    }
+  }
+
+  _getExternalAddressByIndex(index) {
+    return this._getNodeAddressByIndex(0, index);
   }
 
   _getInternalAddressByIndex(index) {
-    index = index * 1; // cast to int
-    if (this.internal_addresses_cache[index]) return this.internal_addresses_cache[index]; // cache hit
-
-    const node = bitcoinjs.bip32.fromBase58(this.getXpub());
-    const address = bitcoinjs.payments.p2pkh({
-      pubkey: node.derive(1).derive(index).publicKey,
-    }).address;
-
-    return (this.internal_addresses_cache[index] = address);
+    return this._getNodeAddressByIndex(1, index);
   }
 
   _getExternalWIFByIndex(index) {
@@ -81,7 +122,96 @@ export class HDLegacyBreadwalletWallet extends HDLegacyP2PKHWallet {
     return child.toWIF();
   }
 
-  allowSendMax() {
-    return true;
+  async fetchBalance() {
+    try {
+      if (this.next_free_change_address_index === 0 && this.next_free_address_index === 0) {
+        // doing binary search for last used addresses external/internal and legacy/bech32:
+        const [nextFreeExternalLegacy, nextFreeInternalLegacy] = await Promise.all([
+          this._binarySearchIteration(0, 1000, 0, false),
+          this._binarySearchIteration(0, 1000, 1, false),
+        ]);
+        const [nextFreeExternalBech32, nextFreeInternalBech32] = await Promise.all([
+          this._binarySearchIteration(nextFreeExternalLegacy, nextFreeExternalLegacy + 1000, 0, true),
+          this._binarySearchIteration(nextFreeInternalLegacy, nextFreeInternalLegacy + 1000, 1, true),
+        ]);
+
+        // trying to detect if segwit activated. This condition can be deleted when BRD will enable segwit by default
+        if (nextFreeExternalLegacy < nextFreeExternalBech32) {
+          this._external_segwit_index = nextFreeExternalLegacy;
+        }
+        this.next_free_address_index = nextFreeExternalBech32;
+
+        this._internal_segwit_index = nextFreeInternalLegacy; // force segwit for change
+        this.next_free_change_address_index = nextFreeInternalBech32;
+      } // end rescanning fresh wallet
+
+      // finally fetching balance
+      await this._fetchBalance();
+    } catch (err) {
+      console.warn(err);
+    }
+  }
+
+  async _binarySearchIteration(startIndex, endIndex, node = 0, p2wpkh = false) {
+    const gerenateChunkAddresses = chunkNum => {
+      const ret = [];
+      for (let c = this.gap_limit * chunkNum; c < this.gap_limit * (chunkNum + 1); c++) {
+        ret.push(this._calcNodeAddressByIndex(node, c, p2wpkh));
+      }
+      return ret;
+    };
+
+    let lastChunkWithUsedAddressesNum = null;
+    let lastHistoriesWithUsedAddresses = null;
+    for (let c = 0; c < Math.round(endIndex / this.gap_limit); c++) {
+      const histories = await BlueElectrum.multiGetHistoryByAddress(gerenateChunkAddresses(c));
+      if (this.constructor._getTransactionsFromHistories(histories).length > 0) {
+        // in this particular chunk we have used addresses
+        lastChunkWithUsedAddressesNum = c;
+        lastHistoriesWithUsedAddresses = histories;
+      } else {
+        // empty chunk. no sense searching more chunks
+        break;
+      }
+    }
+
+    let lastUsedIndex = startIndex;
+
+    if (lastHistoriesWithUsedAddresses) {
+      // now searching for last used address in batch lastChunkWithUsedAddressesNum
+      for (
+        let c = lastChunkWithUsedAddressesNum * this.gap_limit;
+        c < lastChunkWithUsedAddressesNum * this.gap_limit + this.gap_limit;
+        c++
+      ) {
+        const address = this._calcNodeAddressByIndex(node, c, p2wpkh);
+        if (lastHistoriesWithUsedAddresses[address] && lastHistoriesWithUsedAddresses[address].length > 0) {
+          lastUsedIndex = Math.max(c, lastUsedIndex) + 1; // point to next, which is supposed to be unsued
+        }
+      }
+    }
+
+    return lastUsedIndex;
+  }
+
+  _getDerivationPathByAddress(address, BIP = 0) {
+    const path = `m/${BIP}'`;
+    for (let c = 0; c < this.next_free_address_index + this.gap_limit; c++) {
+      if (this._getExternalAddressByIndex(c) === address) return path + '/0/' + c;
+    }
+    for (let c = 0; c < this.next_free_change_address_index + this.gap_limit; c++) {
+      if (this._getInternalAddressByIndex(c) === address) return path + '/1/' + c;
+    }
+
+    return false;
+  }
+
+  _addPsbtInput(psbt, input, sequence, masterFingerprintBuffer) {
+    // hack to use
+    // AbstractHDElectrumWallet._addPsbtInput for bech32 address
+    // HDLegacyP2PKHWallet._addPsbtInput for legacy address
+    const ProxyClass = input.address.startsWith('bc1') ? AbstractHDElectrumWallet : HDLegacyP2PKHWallet;
+    const proxy = new ProxyClass();
+    return proxy._addPsbtInput.apply(this, [psbt, input, sequence, masterFingerprintBuffer]);
   }
 }

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "env":{
+    "es6": true,
+    "jasmine": true,
+    "jest": true
+  }
+}

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -1,8 +1,7 @@
-/* global it, describe, expect, element, by, waitFor, device, jasmine */
-
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
-const createHash = require('create-hash');
+/* global element, by, waitFor, device */
+import assert from 'assert';
+import * as bitcoin from 'bitcoinjs-lib';
+import createHash from 'create-hash';
 
 jasmine.getEnv().addReporter({
   specStarted: result => (jasmine.currentTest = result),

--- a/tests/e2e/init.js
+++ b/tests/e2e/init.js
@@ -1,4 +1,4 @@
-/* global jasmine, jest, beforeAll, afterAll, beforeEach, device */
+/* global device */
 
 const detox = require('detox');
 const config = require('../../package.json').detox;

--- a/tests/integration/App.test.js
+++ b/tests/integration/App.test.js
@@ -1,13 +1,13 @@
-/* global it, expect, jest */
 import React from 'react';
+import assert from 'assert';
 import TestRenderer from 'react-test-renderer';
+
 import Settings from '../../screen/settings/settings';
 import Selftest from '../../screen/selftest';
 import { BlueHeader } from '../../BlueComponents';
-const assert = require('assert');
-jest.mock('react-native-qrcode-svg', () => 'Video');
-jest.useFakeTimers();
 
+jest.useFakeTimers();
+jest.mock('react-native-qrcode-svg', () => 'Video');
 jest.mock('amplitude-js', () => ({
   getInstance: function () {
     return {

--- a/tests/integration/BlueElectrum.test.js
+++ b/tests/integration/BlueElectrum.test.js
@@ -1,19 +1,20 @@
-/* global it, describe, afterAll, beforeAll, jasmine */
+import assert from 'assert';
 global.net = require('net');
 global.tls = require('tls');
 const BlueElectrum = require('../../blue_modules/BlueElectrum');
-const assert = require('assert');
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 150 * 1000;
 
-afterAll(() => {
+afterAll(async () => {
   // after all tests we close socket so the test suite can actually terminate
   BlueElectrum.forceDisconnect();
+  await BlueElectrum.waitTillDisconnected();
 });
 
 beforeAll(async () => {
   // awaiting for Electrum to be connected. For RN Electrum would naturally connect
   // while app starts up, but for tests we need to wait for it
   try {
+    BlueElectrum.connectMain();
     await BlueElectrum.waitTillConnected();
   } catch (err) {
     console.log('failed to connect to Electrum:', err);

--- a/tests/integration/Currency.test.js
+++ b/tests/integration/Currency.test.js
@@ -1,8 +1,9 @@
-/* global describe, it, jest, jasmine */
+import assert from 'assert';
+import AsyncStorage from '@react-native-community/async-storage';
+
 import { AppStorage } from '../../class';
 import { FiatUnit } from '../../models/fiatUnit';
-import AsyncStorage from '@react-native-community/async-storage';
-const assert = require('assert');
+
 jest.useFakeTimers();
 
 describe('currency', () => {

--- a/tests/integration/ElectrumClient.test.js
+++ b/tests/integration/ElectrumClient.test.js
@@ -1,9 +1,9 @@
-/* global it, describe, jasmine */
-const bitcoin = require('bitcoinjs-lib');
+import assert from 'assert';
+import * as bitcoin from 'bitcoinjs-lib';
+
 global.net = require('net');
 global.tls = require('tls');
 
-const assert = require('assert');
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 150 * 1000;
 
 const hardcodedPeers = [
@@ -14,6 +14,8 @@ const hardcodedPeers = [
   { host: 'electrum2.bluewallet.io', tcp: '50001' },
   { host: 'electrum3.bluewallet.io', tcp: '50001' },
 ];
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 describe('ElectrumClient', () => {
   it('can connect and query', async () => {
@@ -50,6 +52,7 @@ describe('ElectrumClient', () => {
       // let peers = await mainClient.serverPeers_subscribe();
       // console.log(peers);
       mainClient.close();
+      await sleep(10); // wait till socket is closed
     }
   });
 });

--- a/tests/integration/hd-legacy-breadwallet.test.js
+++ b/tests/integration/hd-legacy-breadwallet.test.js
@@ -1,0 +1,52 @@
+import assert from 'assert';
+import * as bitcoin from 'bitcoinjs-lib';
+import { HDLegacyBreadwalletWallet } from '../../class';
+global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
+global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
+const BlueElectrum = require('../../blue_modules/BlueElectrum'); // so it connects ASAP
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 300 * 1000;
+
+afterAll(async () => {
+  // after all tests we close socket so the test suite can actually terminate
+  BlueElectrum.forceDisconnect();
+  await BlueElectrum.waitTillDisconnected();
+});
+
+beforeAll(async () => {
+  // awaiting for Electrum to be connected. For RN Electrum would naturally connect
+  // while app starts up, but for tests we need to wait for it
+  BlueElectrum.connectMain();
+  await BlueElectrum.waitTillConnected();
+});
+
+it('Legacy HD Breadwallet can fetch balance and create transaction', async () => {
+  if (!process.env.HD_MNEMONIC_BREAD) {
+    console.error('process.env.HD_MNEMONIC_BREAD not set, skipped');
+    return;
+  }
+  const wallet = new HDLegacyBreadwalletWallet();
+  wallet.setSecret(process.env.HD_MNEMONIC_BREAD);
+
+  await wallet.fetchBalance();
+
+  // m/0'/0/1 1K9ofAnenRn1aR9TMMTreiin9ddjKWbS7z x 0.0001
+  // m/0'/0/2 bc1qh0vtrnjn7zs99j4n6xaadde95ctnnvegh9l2jn x 0.00032084
+  // m/0'/1/0 1A9Sc4opR6c7Ui6NazECiGmsmnUPh2WeHJ x 0.00016378 BTC
+  // m/0'/1/1 bc1qksn08tz44fvnnrpgrrexvs9526t6jg3xnj9tpc x 0.00012422
+  // 0.0001 + 0.00016378 + 0.00012422 + 0.00032084 = 0.00070884
+  assert.strictEqual(wallet.getBalance(), 70884);
+
+  // try to create a tx
+  await wallet.fetchUtxo();
+  const { tx } = wallet.createTransaction(
+    wallet.getUtxo(),
+    [{ address: 'bc1q47efz9aav8g4mnnz9r6ql4pf48phy3g509p7gx' }],
+    1,
+    'bc1qk9hvkxqsqmps6ex3qawr79rvtg8es4ecjfu5v0',
+  );
+
+  const transaction = bitcoin.Transaction.fromHex(tx.toHex());
+  assert.ok(transaction.ins.length === 4);
+  assert.strictEqual(transaction.outs.length, 1);
+});

--- a/tests/integration/hd-segwit-bech32-transaction.test.js
+++ b/tests/integration/hd-segwit-bech32-transaction.test.js
@@ -1,7 +1,6 @@
-/* global it, describe, jasmine, afterAll, beforeAll */
+import assert from 'assert';
+import * as bitcoin from 'bitcoinjs-lib';
 import { HDSegwitBech32Wallet, SegwitP2SHWallet, HDSegwitBech32Transaction, SegwitBech32Wallet } from '../../class';
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
 const BlueElectrum = require('../../blue_modules/BlueElectrum');
@@ -10,11 +9,13 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 150 * 1000;
 afterAll(async () => {
   // after all tests we close socket so the test suite can actually terminate
   BlueElectrum.forceDisconnect();
+  await BlueElectrum.waitTillDisconnected();
 });
 
 beforeAll(async () => {
   // awaiting for Electrum to be connected. For RN Electrum would naturally connect
   // while app starts up, but for tests we need to wait for it
+  BlueElectrum.connectMain();
   await BlueElectrum.waitTillConnected();
 });
 

--- a/tests/integration/hd-segwit-bech32-wallet.test.js
+++ b/tests/integration/hd-segwit-bech32-wallet.test.js
@@ -1,6 +1,5 @@
-/* global it, describe, jasmine, afterAll, beforeAll */
+import assert from 'assert';
 import { HDSegwitBech32Wallet } from '../../class';
-const assert = require('assert');
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
 const BlueElectrum = require('../../blue_modules/BlueElectrum'); // so it connects ASAP
@@ -10,11 +9,13 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 300 * 1000;
 afterAll(async () => {
   // after all tests we close socket so the test suite can actually terminate
   BlueElectrum.forceDisconnect();
+  await BlueElectrum.waitTillDisconnected();
 });
 
 beforeAll(async () => {
   // awaiting for Electrum to be connected. For RN Electrum would naturally connect
   // while app starts up, but for tests we need to wait for it
+  BlueElectrum.connectMain();
   await BlueElectrum.waitTillConnected();
 });
 

--- a/tests/integration/hd-segwit-p2sh-wallet.test.js
+++ b/tests/integration/hd-segwit-p2sh-wallet.test.js
@@ -1,21 +1,22 @@
-/* global it, jasmine, afterAll, beforeAll */
+import assert from 'assert';
+import * as bitcoin from 'bitcoinjs-lib';
 import { HDSegwitP2SHWallet } from '../../class';
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
 const BlueElectrum = require('../../blue_modules/BlueElectrum'); // so it connects ASAP
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 300 * 1000;
 
-afterAll(() => {
+afterAll(async () => {
   // after all tests we close socket so the test suite can actually terminate
   BlueElectrum.forceDisconnect();
+  await BlueElectrum.waitTillDisconnected();
 });
 
 beforeAll(async () => {
   // awaiting for Electrum to be connected. For RN Electrum would naturally connect
   // while app starts up, but for tests we need to wait for it
   try {
+    BlueElectrum.connectMain();
     await BlueElectrum.waitTillConnected();
   } catch (Err) {
     console.log('failed to connect to Electrum:', Err);

--- a/tests/integration/hodlhodl.test.js
+++ b/tests/integration/hodlhodl.test.js
@@ -1,9 +1,7 @@
-/* global it, jasmine, describe */
+import assert from 'assert';
+import * as bitcoin from 'bitcoinjs-lib';
 import { LegacyWallet, SegwitBech32Wallet, SegwitP2SHWallet } from '../../class';
 import { HodlHodlApi } from '../../class/hodl-hodl-api';
-
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
 
 it.skip('can verify escrow address', () => {
   const encryptedSeed =

--- a/tests/integration/legacy-wallet.test.js
+++ b/tests/integration/legacy-wallet.test.js
@@ -1,6 +1,5 @@
-/* global describe, it, jasmine, afterAll, beforeAll */
+import assert from 'assert';
 import { LegacyWallet, SegwitP2SHWallet, SegwitBech32Wallet } from '../../class';
-const assert = require('assert');
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
 const BlueElectrum = require('../../blue_modules/BlueElectrum'); // so it connects ASAP
@@ -10,11 +9,13 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 afterAll(async () => {
   // after all tests we close socket so the test suite can actually terminate
   BlueElectrum.forceDisconnect();
+  await BlueElectrum.waitTillDisconnected();
 });
 
 beforeAll(async () => {
   // awaiting for Electrum to be connected. For RN Electrum would naturally connect
   // while app starts up, but for tests we need to wait for it
+  BlueElectrum.connectMain();
   await BlueElectrum.waitTillConnected();
 });
 

--- a/tests/integration/lightning-custodian-wallet.test.js
+++ b/tests/integration/lightning-custodian-wallet.test.js
@@ -1,7 +1,6 @@
-/* global it, describe, jasmine */
+import assert from 'assert';
 import Frisbee from 'frisbee';
 import { LightningCustodianWallet } from '../../class';
-const assert = require('assert');
 
 describe('LightningCustodianWallet', () => {
   const l1 = new LightningCustodianWallet();

--- a/tests/integration/multisig-hd-wallet.test.js
+++ b/tests/integration/multisig-hd-wallet.test.js
@@ -1,4 +1,3 @@
-/* global it, describe, jasmine, afterAll, beforeAll */
 import assert from 'assert';
 import { MultisigHDWallet } from '../../class/';
 const BlueElectrum = require('../../blue_modules/BlueElectrum'); // so it connects ASAP
@@ -6,15 +5,17 @@ global.net = require('net'); // needed by Electrum client. For RN it is proviced
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 300 * 1000;
 
-afterAll(() => {
+afterAll(async () => {
   // after all tests we close socket so the test suite can actually terminate
   BlueElectrum.forceDisconnect();
+  await BlueElectrum.waitTillDisconnected();
 });
 
 beforeAll(async () => {
   // awaiting for Electrum to be connected. For RN Electrum would naturally connect
   // while app starts up, but for tests we need to wait for it
   try {
+    BlueElectrum.connectMain();
     await BlueElectrum.waitTillConnected();
   } catch (Err) {
     console.log('failed to connect to Electrum:', Err);

--- a/tests/integration/notifications.test.js
+++ b/tests/integration/notifications.test.js
@@ -1,7 +1,8 @@
-/* global it, describe */
+import assert from 'assert';
 import Notifications from '../../blue_modules/notifications';
-const assert = require('assert');
+
 Notifications.default = new Notifications();
+
 describe('notifications', () => {
   it('can check groundcontrol server uri validity', async () => {
     assert.ok(await Notifications.isGroundControlUriValid('https://groundcontrol-bluewallet.herokuapp.com'));

--- a/tests/integration/watch-only-wallet.test.js
+++ b/tests/integration/watch-only-wallet.test.js
@@ -1,6 +1,5 @@
-/* global it, describe, jasmine, afterAll, beforeAll  */
+import assert from 'assert';
 import { WatchOnlyWallet } from '../../class';
-const assert = require('assert');
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
 const BlueElectrum = require('../../blue_modules/BlueElectrum'); // so it connects ASAP
@@ -8,11 +7,13 @@ const BlueElectrum = require('../../blue_modules/BlueElectrum'); // so it connec
 afterAll(async () => {
   // after all tests we close socket so the test suite can actually terminate
   BlueElectrum.forceDisconnect();
+  await BlueElectrum.waitTillDisconnected();
 });
 
 beforeAll(async () => {
   // awaiting for Electrum to be connected. For RN Electrum would naturally connect
   // while app starts up, but for tests we need to wait for it
+  BlueElectrum.connectMain();
   await BlueElectrum.waitTillConnected();
 });
 

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,5 +1,3 @@
-/* global jest */
-
 jest.mock('react-native-watch-connectivity', () => {
   return {
     getIsWatchAppInstalled: jest.fn(() => Promise.resolve(false)),

--- a/tests/setupAfterEnv.js
+++ b/tests/setupAfterEnv.js
@@ -1,14 +1,14 @@
 global.beforeEach(() => {
   if (process.env.TRAVIS || process.env.CI) return;
-  process.stdout.write(jasmine.currentTest.fullName + "...\r");
+  process.stdout.write(jasmine.currentTest.fullName + '...\r');
 });
 
 global.afterEach(() => {
   if (process.env.TRAVIS || process.env.CI) return;
   if (jasmine.currentTest.failedExpectations.length) {
-    process.stdout.write(jasmine.currentTest.fullName + "...FAIL\n");
+    process.stdout.write(jasmine.currentTest.fullName + '...FAIL\n');
   } else {
-    process.stdout.write(jasmine.currentTest.fullName + "...OK\n");
+    process.stdout.write(jasmine.currentTest.fullName + '...OK\n');
   }
 });
 
@@ -16,4 +16,3 @@ jasmine.getEnv().addReporter({
   specStarted: result => (jasmine.currentTest = result),
   specDone: result => (jasmine.currentTest = result),
 });
-

--- a/tests/unit/bip38.test.js
+++ b/tests/unit/bip38.test.js
@@ -1,5 +1,4 @@
-/* global it, jasmine */
-const assert = require('assert');
+import assert from 'assert';
 
 it('bip38 decodes', async () => {
   const bip38 = require('../../blue_modules/bip38');

--- a/tests/unit/currency.test.js
+++ b/tests/unit/currency.test.js
@@ -1,6 +1,5 @@
-/* global describe, it */
+import assert from 'assert';
 import { FiatUnit } from '../../models/fiatUnit';
-const assert = require('assert');
 
 describe('currency', () => {
   it('formats everything correctly', async () => {

--- a/tests/unit/deeplink-schema-match.test.js
+++ b/tests/unit/deeplink-schema-match.test.js
@@ -1,6 +1,6 @@
-/* global describe, it, jest */
+import assert from 'assert';
 import DeeplinkSchemaMatch from '../../class/deeplink-schema-match';
-const assert = require('assert');
+
 jest.useFakeTimers();
 
 describe('unit - DeepLinkSchemaMatch', function () {

--- a/tests/unit/encryption.test.js
+++ b/tests/unit/encryption.test.js
@@ -1,5 +1,4 @@
-/* global describe, it */
-const assert = require('assert');
+import assert from 'assert';
 const c = require('../../blue_modules/encryption');
 
 describe('unit - encryption', function () {

--- a/tests/unit/hd-legacy-breadwallet.test.js
+++ b/tests/unit/hd-legacy-breadwallet.test.js
@@ -1,6 +1,5 @@
-/* global it */
+import assert from 'assert';
 import { HDLegacyBreadwalletWallet } from '../../class';
-const assert = require('assert');
 
 it('Legacy HD Breadwallet works', async () => {
   if (!process.env.HD_MNEMONIC_BREAD) {
@@ -11,22 +10,32 @@ it('Legacy HD Breadwallet works', async () => {
   hdBread.setSecret(process.env.HD_MNEMONIC_BREAD);
 
   assert.strictEqual(hdBread.validateMnemonic(), true);
-  assert.strictEqual(hdBread._getExternalAddressByIndex(0), '1ARGkNMdsBE36fJhddSwf8PqBXG3s4d2KU');
-  assert.ok(hdBread.getAllExternalAddresses().includes('1ARGkNMdsBE36fJhddSwf8PqBXG3s4d2KU'));
-  assert.strictEqual(hdBread._getInternalAddressByIndex(0), '1JLvA5D7RpWgChb4A5sFcLNrfxYbyZdw3V');
-  assert.strictEqual(hdBread._getExternalWIFByIndex(0), 'L25CoHfqWKR5byQhgp4M8sW1roifBteD3Lj3zCGNcV4JXhbxZ93F');
-  assert.strictEqual(hdBread._getInternalWIFByIndex(0), 'KyEQuB73eueeS7D6iBJrNSvkD1kkdkJoUsavuxGXv5fxWkPJxt96');
+  assert.strictEqual(hdBread._getExternalAddressByIndex(0), '1M1UphJDb1mpXV3FVEg6b2qqaBieNuaNrt');
+  assert.strictEqual(hdBread._getInternalAddressByIndex(0), '1A9Sc4opR6c7Ui6NazECiGmsmnUPh2WeHJ');
+  hdBread._internal_segwit_index = 2;
+  hdBread._external_segwit_index = 2;
+  assert.ok(hdBread._getExternalAddressByIndex(0).startsWith('1'));
+  assert.ok(hdBread._getInternalAddressByIndex(0).startsWith('1'));
+  assert.strictEqual(hdBread._getExternalAddressByIndex(2), 'bc1qh0vtrnjn7zs99j4n6xaadde95ctnnvegh9l2jn');
+  assert.strictEqual(hdBread._getInternalAddressByIndex(2), 'bc1qk9hvkxqsqmps6ex3qawr79rvtg8es4ecjfu5v0');
+
+  assert.strictEqual(hdBread._getDerivationPathByAddress('1M1UphJDb1mpXV3FVEg6b2qqaBieNuaNrt'), "m/0'/0/0");
+  assert.strictEqual(hdBread._getDerivationPathByAddress('bc1qk9hvkxqsqmps6ex3qawr79rvtg8es4ecjfu5v0'), "m/0'/1/2");
+
   assert.strictEqual(
     hdBread._getPubkeyByAddress(hdBread._getExternalAddressByIndex(0)).toString('hex'),
-    '0354d804a7943eb61ec13deef44586510506889175dc2f3a375867e4796debf2a9',
+    '029ba027f3f0a9fa69ce680a246198d56a3b047108f26791d1e4aa2d10e7e7a29a',
   );
   assert.strictEqual(
     hdBread._getPubkeyByAddress(hdBread._getInternalAddressByIndex(0)).toString('hex'),
-    '02d241fadf3e48ff30a93360f6ef255cc3a797c588c907615d096510a918f46dce',
+    '03074225b31a95af63de31267104e07863d892d291a33ef5b2b32d59c772d5c784',
   );
 
   assert.strictEqual(
     hdBread.getXpub(),
-    'xpub68nLLEi3KERQY7jyznC9PQSpSjmekrEmN8324YRCXayMXaavbdEJsK4gEcX2bNf9vGzT4xRks9utZ7ot1CTHLtdyCn9udvv1NWvtY7HXroh',
+    'xpub68hPk9CrHimZMBQEja43qWRC2TuXmCDdgZcR5YMebr38XatUEPu2Q2oaBViSMshDcyuMDGkGbTS2aqNHFKdcN1sFWaZgK6SLg84dtN7Ym64',
   );
+
+  assert.ok(hdBread.getAllExternalAddresses().includes('1M1UphJDb1mpXV3FVEg6b2qqaBieNuaNrt'));
+  assert.ok(hdBread.getAllExternalAddresses().includes('bc1qh0vtrnjn7zs99j4n6xaadde95ctnnvegh9l2jn'));
 });

--- a/tests/unit/hd-legacy-electrum-seed-p2pkh-wallet.test.js
+++ b/tests/unit/hd-legacy-electrum-seed-p2pkh-wallet.test.js
@@ -1,6 +1,5 @@
-/* global describe, it */
+import assert from 'assert';
 import { HDLegacyElectrumSeedP2PKHWallet } from '../../class';
-const assert = require('assert');
 
 describe('HDLegacyElectrumSeedP2PKHWallet', () => {
   it('can import mnemonics and generate addresses and WIFs', async function () {

--- a/tests/unit/hd-legacy-wallet.test.js
+++ b/tests/unit/hd-legacy-wallet.test.js
@@ -1,7 +1,6 @@
-/* global it */
+import assert from 'assert';
+import * as bitcoin from 'bitcoinjs-lib';
 import { HDLegacyP2PKHWallet } from '../../class';
-const assert = require('assert');
-const bitcoin = require('bitcoinjs-lib');
 
 it('Legacy HD (BIP44) works', async () => {
   if (!process.env.HD_MNEMONIC) {

--- a/tests/unit/hd-segwit-bech32-wallet.test.js
+++ b/tests/unit/hd-segwit-bech32-wallet.test.js
@@ -1,6 +1,5 @@
-/* global it, describe */
+import assert from 'assert';
 import { HDSegwitBech32Wallet } from '../../class';
-const assert = require('assert');
 
 describe('Bech32 Segwit HD (BIP84)', () => {
   it('can create', async function () {

--- a/tests/unit/hd-segwit-electrum-seed-p2wpkh-wallet.test.js
+++ b/tests/unit/hd-segwit-electrum-seed-p2wpkh-wallet.test.js
@@ -1,6 +1,5 @@
-/* global describe, it */
+import assert from 'assert';
 import { HDSegwitElectrumSeedP2WPKHWallet } from '../../class';
-const assert = require('assert');
 
 describe('HDSegwitElectrumSeedP2WPKHWallet', () => {
   it('can import mnemonics and generate addresses and WIFs', async function () {

--- a/tests/unit/hd-segwit-p2sh-wallet.test.js
+++ b/tests/unit/hd-segwit-p2sh-wallet.test.js
@@ -1,6 +1,5 @@
-/* global it */
+import assert from 'assert';
 import { SegwitP2SHWallet, SegwitBech32Wallet, HDSegwitP2SHWallet, HDLegacyP2PKHWallet, LegacyWallet } from '../../class';
-const assert = require('assert');
 
 it('can create a Segwit HD (BIP49)', async function () {
   const mnemonic =

--- a/tests/unit/legacy-wallet.test.js
+++ b/tests/unit/legacy-wallet.test.js
@@ -1,7 +1,6 @@
-/* global it, describe */
+import assert from 'assert';
+import * as bitcoin from 'bitcoinjs-lib';
 import { LegacyWallet } from '../../class';
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
 
 describe('Legacy wallet', () => {
   it('can create transaction', async () => {

--- a/tests/unit/lnurl.test.js
+++ b/tests/unit/lnurl.test.js
@@ -1,6 +1,5 @@
-/* global describe, it */
+import assert from 'assert';
 import Lnurl from '../../class/lnurl';
-const assert = require('assert');
 
 describe('LNURL', function () {
   it('can findlnurl', () => {

--- a/tests/unit/loc.test.js
+++ b/tests/unit/loc.test.js
@@ -1,9 +1,9 @@
-/* global it, describe, jest */
+import assert from 'assert';
 import { BitcoinUnit } from '../../models/bitcoinUnits';
 import { FiatUnit } from '../../models/fiatUnit';
 import { _leaveNumbersAndDots, formatBalanceWithoutSuffix, formatBalancePlain, formatBalance } from '../../loc';
-const assert = require('assert');
 const currency = require('../../blue_modules/currency');
+
 jest.useFakeTimers();
 
 describe('Localization', () => {

--- a/tests/unit/multisig-hd-wallet.test.js
+++ b/tests/unit/multisig-hd-wallet.test.js
@@ -1,9 +1,8 @@
-/* global it, describe */
 import assert from 'assert';
 import { MultisigHDWallet } from '../../class/';
 import { decodeUR } from 'bc-ur/dist';
 import { MultisigCosigner } from '../../class/multisig-cosigner';
-const bitcoin = require('bitcoinjs-lib');
+import * as bitcoin from 'bitcoinjs-lib';
 const Base43 = require('../../blue_modules/base43');
 
 const fp1cobo = 'D37EAD88';

--- a/tests/unit/payjoin-transaction.test.js
+++ b/tests/unit/payjoin-transaction.test.js
@@ -1,9 +1,10 @@
-/* global it, describe, jest */
+import assert from 'assert';
+import * as bitcoin from 'bitcoinjs-lib';
+import { PayjoinClient } from 'payjoin-client';
+
 import { HDSegwitBech32Wallet } from '../../class';
 import PayjoinTransaction from '../../class/payjoin-transaction';
-import { PayjoinClient } from 'payjoin-client';
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
+
 jest.useFakeTimers();
 
 const utxos = [

--- a/tests/unit/provide-entropy.test.js
+++ b/tests/unit/provide-entropy.test.js
@@ -1,4 +1,3 @@
-/* global it, describe */
 import assert from 'assert';
 
 import { eReducer, entropyToHex, getEntropy, convertToBuffer } from '../../screen/wallets/provideEntropy';

--- a/tests/unit/segwit-bech32-wallet.test.js
+++ b/tests/unit/segwit-bech32-wallet.test.js
@@ -1,7 +1,6 @@
-/* global it, describe */
+import assert from 'assert';
+import * as bitcoin from 'bitcoinjs-lib';
 import { SegwitBech32Wallet } from '../../class';
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
 
 describe('Segwit P2SH wallet', () => {
   it('can create transaction', async () => {

--- a/tests/unit/segwit-p2sh-wallet.test.js
+++ b/tests/unit/segwit-p2sh-wallet.test.js
@@ -1,7 +1,6 @@
-/* global it, describe */
+import assert from 'assert';
+import * as bitcoin from 'bitcoinjs-lib';
 import { SegwitP2SHWallet } from '../../class';
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
 
 describe('Segwit P2SH wallet', () => {
   it('can create transaction', async () => {

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -1,7 +1,6 @@
-/* global it */
-import { SegwitP2SHWallet, AppStorage } from '../../class';
+import assert from 'assert';
 import AsyncStorage from '@react-native-community/async-storage';
-const assert = require('assert');
+import { SegwitP2SHWallet, AppStorage } from '../../class';
 
 it('Appstorage - loadFromDisk works', async () => {
   /** @type {AppStorage} */

--- a/tests/unit/watch-only-wallet.test.js
+++ b/tests/unit/watch-only-wallet.test.js
@@ -1,8 +1,7 @@
-/* global it, describe */
-import { WatchOnlyWallet } from '../../class';
+import assert from 'assert';
 import { decodeUR } from 'bc-ur/dist';
 import { Psbt } from 'bitcoinjs-lib';
-const assert = require('assert');
+import { WatchOnlyWallet } from '../../class';
 
 describe('Watch only wallet', () => {
   it('can validate address', async () => {


### PR DESCRIPTION
Some wallets depend on BlueElectum, BlueElectum starts server connection when imported, this produces unwanted side effects. Connection should be closed before test is completed. 
To solve this I moved connection initialization from BlueElectum to App.js
Now tests are required to run BlueElectum.mainConnect() before testing.

Another issue - lots of jest warnings because of console.log after tests are complete. To solve this I added `await BlueElectrum.waitTillDisconnected();` helper to use in tests