### PR TITLE
FIX:  Custom fee cancelation on iPadOS 14.4 fade into black screen #2568

### DIFF
--- a/App.js
+++ b/App.js
@@ -302,7 +302,7 @@ const App = () => {
         isVisible={isClipboardContentModalVisible}
         onClose={hideClipboardContentModal}
       >
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={[styles.modalContent, stylesHook.modalContent]}>
             <BlueTextCentered>
               {clipboardContentType === ClipboardContentType.BITCOIN && loc.wallets.clipboard_bitcoin}

--- a/screen/lnd/lndCreateInvoice.js
+++ b/screen/lnd/lndCreateInvoice.js
@@ -9,6 +9,7 @@ import {
   StyleSheet,
   Text,
   TextInput,
+  Platform,
   TouchableOpacity,
   TouchableWithoutFeedback,
   View,
@@ -360,7 +361,7 @@ const LNDCreateInvoice = () => {
       <View style={[styles.root, styleHooks.root]}>
         <StatusBar barStyle="light-content" />
         <View style={[styles.amount, styleHooks.amount]}>
-          <KeyboardAvoidingView behavior="position">
+          <KeyboardAvoidingView enabled={!Platform.isPad} behavior="position">
             <BlueBitcoinAmount
               isLoading={isLoading}
               amount={amount}

--- a/screen/receive/details.js
+++ b/screen/receive/details.js
@@ -313,7 +313,7 @@ const ReceiveDetails = () => {
   const renderCustomAmountModal = () => {
     return (
       <BottomModal isVisible={isCustomModalVisible} onClose={dismissCustomAmountModal}>
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContent}>
             <BlueBitcoinAmount
               unit={customUnit}

--- a/screen/send/broadcast.js
+++ b/screen/send/broadcast.js
@@ -115,7 +115,11 @@ const Broadcast = () => {
 
   return (
     <SafeBlueArea style={styles.blueArea}>
-      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null} keyboardShouldPersistTaps="handled">
+      <KeyboardAvoidingView
+        enabled={!Platform.isPad}
+        behavior={Platform.OS === 'ios' ? 'position' : null}
+        keyboardShouldPersistTaps="handled"
+      >
         <View style={styles.wrapper}>
           {BROADCAST_RESULT.success !== broadcastResult && (
             <BlueCard style={styles.mainCard}>

--- a/screen/send/coinControl.js
+++ b/screen/send/coinControl.js
@@ -409,7 +409,7 @@ const CoinControl = () => {
           setOutput(false);
         }}
       >
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={[styles.modalContent, { backgroundColor: colors.elevated }]}>{output && renderOutputModalContent()}</View>
         </KeyboardAvoidingView>
       </BottomModal>

--- a/screen/send/details.js
+++ b/screen/send/details.js
@@ -807,7 +807,7 @@ export default class SendDetails extends Component {
         isVisible={this.state.isFeeSelectionModalVisible}
         onClose={this.hideFeeSelectionModal}
       >
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContent}>
             {options.map(({ label, time, fee, rate, active }, index) => (
               <TouchableOpacity
@@ -1165,7 +1165,7 @@ export default class SendDetails extends Component {
         isVisible={this.state.isAdvancedTransactionOptionsVisible}
         onClose={this.hideAdvancedTransactionOptionsModal}
       >
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.advancedTransactionOptionsModalContent}>
             {this.state.fromWallet.allowSendMax() && (
               <BlueListItem
@@ -1474,7 +1474,7 @@ export default class SendDetails extends Component {
         <View style={styles.root} onLayout={this.onLayout}>
           <StatusBar barStyle="light-content" />
           <View>
-            <KeyboardAvoidingView behavior="position">
+            <KeyboardAvoidingView enabled={!Platform.isPad} behavior="position">
               <FlatList
                 keyboardShouldPersistTaps="always"
                 scrollEnabled={this.state.addresses.length > 1}

--- a/screen/send/isItMyAddress.js
+++ b/screen/send/isItMyAddress.js
@@ -78,7 +78,11 @@ const IsItMyAddress = () => {
 
   return (
     <SafeBlueArea style={[styles.blueArea, stylesHooks.blueArea]}>
-      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null} keyboardShouldPersistTaps="handled">
+      <KeyboardAvoidingView
+        enabled={!Platform.isPad}
+        behavior={Platform.OS === 'ios' ? 'position' : null}
+        keyboardShouldPersistTaps="handled"
+      >
         <View style={styles.wrapper}>
           <BlueCard style={styles.mainCard}>
             <View style={[styles.input, stylesHooks.input]}>

--- a/screen/transactions/CPFP.js
+++ b/screen/transactions/CPFP.js
@@ -1,7 +1,17 @@
 /* global alert */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { ActivityIndicator, View, TextInput, TouchableOpacity, Linking, ScrollView, StyleSheet, KeyboardAvoidingView } from 'react-native';
+import {
+  ActivityIndicator,
+  Platform,
+  View,
+  TextInput,
+  TouchableOpacity,
+  Linking,
+  ScrollView,
+  StyleSheet,
+  KeyboardAvoidingView,
+} from 'react-native';
 import Clipboard from '@react-native-community/clipboard';
 import { Text } from 'react-native-elements';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
@@ -158,7 +168,7 @@ export default class CPFP extends Component {
 
   renderStage1(text) {
     return (
-      <KeyboardAvoidingView behavior="position">
+      <KeyboardAvoidingView enabled={!Platform.isPad} behavior="position">
         <SafeBlueArea style={styles.root}>
           <BlueSpacing />
           <BlueCard style={styles.center}>

--- a/screen/wallets/addMultisig.js
+++ b/screen/wallets/addMultisig.js
@@ -102,7 +102,7 @@ const WalletsAddMultisig = () => {
   const renderModal = () => {
     return (
       <BottomModal isVisible={isModalVisible} onClose={closeModal}>
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={[styles.modalContentShort, stylesHook.modalContentShort]}>
             <Text style={[styles.textHeader, stylesHook.textHeader]}>{loc.multisig.quorum_header}</Text>
             <Text style={[styles.textSubtitle, stylesHook.textSubtitle]}>{loc.multisig.required_keys_out_of_total}</Text>

--- a/screen/wallets/addMultisigStep2.js
+++ b/screen/wallets/addMultisigStep2.js
@@ -603,7 +603,7 @@ const WalletsAddMultisigStep2 = () => {
   const renderProvideMnemonicsModal = () => {
     return (
       <BottomModal isVisible={isProvideMnemonicsModalVisible} onClose={hideProvideMnemonicsModal}>
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={[styles.modalContent, stylesHook.modalContent]}>
             <BlueTextCentered>{loc.multisig.type_your_mnemonics}</BlueTextCentered>
             <BlueSpacing20 />
@@ -634,7 +634,7 @@ const WalletsAddMultisigStep2 = () => {
   const renderCosignersXpubModal = () => {
     return (
       <BottomModal isVisible={isRenderCosignersXpubModalVisible} onClose={hideCosignersXpubModal}>
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={[styles.modalContent, stylesHook.modalContent, styles.alignItemsCenter]}>
             <Text style={[styles.headerText, stylesHook.textDestination]}>{loc.multisig.this_is_cosigners_xpub}</Text>
             <BlueSpacing20 />

--- a/screen/wallets/details.js
+++ b/screen/wallets/details.js
@@ -414,7 +414,7 @@ const WalletDetails = () => {
               }
             })()}
             <Text style={[styles.textLabel2, stylesHook.textLabel2]}>{loc.wallets.add_wallet_name.toLowerCase()}</Text>
-            <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+            <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
               <View style={[styles.input, stylesHook.input]}>
                 <TextInput
                   placeholder={loc.send.details_note_placeholder}

--- a/screen/wallets/hodlHodl.js
+++ b/screen/wallets/hodlHodl.js
@@ -328,7 +328,7 @@ export default class HodlHodl extends Component {
   renderChooseSideModal = () => {
     return (
       <BottomModal isVisible={this.state.isChooseSideModalVisible} onClose={this.hideChooseSideModal}>
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContentShort}>
             <FlatList
               scrollEnabled={false}
@@ -377,7 +377,7 @@ export default class HodlHodl extends Component {
           }
         }}
       >
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContentShort}>
             <FlatList
               scrollEnabled={false}
@@ -472,7 +472,7 @@ export default class HodlHodl extends Component {
 
     return (
       <BottomModal isVisible={this.state.isChooseCountryModalVisible} onClose={this.hideChooseCountryModal}>
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContent}>
             <View style={styles.searchInputContainer}>
               <TextInput
@@ -546,7 +546,7 @@ export default class HodlHodl extends Component {
 
     return (
       <BottomModal isVisible={this.state.isChooseCurrencyVisible} onClose={this.hideChooseCurrencyModal}>
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContent}>
             <View style={styles.searchInputContainer}>
               <TextInput
@@ -620,7 +620,7 @@ export default class HodlHodl extends Component {
 
     return (
       <BottomModal isVisible={this.state.isChooseMethodVisible} deviceHeight={windowHeight} onClose={this.hideChooseMethodModal}>
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContent}>
             <View style={styles.searchInputContainer}>
               <TextInput

--- a/screen/wallets/hodlHodlMyContracts.js
+++ b/screen/wallets/hodlHodlMyContracts.js
@@ -172,7 +172,7 @@ export default class HodlHodlMyContracts extends Component {
 
     return (
       <BottomModal isVisible={this.state.isRenderContractVisible} onClose={this.hideContractModal}>
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={styles.modalContent}>
             <View style={styles.modalContentCentered}>
               <Text style={styles.btcText}>

--- a/screen/wallets/hodlHodlViewOffer.js
+++ b/screen/wallets/hodlHodlViewOffer.js
@@ -176,7 +176,7 @@ export default class HodlHodlViewOffer extends Component {
     ) : (
       <SafeBlueArea>
         <ScrollView>
-          <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+          <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
             <View style={styles.modalContent}>
               <Text style={styles.Title}>{this.state.offerToDisplay.title}</Text>
 

--- a/screen/wallets/transactions.js
+++ b/screen/wallets/transactions.js
@@ -272,7 +272,7 @@ const WalletTransactions = () => {
   const renderManageFundsModal = () => {
     return (
       <BottomModal isVisible={isManageFundsModalVisible} onClose={hideManageFundsModal}>
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={[styles.advancedTransactionOptionsModalContent, stylesHook.advancedTransactionOptionsModalContent]}>
             <BlueListItem
               hideChevron

--- a/screen/wallets/viewEditMultisigCosigners.js
+++ b/screen/wallets/viewEditMultisigCosigners.js
@@ -510,7 +510,7 @@ const ViewEditMultisigCosigners = () => {
   const renderProvideMnemonicsModal = () => {
     return (
       <BottomModal isVisible={isProvideMnemonicsModalVisible} onClose={hideProvideMnemonicsModal}>
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={[styles.modalContent, stylesHook.modalContent]}>
             <BlueTextCentered>{loc.multisig.type_your_mnemonics}</BlueTextCentered>
             <BlueSpacing20 />
@@ -535,7 +535,7 @@ const ViewEditMultisigCosigners = () => {
   const renderShareModal = () => {
     return (
       <BottomModal isVisible={isShareModalVisible} onClose={hideShareModal}>
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : null}>
+        <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={[styles.modalContent, stylesHook.modalContent, styles.alignItemsCenter]}>
             <Text style={[styles.headerText, stylesHook.textDestination]}>{loc.multisig.this_is_cosigners_xpub}</Text>
             <View style={styles.qrCodeContainer}>
@@ -601,7 +601,7 @@ const ViewEditMultisigCosigners = () => {
     <View style={[styles.root, stylesHook.root]}>
       <StatusBar barStyle="light-content" />
       <KeyboardAvoidingView
-        enabled
+        enabled={!Platform.isPad}
         behavior={Platform.OS === 'ios' ? 'padding' : null}
         keyboardVerticalOffset={62}
         style={[styles.mainBlock, styles.root]}


### PR DESCRIPTION
iPadOS offers floating keyboard. KeyboardAvoidingView breaks when this is in use. Currently theres no RN API  to detect when keyboard is in floating mode. Since iPads have large displays, the content shouldnt be covered by the keyboard.