### PR TITLE
FIX: BlueWalletNavigationHeader force balance remount on unit change

### DIFF
--- a/BlueComponents.js
+++ b/BlueComponents.js
@@ -337,6 +337,10 @@ export class BlueWalletNavigationHeader extends Component {
   };
 
   render() {
+    const balance =
+      !this.state.wallet.hideBalance &&
+      formatBalance(this.state.wallet.getBalance(), this.state.wallet.getPreferredBalanceUnit(), true).toString();
+
     return (
       <LinearGradient
         colors={WalletGradient.gradientsFor(this.state.wallet.type)}
@@ -408,6 +412,7 @@ export class BlueWalletNavigationHeader extends Component {
           ) : (
             <Text
               testID="WalletBalance"
+              key={balance} // force component recreation on balance change. To fix right-to-left languages, like Farsi
               numberOfLines={1}
               adjustsFontSizeToFit
               style={{
@@ -417,7 +422,7 @@ export class BlueWalletNavigationHeader extends Component {
                 color: '#fff',
               }}
             >
-              {formatBalance(this.state.wallet.getBalance(), this.state.wallet.getPreferredBalanceUnit(), true).toString()}
+              {balance}
             </Text>
           )}
         </TouchableOpacity>

--- a/components/WalletsCarousel.js
+++ b/components/WalletsCarousel.js
@@ -20,7 +20,6 @@ import loc, { formatBalance, transactionTimeToReadable } from '../loc';
 import { LightningCustodianWallet, MultisigHDWallet, PlaceholderWallet } from '../class';
 import WalletGradient from '../class/wallet-gradient';
 import { BluePrivateBalance } from '../BlueComponents';
-
 import { BlueStorageContext } from '../blue_modules/storage-context';
 
 const nStyles = StyleSheet.create({
@@ -213,6 +212,8 @@ const WalletCarouselItem = ({ item, index, onPress, handleLongPress, isSelectedW
       ? loc.transactions.pending
       : transactionTimeToReadable(item.getLatestTransactionTime());
 
+  const balance = !item.hideBalance && formatBalance(Number(item.getBalance()), item.getPreferredBalanceUnit(), true);
+
   return (
     <Animated.View
       style={[iStyles.root, { opacity, transform: [{ scale: scaleValue }] }]}
@@ -240,8 +241,13 @@ const WalletCarouselItem = ({ item, index, onPress, handleLongPress, isSelectedW
           {item.hideBalance ? (
             <BluePrivateBalance />
           ) : (
-            <Text numberOfLines={1} adjustsFontSizeToFit style={[iStyles.balance, { color: colors.inverseForegroundColor }]}>
-              {formatBalance(Number(item.getBalance()), item.getPreferredBalanceUnit(), true)}
+            <Text
+              numberOfLines={1}
+              key={balance} // force component recreation on balance change. To fix right-to-left languages, like Farsi
+              adjustsFontSizeToFit
+              style={[iStyles.balance, { color: colors.inverseForegroundColor }]}
+            >
+              {balance}
             </Text>
           )}
           <Text style={iStyles.br} />


### PR DESCRIPTION
For some reason content of <Text> in RN disappears of it switches from left-to-right to right-to-left text.
By adding `key` to the Text I'm forcing it recreation on balance change.

closes #2592