### PR TITLE
Fix multisig

### DIFF
--- a/class/wallets/multisig-hd-wallet.js
+++ b/class/wallets/multisig-hd-wallet.js
@@ -1082,4 +1082,16 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
   allowBatchSend() {
     return true;
   }
+
+  /**
+   * Returns TRUE only for _multisignature_ xpubs as per SLIP-0132
+   * (capital Z, capital Y, or just xpub)
+   * @see https://github.com/satoshilabs/slips/blob/master/slip-0132.md
+   *
+   * @param xpub
+   * @return {boolean}
+   */
+  static isXpubForMultisig(xpub) {
+    return ['xpub', 'Ypub', 'Zpub'].includes(xpub.substring(0, 4));
+  }
 }

--- a/loc/en.json
+++ b/loc/en.json
@@ -486,6 +486,7 @@
     "view_key": "View",
     "invalid_mnemonics": "This mnemonic phrase doesn’t seem to be valid",
     "invalid_cosigner": "Not a valid cosigner data",
+    "not_a_multisignature_xpub": "This is not an xpub from multisignature wallet!",
     "invalid_cosigner_format": "Incorrect cosigner: this is not a cosigner for {format} format",
     "create_new_key": "Create New",
     "scan_or_open_file": "Scan or open file",

--- a/screen/wallets/addMultisigStep2.js
+++ b/screen/wallets/addMultisigStep2.js
@@ -259,6 +259,13 @@ const WalletsAddMultisigStep2 = () => {
   };
 
   const tryUsingXpub = async xpub => {
+    if (!MultisigHDWallet.isXpubForMultisig(xpub)) {
+      setIsProvideMnemonicsModalVisible(false);
+      setIsLoading(false);
+      setImportText('');
+      alert(loc.multisig.not_a_multisignature_xpub);
+      return;
+    }
     let fp = await prompt(loc.multisig.input_fp, loc.multisig.input_fp_explain, false, 'plain-text');
     fp = (fp + '').toUpperCase();
     if (!MultisigHDWallet.isFpValid(fp)) fp = '00000000';
@@ -319,6 +326,9 @@ const WalletsAddMultisigStep2 = () => {
       setIsProvideMnemonicsModalVisible(true);
       setImportText(ret.data);
     } else {
+      if (MultisigHDWallet.isXpubValid(ret.data) && !MultisigHDWallet.isXpubForMultisig(ret.data)) {
+        return alert(loc.multisig.not_a_multisignature_xpub);
+      }
       let cosigner = new MultisigCosigner(ret.data);
       if (!cosigner.isValid()) return alert(loc.multisig.invalid_cosigner);
       setIsProvideMnemonicsModalVisible(false);

--- a/screen/wallets/viewEditMultisigCosigners.js
+++ b/screen/wallets/viewEditMultisigCosigners.js
@@ -134,8 +134,7 @@ const ViewEditMultisigCosigners = () => {
 
   const exportCosigner = () => {
     setIsShareModalVisible(false);
-    setIsLoading(true);
-    fs.writeFileAndExport(exportFilename, exportString).finally(() => setIsLoading(false));
+    fs.writeFileAndExport(exportFilename, exportString);
   };
 
   const onSave = async () => {

--- a/screen/wallets/viewEditMultisigCosigners.js
+++ b/screen/wallets/viewEditMultisigCosigners.js
@@ -31,7 +31,7 @@ import {
 } from '../../BlueComponents';
 import SquareEnumeratedWords, { SquareEnumeratedWordsContentAlign } from '../../components/SquareEnumeratedWords';
 import BottomModal from '../../components/BottomModal';
-import { HDSegwitBech32Wallet, MultisigHDWallet } from '../../class';
+import { HDSegwitBech32Wallet, MultisigCosigner, MultisigHDWallet } from '../../class';
 import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import MultipleStepsListItem, {
@@ -40,6 +40,8 @@ import MultipleStepsListItem, {
 } from '../../components/MultipleStepsListItem';
 import Privacy from '../../Privacy';
 import Biometric from '../../class/biometrics';
+import QRCode from 'react-native-qrcode-svg';
+import { SquareButton } from '../../components/SquareButton';
 const fs = require('../../blue_modules/fs');
 const isDesktop = getSystemName() === 'Mac OS X';
 
@@ -51,13 +53,16 @@ const ViewEditMultisigCosigners = () => {
   const { walletId } = route.params;
   const w = useRef(wallets.find(wallet => wallet.getID() === walletId));
   const tempWallet = useRef(new MultisigHDWallet());
-  const [wallet, setWallet] = useState();
+  const [wallet: MultisigHDWallet, setWallet] = useState();
   const [isLoading, setIsLoading] = useState(true);
   const [isSaveButtonDisabled, setIsSaveButtonDisabled] = useState(true);
   const [currentlyEditingCosignerNum, setCurrentlyEditingCosignerNum] = useState(false);
   const [isProvideMnemonicsModalVisible, setIsProvideMnemonicsModalVisible] = useState(false);
   const [isMnemonicsModalVisible, setIsMnemonicsModalVisible] = useState(false);
+  const [isShareModalVisible, setIsShareModalVisible] = useState(false);
   const [importText, setImportText] = useState('');
+  const [exportString, setExportString] = useState('{}');
+  const [exportFilename, setExportFilename] = useState('bw-cosigner.json');
   const [vaultKeyData, setVaultKeyData] = useState({ keyIndex: 1, xpub: '', seed: '', path: '', fp: '', isLoading: false }); // string rendered in modal
   const data = useRef();
   const stylesHook = StyleSheet.create({
@@ -126,6 +131,12 @@ const ViewEditMultisigCosigners = () => {
       color: colors.buttonTextColor,
     },
   });
+
+  const exportCosigner = () => {
+    setIsShareModalVisible(false);
+    setIsLoading(true);
+    fs.writeFileAndExport(exportFilename, exportString).finally(() => setIsLoading(false));
+  };
 
   const onSave = async () => {
     setIsLoading(true);
@@ -225,6 +236,16 @@ const ViewEditMultisigCosigners = () => {
             </>
           )}
           <BlueSpacing20 />
+          <BlueButton
+            title={loc.multisig.share}
+            onPress={() => {
+              setIsMnemonicsModalVisible(false);
+              setTimeout(() => {
+                setIsShareModalVisible(true);
+              }, 1000);
+            }}
+          />
+          <BlueSpacing20 />
           <BlueButton title={loc.send.success_done} onPress={() => setIsMnemonicsModalVisible(false)} />
           <BlueSpacing40 />
         </View>
@@ -263,14 +284,20 @@ const ViewEditMultisigCosigners = () => {
                   text: loc.multisig.view,
                   disabled: vaultKeyData.isLoading,
                   onPress: () => {
+                    const keyIndex = el.index + 1;
+                    const xpub = wallet.getCosigner(keyIndex);
+                    const fp = wallet.getFingerprint(keyIndex);
+                    const path = wallet.getCustomDerivationPathForCosigner(keyIndex);
                     setVaultKeyData({
-                      keyIndex: el.index + 1,
+                      keyIndex,
                       seed: '',
-                      xpub: wallet.getCosigner(el.index + 1),
-                      fp: wallet.getFingerprint(el.index + 1),
-                      path: wallet.getCustomDerivationPathForCosigner(el.index + 1),
+                      xpub,
+                      fp,
+                      path,
                       isLoading: false,
                     });
+                    setExportString(MultisigCosigner.exportToJson(fp, xpub, path));
+                    setExportFilename('bw-cosigner-' + fp + '.json');
                     setIsMnemonicsModalVisible(true);
                   },
                 }}
@@ -302,15 +329,22 @@ const ViewEditMultisigCosigners = () => {
                   disabled: vaultKeyData.isLoading,
                   buttonType: MultipleStepsListItemButtohType.partial,
                   onPress: () => {
+                    const keyIndex = el.index + 1;
+                    const seed = wallet.getCosigner(keyIndex);
                     setVaultKeyData({
-                      keyIndex: el.index + 1,
-                      seed: wallet.getCosigner(el.index + 1),
+                      keyIndex,
+                      seed,
                       xpub: '',
                       fp: '',
                       path: '',
                       isLoading: false,
                     });
                     setIsMnemonicsModalVisible(true);
+                    const fp = wallet.getFingerprint(keyIndex);
+                    const path = wallet.getCustomDerivationPathForCosigner(keyIndex);
+                    const xpub = wallet.convertXpubToMultisignatureXpub(MultisigHDWallet.seedToXpub(seed, path));
+                    setExportString(MultisigCosigner.exportToJson(fp, xpub, path));
+                    setExportFilename('bw-cosigner-' + fp + '.json');
                   },
                 }}
                 dashes={MultipleStepsListItemDashType.topAndBottom}
@@ -431,6 +465,10 @@ const ViewEditMultisigCosigners = () => {
     setImportText('');
   };
 
+  const hideShareModal = () => {
+    setIsShareModalVisible(false);
+  };
+
   const renderProvideMnemonicsModal = () => {
     return (
       <BottomModal isVisible={isProvideMnemonicsModalVisible} onClose={hideProvideMnemonicsModal}>
@@ -450,6 +488,32 @@ const ViewEditMultisigCosigners = () => {
               />
             )}
             <BlueButtonLink disabled={isLoading} onPress={scanOrOpenFile} title={loc.wallets.import_scan_qr} />
+          </View>
+        </KeyboardAvoidingView>
+      </BottomModal>
+    );
+  };
+
+  const renderShareModal = () => {
+    return (
+      <BottomModal isVisible={isShareModalVisible} onClose={hideShareModal}>
+        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+          <View style={[styles.modalContent, stylesHook.modalContent, styles.alignItemsCenter]}>
+            <Text style={[styles.headerText, stylesHook.textDestination]}>{loc.multisig.this_is_cosigners_xpub}</Text>
+            <View style={styles.qrCodeContainer}>
+              <QRCode
+                value={exportString}
+                size={260}
+                color="#000000"
+                logoBackgroundColor={colors.brandingColor}
+                backgroundColor="#FFFFFF"
+                ecl="H"
+              />
+            </View>
+            <BlueSpacing20 />
+            <View style={styles.squareButtonWrapper}>
+              <SquareButton style={[styles.exportButton, stylesHook.exportButton]} onPress={exportCosigner} title={loc.multisig.share} />
+            </View>
           </View>
         </KeyboardAvoidingView>
       </BottomModal>
@@ -500,6 +564,8 @@ const ViewEditMultisigCosigners = () => {
       </KeyboardAvoidingView>
 
       {renderProvideMnemonicsModal()}
+
+      {renderShareModal()}
 
       {renderMnemonicsModal()}
     </View>
@@ -611,6 +677,7 @@ const styles = StyleSheet.create({
     position: 'relative',
     bottom: -3,
   },
+  qrCodeContainer: { borderWidth: 6, borderRadius: 8, borderColor: '#FFFFFF' },
   tipLabelText: {
     fontWeight: '500',
   }


### PR DESCRIPTION
in this  PR we add new features to 'manage keys' multisig screen, in particular, user can now press 'share' on keys and get a QR or a file for the specific cosigner, in case he wants to import them somewhere else (specter or other BW).
its a bit ugly but its the easiest place I could place it, plus its gonna be a rarely used feature:

![image](https://user-images.githubusercontent.com/1913337/103562767-873d8300-4eb3-11eb-944c-7428d18102a8.png)


![image](https://user-images.githubusercontent.com/1913337/103562795-915f8180-4eb3-11eb-905f-57091d0bf3c3.png)





ALSO, in this PR we forbid usage of regular HD wallets xpubs when creating multisig (for example, zpub from BIP84 wallet)