### PR TITLE
REF: Correcting “Input transaction hash”

### DIFF
--- a/loc/en.json
+++ b/loc/en.json
@@ -147,7 +147,7 @@
   "send": {
     "broadcastButton": "BROADCAST",
     "broadcastError": "error",
-    "broadcastNone": "Input transaction hash",
+    "broadcastNone": "Insert Input Transaction Hex",
     "broadcastPending": "pending",
     "broadcastSuccess": "success",
     "confirm_header": "Confirm",


### PR DESCRIPTION
Hash must be corrected to hex.

Since this is a title and not a phrase or sentence, all words must be capitalized, thus “Insert Transaction Hex.”