### PR TITLE
TST: retry helperImportWallet

### DIFF
--- a/components/WalletsCarousel.js
+++ b/components/WalletsCarousel.js
@@ -178,7 +178,7 @@ const WalletCarouselItem = ({ item, index, onPress, handleLongPress, isSelectedW
               {item.getIsFailure() ? loc.wallets.import_placeholder_fail : loc.wallets.import_placeholder_inprogress}
             </Text>
             {item.getIsFailure() ? (
-              <Text numberOfLines={0} style={[iStyles.importError, { color: colors.inverseForegroundColor }]}>
+              <Text testID="ImportError" numberOfLines={0} style={[iStyles.importError, { color: colors.inverseForegroundColor }]}>
                 {loc.wallets.list_import_error}
               </Text>
             ) : (

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -891,18 +891,36 @@ async function helperCreateWallet(walletName) {
 
 async function helperImportWallet(importText, expectedWalletLabel, expectedBalance) {
   await yo('WalletsList');
+
   await element(by.id('WalletsList')).swipe('left', 'fast', 1); // in case emu screen is small and it doesnt fit
   // going to Import Wallet screen and importing mnemonic
   await element(by.id('CreateAWallet')).tap();
   await element(by.id('ImportWallet')).tap();
   await element(by.id('MnemonicInput')).replaceText(importText);
-  try {
-    await element(by.id('DoImport')).tap();
-  } catch (_) {}
-  if (process.env.TRAVIS) await sleep(60000);
-  await sup('OK', 3 * 61000); // waiting for wallet import
-  await element(by.text('OK')).tap();
-  // ok, wallet imported
+
+  let retries = 0;
+  while (true) {
+    retries = retries + 1;
+    try {
+      await element(by.id('DoImport')).tap();
+    } catch (_) {}
+    if (process.env.TRAVIS) await sleep(60000);
+
+    // waiting for import result
+    await sup('OK', 3 * 61000);
+    await element(by.text('OK')).tap();
+
+    try {
+      await expect(element(by.id('ImportError'))).not.toBeVisible();
+      break; // import succeded
+    } catch (e) {
+      // exit after two failed attempts
+      if (retries === 2) break;
+      // restart import
+      await element(by.id('ImportError')).tap();
+      await element(by.text('Try again')).tap();
+    }
+  }
 
   // lets go inside wallet
   await element(by.text(expectedWalletLabel)).tap();


### PR DESCRIPTION
When I'm rutting e2e tests I have about 10-20% failed results because of import errors. Import fails because of connection problems, like
```
[Fri Feb 26 2021 13:22:40.100]  LOG      posting analytics... GOT_ZERO_BALANCE
[Fri Feb 26 2021 13:22:50.652]  LOG      reconnecting after socket error
[Fri Feb 26 2021 13:22:55.690]  WARN     [Error: Connection to server lost, please retry]
[Fri Feb 26 2021 13:23:07.220]  WARN     [Error: Connection to server lost, please retry]
[Fri Feb 26 2021 13:23:23.924]  WARN     [Error: Connection to server lost, please retry]
[Fri Feb 26 2021 13:23:23.929]  WARN     [Error: Connection to server lost, please retry]
[Fri Feb 26 2021 13:23:32.274]  LOG      [Error: Connection to server lost, please retry]
[Fri Feb 26 2021 13:23:32.371]  LOG      begin connection: {"host":"electrum2.bluewallet.io","ssl":"443"}
[Fri Feb 26 2021 13:23:32.583]  LOG      TLS Connected to  electrum2.bluewallet.io 443
[Fri Feb 26 2021 13:23:32.679]  LOG      connected to  ["ElectrumX 1.16.0", "1.4"]
[Fri Feb 26 2021 13:23:33.212]  LOG      click 0
```

With this patch `helperImportWallet` will try again if first import failed.

https://user-images.githubusercontent.com/155891/109289720-ab746b00-7837-11eb-994c-149a8a92da8b.mov

