### PR TITLE
ADD: refresh wallet transactions for freshly imported wallets

### DIFF
--- a/screen/wallets/transactions.js
+++ b/screen/wallets/transactions.js
@@ -140,6 +140,15 @@ const WalletTransactions = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [walletID]);
 
+  // if balance of the wallet positive and there are no transactions, then
+  // it'a freshly impoted wallet and we need to refresh transactions
+  useEffect(() => {
+    if (dataSource.length === 0 && wallet.current.getBalance() > 0) {
+      refreshTransactions();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // if description of transaction has been changed we want to show new one
   useFocusEffect(
     useCallback(() => {


### PR DESCRIPTION
Freshly imported wallets has positive balance and no transactions in a list. 
This patch adds `refreshTransactions` call if this happens.