### PR TITLE
FIX: show more accurate precalculation fee on "Not enough balance." exception

### DIFF
--- a/class/wallets/legacy-wallet.js
+++ b/class/wallets/legacy-wallet.js
@@ -276,8 +276,8 @@ export class LegacyWallet extends AbstractWallet {
     if (!changeAddress) throw new Error('No change address provided');
 
     let algo = coinSelectAccumulative;
-    if (targets.length === 1 && targets[0] && !targets[0].value) {
-      // we want to send MAX
+    // if targets has output without a value, we want send MAX to it
+    if (targets.some(i => !('value' in i))) {
       algo = coinSelectSplit;
     }
 
@@ -285,7 +285,7 @@ export class LegacyWallet extends AbstractWallet {
 
     // .inputs and .outputs will be undefined if no solution was found
     if (!inputs || !outputs) {
-      throw new Error('Not enough balance. Try sending smaller amount');
+      throw new Error('Not enough balance. Try sending smaller amount or decrease the fee.');
     }
 
     return { inputs, outputs, fee };

--- a/screen/send/details.js
+++ b/screen/send/details.js
@@ -557,6 +557,11 @@ export default class SendDetails extends Component {
         }
       }
 
+      // if targets is empty, insert dust
+      if (targets.length === 0) {
+        targets.push({ address: '36JxaUrpDzkEerkTf1FzwHNE1Hb7cCjgJV', value: 546 });
+      }
+
       // replace wrong addresses with dump
       targets = targets.map(t => {
         try {
@@ -570,21 +575,15 @@ export default class SendDetails extends Component {
       let flag = false;
       while (true) {
         try {
-          const { fee } = wallet.coinselect(
-            utxo,
-            targets,
-            opt.fee,
-            changeAddress,
-            this.state.isTransactionReplaceable ? HDSegwitBech32Wallet.defaultRBFSequence : HDSegwitBech32Wallet.finalRBFSequence,
-          );
+          const { fee } = wallet.coinselect(utxo, targets, opt.fee, changeAddress);
 
           feePrecalc[opt.key] = fee;
           break;
         } catch (e) {
           if (e.message.includes('Not enough') && !flag) {
             flag = true;
-            // if the outputs are too big, replace them with dust
-            targets = targets.map(t => ({ ...t, value: 546 }));
+            // if we don't have enough funds, construct maximum possible transaction
+            targets = targets.map((t, index) => (index > 0 ? { ...t, value: 546 } : { address: t.address }));
             continue;
           }
 
@@ -1291,13 +1290,15 @@ export default class SendDetails extends Component {
             item.address = address || text;
             item.amount = amount || item.amount;
             transactions[index] = item;
-            this.setState({
-              addresses: transactions,
-              memo: memo || this.state.memo,
-              isLoading: false,
-              payjoinUrl,
-            });
-            this.reCalcTx();
+            this.setState(
+              {
+                addresses: transactions,
+                memo: memo || this.state.memo,
+                isLoading: false,
+                payjoinUrl,
+              },
+              this.reCalcTx,
+            );
           }}
           onBarScanned={this.processAddressData}
           address={item.address}
@@ -1326,11 +1327,14 @@ export default class SendDetails extends Component {
             recipient.amount = BitcoinUnit.MAX;
             recipient.amountSats = BitcoinUnit.MAX;
             LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-            this.setState({
-              addresses: [recipient],
-              units: [BitcoinUnit.BTC],
-              isAdvancedTransactionOptionsVisible: false,
-            });
+            this.setState(
+              {
+                addresses: [recipient],
+                units: [BitcoinUnit.BTC],
+                isAdvancedTransactionOptionsVisible: false,
+              },
+              this.reCalcTx,
+            );
           },
           style: 'default',
         },


### PR DESCRIPTION
When the user tries to send more funds than a wallet balance, BW still tries to precalculate fee to show something. 
To do this all transaction output values was replaced with dust value. In result, this tx always smaller than maximum possible option, because it has smaller number of inputs. 

Now BW will create tx with the same amount of outputs, but one of them will be MAX. It will allow showing more accurate fee estimation.

Fixes #2404