### PR TITLE
FIX: Fallback to English if case isn't found

### DIFF
--- a/loc/index.js
+++ b/loc/index.js
@@ -128,6 +128,8 @@ const setDateTimeLocale = async () => {
   }
   if (localeForDayJSAvailable) {
     dayjs.locale(lang.split('_')[0]);
+  } else {
+    dayjs.locale('en');
   }
 };
 


### PR DESCRIPTION
When switching back to English, dayjs wouldnt change.