### PR TITLE
ADD: wallets message sign/verify

### DIFF
--- a/class/wallets/abstract-wallet.js
+++ b/class/wallets/abstract-wallet.js
@@ -123,6 +123,10 @@ export class AbstractWallet {
     return false;
   }
 
+  allowSignVerifyMessage() {
+    return false;
+  }
+
   weOwnAddress(address) {
     throw Error('not implemented');
   }

--- a/class/wallets/hd-aezeed-wallet.js
+++ b/class/wallets/hd-aezeed-wallet.js
@@ -160,4 +160,8 @@ export class HDAezeedWallet extends AbstractHDElectrumWallet {
   allowPayJoin() {
     return true;
   }
+
+  allowSignVerifyMessage() {
+    return true;
+  }
 }

--- a/class/wallets/hd-legacy-p2pkh-wallet.js
+++ b/class/wallets/hd-legacy-p2pkh-wallet.js
@@ -25,6 +25,10 @@ export class HDLegacyP2PKHWallet extends AbstractHDElectrumWallet {
     return true;
   }
 
+  allowSignVerifyMessage() {
+    return true;
+  }
+
   getXpub() {
     if (this._xpub) {
       return this._xpub; // cache hit

--- a/class/wallets/hd-segwit-bech32-wallet.js
+++ b/class/wallets/hd-segwit-bech32-wallet.js
@@ -36,4 +36,8 @@ export class HDSegwitBech32Wallet extends AbstractHDElectrumWallet {
   allowCosignPsbt() {
     return true;
   }
+
+  allowSignVerifyMessage() {
+    return true;
+  }
 }

--- a/class/wallets/hd-segwit-p2sh-wallet.js
+++ b/class/wallets/hd-segwit-p2sh-wallet.js
@@ -25,6 +25,10 @@ export class HDSegwitP2SHWallet extends AbstractHDElectrumWallet {
     return true;
   }
 
+  allowSignVerifyMessage() {
+    return true;
+  }
+
   /**
    * Get internal/external WIF by wallet index
    * @param {Boolean} internal

--- a/class/wallets/segwit-bech32-wallet.js
+++ b/class/wallets/segwit-bech32-wallet.js
@@ -132,4 +132,8 @@ export class SegwitBech32Wallet extends LegacyWallet {
   allowSendMax() {
     return true;
   }
+
+  allowSignVerifyMessage() {
+    return true;
+  }
 }

--- a/class/wallets/segwit-p2sh-wallet.js
+++ b/class/wallets/segwit-p2sh-wallet.js
@@ -141,4 +141,8 @@ export class SegwitP2SHWallet extends LegacyWallet {
   allowSendMax() {
     return true;
   }
+
+  allowSignVerifyMessage() {
+    return true;
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7469,6 +7469,19 @@
         }
       }
     },
+    "bitcoinjs-message": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-message/-/bitcoinjs-message-2.2.0.tgz",
+      "integrity": "sha512-103Wy3xg8Y9o+pdhGP4M3/mtQQuUWs6sPuOp1mYphSUoSMHjHTlkj32K4zxU8qMH0Ckv23emfkGlFWtoWZ7YFA==",
+      "requires": {
+        "bech32": "^1.1.3",
+        "bs58check": "^2.1.2",
+        "buffer-equals": "^1.0.3",
+        "create-hash": "^1.1.2",
+        "secp256k1": "^3.0.1",
+        "varuint-bitcoin": "^1.0.1"
+      }
+    },
     "bl": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
@@ -7736,6 +7749,11 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "buffer-equals": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz",
+      "integrity": "sha1-A1O1T9B/2VZBcGca5vZrnPENJ/U="
     },
     "buffer-fill": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "bip32": "2.0.6",
     "bip39": "2.6.0",
     "bitcoinjs-lib": "5.2.0",
+    "bitcoinjs-message": "2.2.0",
     "bolt11": "1.2.7",
     "buffer": "6.0.3",
     "buffer-reverse": "1.0.1",

--- a/tests/unit/hd-aezeed.test.js
+++ b/tests/unit/hd-aezeed.test.js
@@ -84,4 +84,24 @@ describe('HDAezeedWallet', () => {
       aezeed._getNodePubkeyByIndex(1, 1).toString('hex'),
     );
   });
+
+  it('can sign and verify messages', async () => {
+    const aezeed = new HDAezeedWallet();
+    aezeed.setSecret(
+      'abstract rhythm weird food attract treat mosquito sight royal actor surround ride strike remove guilt catch filter summer mushroom protect poverty cruel chaos pattern',
+    );
+    assert.ok(await aezeed.validateMnemonicAsync());
+    assert.ok(!(await aezeed.mnemonicInvalidPassword()));
+    let signature;
+
+    // external address
+    signature = aezeed.signMessage('vires is numeris', 'bc1qdjj7lhj9lnjye7xq3dzv3r4z0cta294xy78txn');
+    assert.strictEqual(signature, 'J9zF7mdGGdc/9HMlvor6Zl7ap1qseQpiBDJ4oaSpkzbQGGhdfkM6LHo6m9BV8o/BlqiQI1vuODaNlBFyeyIWgfE=');
+    assert.strictEqual(aezeed.verifyMessage('vires is numeris', 'bc1qdjj7lhj9lnjye7xq3dzv3r4z0cta294xy78txn', signature), true);
+
+    // internal address
+    signature = aezeed.signMessage('vires is numeris', 'bc1qzyjq8sjj56n8v9fgw5klsc8sq8yuy0jx03hzzp');
+    assert.strictEqual(signature, 'KIda06aSswmo9NiAYNUBRADA9q1v39raSmHHVg56+thtah5xL7hVw/x+cZgydFNyel2bXfyGluJRaP1uRQfJtzo=');
+    assert.strictEqual(aezeed.verifyMessage('vires is numeris', 'bc1qzyjq8sjj56n8v9fgw5klsc8sq8yuy0jx03hzzp', signature), true);
+  });
 });

--- a/tests/unit/hd-legacy-wallet.test.js
+++ b/tests/unit/hd-legacy-wallet.test.js
@@ -2,132 +2,151 @@ import { HDLegacyP2PKHWallet } from '../../class';
 const assert = require('assert');
 const bitcoin = require('bitcoinjs-lib');
 
-it('Legacy HD (BIP44) works', async () => {
-  if (!process.env.HD_MNEMONIC) {
-    console.error('process.env.HD_MNEMONIC not set, skipped');
-    return;
-  }
-  const hd = new HDLegacyP2PKHWallet();
-  hd.setSecret(process.env.HD_MNEMONIC);
-  assert.ok(hd.validateMnemonic());
+describe('Legacy HD (BIP44)', () => {
+  it('works', async () => {
+    if (!process.env.HD_MNEMONIC) {
+      console.error('process.env.HD_MNEMONIC not set, skipped');
+      return;
+    }
+    const hd = new HDLegacyP2PKHWallet();
+    hd.setSecret(process.env.HD_MNEMONIC);
+    assert.ok(hd.validateMnemonic());
 
-  assert.strictEqual(
-    hd.getXpub(),
-    'xpub6ByZUAv558PPheJgcPYHpxPLwz8M7TtueYMAik84NADeQcvbzS8W3WxxJ3C9NzfYkMoChiMAumWbeEvMWhTVpH75NqGv5c9wF3wKDbfQShb',
-  );
+    assert.strictEqual(
+      hd.getXpub(),
+      'xpub6ByZUAv558PPheJgcPYHpxPLwz8M7TtueYMAik84NADeQcvbzS8W3WxxJ3C9NzfYkMoChiMAumWbeEvMWhTVpH75NqGv5c9wF3wKDbfQShb',
+    );
 
-  assert.strictEqual(hd._getExternalAddressByIndex(0), '186FBQmCV5W1xY7ywaWtTZPAQNciVN8Por');
-  assert.strictEqual(hd._getInternalAddressByIndex(0), '1J9zoJz5LsAJ361SQHYnLTWg46Tc2AXUCj');
+    assert.strictEqual(hd._getExternalAddressByIndex(0), '186FBQmCV5W1xY7ywaWtTZPAQNciVN8Por');
+    assert.strictEqual(hd._getInternalAddressByIndex(0), '1J9zoJz5LsAJ361SQHYnLTWg46Tc2AXUCj');
 
-  assert.strictEqual(hd._getInternalWIFByIndex(0), 'L4ojevRtK81A8Kof3qyLS2M7HvsVDbUDENNhJqU4vf79w9yGnQLb');
-  assert.strictEqual(hd._getExternalWIFByIndex(0), 'Kz6kLhdyDfSbKuVH25XVqBRztjmFe8X22Xe1hnFzEv79gJNMkTAH');
+    assert.strictEqual(hd._getInternalWIFByIndex(0), 'L4ojevRtK81A8Kof3qyLS2M7HvsVDbUDENNhJqU4vf79w9yGnQLb');
+    assert.strictEqual(hd._getExternalWIFByIndex(0), 'Kz6kLhdyDfSbKuVH25XVqBRztjmFe8X22Xe1hnFzEv79gJNMkTAH');
 
-  assert.ok(hd.getAllExternalAddresses().includes('186FBQmCV5W1xY7ywaWtTZPAQNciVN8Por'));
-  assert.ok(!hd.getAllExternalAddresses().includes('1J9zoJz5LsAJ361SQHYnLTWg46Tc2AXUCj')); // not internal
+    assert.ok(hd.getAllExternalAddresses().includes('186FBQmCV5W1xY7ywaWtTZPAQNciVN8Por'));
+    assert.ok(!hd.getAllExternalAddresses().includes('1J9zoJz5LsAJ361SQHYnLTWg46Tc2AXUCj')); // not internal
 
-  assert.strictEqual(
-    hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex'),
-    '0316e84a2556f30a199541633f5dda6787710ccab26771b7084f4c9e1104f47667',
-  );
-  assert.strictEqual(
-    hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex'),
-    '02ad7b2216f3a2b38d56db8a7ee5c540fd12c4bbb7013106eff78cc2ace65aa002',
-  );
+    assert.strictEqual(
+      hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex'),
+      '0316e84a2556f30a199541633f5dda6787710ccab26771b7084f4c9e1104f47667',
+    );
+    assert.strictEqual(
+      hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex'),
+      '02ad7b2216f3a2b38d56db8a7ee5c540fd12c4bbb7013106eff78cc2ace65aa002',
+    );
 
-  assert.strictEqual(hd._getDerivationPathByAddress(hd._getExternalAddressByIndex(0)), "m/84'/0'/0'/0/0"); // wrong, FIXME
-  assert.strictEqual(hd._getDerivationPathByAddress(hd._getInternalAddressByIndex(0)), "m/84'/0'/0'/1/0"); // wrong, FIXME
-});
+    assert.strictEqual(hd._getDerivationPathByAddress(hd._getExternalAddressByIndex(0)), "m/84'/0'/0'/0/0"); // wrong, FIXME
+    assert.strictEqual(hd._getDerivationPathByAddress(hd._getInternalAddressByIndex(0)), "m/84'/0'/0'/1/0"); // wrong, FIXME
+  });
 
-it('Legacy HD (BIP44) can create TX', async () => {
-  if (!process.env.HD_MNEMONIC) {
-    console.error('process.env.HD_MNEMONIC not set, skipped');
-    return;
-  }
-  const hd = new HDLegacyP2PKHWallet();
-  hd.setSecret(process.env.HD_MNEMONIC);
-  assert.ok(hd.validateMnemonic());
+  it('can create TX', async () => {
+    if (!process.env.HD_MNEMONIC) {
+      console.error('process.env.HD_MNEMONIC not set, skipped');
+      return;
+    }
+    const hd = new HDLegacyP2PKHWallet();
+    hd.setSecret(process.env.HD_MNEMONIC);
+    assert.ok(hd.validateMnemonic());
 
-  const utxo = [
-    {
-      height: 554830,
-      value: 10000,
-      address: '186FBQmCV5W1xY7ywaWtTZPAQNciVN8Por',
-      txId: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
-      vout: 0,
-      txid: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
-      amount: 10000,
-      wif: 'Kz6kLhdyDfSbKuVH25XVqBRztjmFe8X22Xe1hnFzEv79gJNMkTAH',
-      confirmations: 1,
-      txhex:
-        '01000000000101e8d98effbb4fba4f0a89bcf217eb5a7e2f8efcae44f32ecacbc5d8cc3ce683c301000000171600148ba6d02e74c0a6e000e8b174eb2ed44e5ea211a6ffffffff0510270000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac204e0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac30750000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac409c0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac204716000000000017a914e286d58e53f9247a4710e51232cce0686f16873c8702483045022100af3800cd8171f154785cf13f46c092f61c1668f97db432bb4e7ed7bc812a8c6d022051bddca1eaf1ad8b5f3bd0ccde7447e56fd3c8709e5906f02ec6326e9a5b2ff30121039a421d5eb7c9de6590ae2a471cb556b60de8c6b056beb907dbdc1f5e6092f58800000000',
-    },
-    {
-      height: 554830,
-      value: 20000,
-      address: '1J9zoJz5LsAJ361SQHYnLTWg46Tc2AXUCj',
-      txId: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
-      vout: 1,
-      txid: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
-      amount: 20000,
-      wif: 'L4ojevRtK81A8Kof3qyLS2M7HvsVDbUDENNhJqU4vf79w9yGnQLb',
-      confirmations: 1,
-      txhex:
-        '01000000000101e8d98effbb4fba4f0a89bcf217eb5a7e2f8efcae44f32ecacbc5d8cc3ce683c301000000171600148ba6d02e74c0a6e000e8b174eb2ed44e5ea211a6ffffffff0510270000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac204e0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac30750000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac409c0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac204716000000000017a914e286d58e53f9247a4710e51232cce0686f16873c8702483045022100af3800cd8171f154785cf13f46c092f61c1668f97db432bb4e7ed7bc812a8c6d022051bddca1eaf1ad8b5f3bd0ccde7447e56fd3c8709e5906f02ec6326e9a5b2ff30121039a421d5eb7c9de6590ae2a471cb556b60de8c6b056beb907dbdc1f5e6092f58800000000',
-    },
-    {
-      height: 554830,
-      value: 30000,
-      address: '186FBQmCV5W1xY7ywaWtTZPAQNciVN8Por',
-      txId: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
-      vout: 2,
-      txid: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
-      amount: 30000,
-      wif: 'Kz6kLhdyDfSbKuVH25XVqBRztjmFe8X22Xe1hnFzEv79gJNMkTAH',
-      confirmations: 1,
-      txhex:
-        '01000000000101e8d98effbb4fba4f0a89bcf217eb5a7e2f8efcae44f32ecacbc5d8cc3ce683c301000000171600148ba6d02e74c0a6e000e8b174eb2ed44e5ea211a6ffffffff0510270000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac204e0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac30750000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac409c0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac204716000000000017a914e286d58e53f9247a4710e51232cce0686f16873c8702483045022100af3800cd8171f154785cf13f46c092f61c1668f97db432bb4e7ed7bc812a8c6d022051bddca1eaf1ad8b5f3bd0ccde7447e56fd3c8709e5906f02ec6326e9a5b2ff30121039a421d5eb7c9de6590ae2a471cb556b60de8c6b056beb907dbdc1f5e6092f58800000000',
-    },
-    {
-      height: 554830,
-      value: 40000,
-      address: '1J9zoJz5LsAJ361SQHYnLTWg46Tc2AXUCj',
-      txId: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
-      vout: 3,
-      txid: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
-      amount: 40000,
-      wif: 'L4ojevRtK81A8Kof3qyLS2M7HvsVDbUDENNhJqU4vf79w9yGnQLb',
-      confirmations: 1,
-      txhex:
-        '01000000000101e8d98effbb4fba4f0a89bcf217eb5a7e2f8efcae44f32ecacbc5d8cc3ce683c301000000171600148ba6d02e74c0a6e000e8b174eb2ed44e5ea211a6ffffffff0510270000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac204e0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac30750000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac409c0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac204716000000000017a914e286d58e53f9247a4710e51232cce0686f16873c8702483045022100af3800cd8171f154785cf13f46c092f61c1668f97db432bb4e7ed7bc812a8c6d022051bddca1eaf1ad8b5f3bd0ccde7447e56fd3c8709e5906f02ec6326e9a5b2ff30121039a421d5eb7c9de6590ae2a471cb556b60de8c6b056beb907dbdc1f5e6092f58800000000',
-    },
-  ];
+    const utxo = [
+      {
+        height: 554830,
+        value: 10000,
+        address: '186FBQmCV5W1xY7ywaWtTZPAQNciVN8Por',
+        txId: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
+        vout: 0,
+        txid: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
+        amount: 10000,
+        wif: 'Kz6kLhdyDfSbKuVH25XVqBRztjmFe8X22Xe1hnFzEv79gJNMkTAH',
+        confirmations: 1,
+        txhex:
+          '01000000000101e8d98effbb4fba4f0a89bcf217eb5a7e2f8efcae44f32ecacbc5d8cc3ce683c301000000171600148ba6d02e74c0a6e000e8b174eb2ed44e5ea211a6ffffffff0510270000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac204e0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac30750000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac409c0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac204716000000000017a914e286d58e53f9247a4710e51232cce0686f16873c8702483045022100af3800cd8171f154785cf13f46c092f61c1668f97db432bb4e7ed7bc812a8c6d022051bddca1eaf1ad8b5f3bd0ccde7447e56fd3c8709e5906f02ec6326e9a5b2ff30121039a421d5eb7c9de6590ae2a471cb556b60de8c6b056beb907dbdc1f5e6092f58800000000',
+      },
+      {
+        height: 554830,
+        value: 20000,
+        address: '1J9zoJz5LsAJ361SQHYnLTWg46Tc2AXUCj',
+        txId: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
+        vout: 1,
+        txid: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
+        amount: 20000,
+        wif: 'L4ojevRtK81A8Kof3qyLS2M7HvsVDbUDENNhJqU4vf79w9yGnQLb',
+        confirmations: 1,
+        txhex:
+          '01000000000101e8d98effbb4fba4f0a89bcf217eb5a7e2f8efcae44f32ecacbc5d8cc3ce683c301000000171600148ba6d02e74c0a6e000e8b174eb2ed44e5ea211a6ffffffff0510270000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac204e0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac30750000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac409c0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac204716000000000017a914e286d58e53f9247a4710e51232cce0686f16873c8702483045022100af3800cd8171f154785cf13f46c092f61c1668f97db432bb4e7ed7bc812a8c6d022051bddca1eaf1ad8b5f3bd0ccde7447e56fd3c8709e5906f02ec6326e9a5b2ff30121039a421d5eb7c9de6590ae2a471cb556b60de8c6b056beb907dbdc1f5e6092f58800000000',
+      },
+      {
+        height: 554830,
+        value: 30000,
+        address: '186FBQmCV5W1xY7ywaWtTZPAQNciVN8Por',
+        txId: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
+        vout: 2,
+        txid: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
+        amount: 30000,
+        wif: 'Kz6kLhdyDfSbKuVH25XVqBRztjmFe8X22Xe1hnFzEv79gJNMkTAH',
+        confirmations: 1,
+        txhex:
+          '01000000000101e8d98effbb4fba4f0a89bcf217eb5a7e2f8efcae44f32ecacbc5d8cc3ce683c301000000171600148ba6d02e74c0a6e000e8b174eb2ed44e5ea211a6ffffffff0510270000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac204e0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac30750000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac409c0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac204716000000000017a914e286d58e53f9247a4710e51232cce0686f16873c8702483045022100af3800cd8171f154785cf13f46c092f61c1668f97db432bb4e7ed7bc812a8c6d022051bddca1eaf1ad8b5f3bd0ccde7447e56fd3c8709e5906f02ec6326e9a5b2ff30121039a421d5eb7c9de6590ae2a471cb556b60de8c6b056beb907dbdc1f5e6092f58800000000',
+      },
+      {
+        height: 554830,
+        value: 40000,
+        address: '1J9zoJz5LsAJ361SQHYnLTWg46Tc2AXUCj',
+        txId: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
+        vout: 3,
+        txid: '4f65c8cb159585c00d4deba9c5b36a2bcdfb1399a561114dcf6f2d0c1174bc5f',
+        amount: 40000,
+        wif: 'L4ojevRtK81A8Kof3qyLS2M7HvsVDbUDENNhJqU4vf79w9yGnQLb',
+        confirmations: 1,
+        txhex:
+          '01000000000101e8d98effbb4fba4f0a89bcf217eb5a7e2f8efcae44f32ecacbc5d8cc3ce683c301000000171600148ba6d02e74c0a6e000e8b174eb2ed44e5ea211a6ffffffff0510270000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac204e0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac30750000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac409c0000000000001976a914bc2db6b74c8db9b188711dcedd511e6a305603f588ac204716000000000017a914e286d58e53f9247a4710e51232cce0686f16873c8702483045022100af3800cd8171f154785cf13f46c092f61c1668f97db432bb4e7ed7bc812a8c6d022051bddca1eaf1ad8b5f3bd0ccde7447e56fd3c8709e5906f02ec6326e9a5b2ff30121039a421d5eb7c9de6590ae2a471cb556b60de8c6b056beb907dbdc1f5e6092f58800000000',
+      },
+    ];
 
-  let txNew = hd.createTransaction(
-    utxo,
-    [{ address: '3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', value: 80000 }],
-    1,
-    hd._getInternalAddressByIndex(hd.next_free_change_address_index),
-  );
-  let tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-  assert.strictEqual(tx.ins.length, 4);
-  assert.strictEqual(tx.outs.length, 2);
-  assert.strictEqual(tx.outs[0].value, 80000); // payee
-  assert.strictEqual(tx.outs[1].value, 19330); // change
-  let toAddress = bitcoin.address.fromOutputScript(tx.outs[0].script);
-  const changeAddress = bitcoin.address.fromOutputScript(tx.outs[1].script);
-  assert.strictEqual('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', toAddress);
-  assert.strictEqual(hd._getInternalAddressByIndex(hd.next_free_change_address_index), changeAddress);
+    let txNew = hd.createTransaction(
+      utxo,
+      [{ address: '3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', value: 80000 }],
+      1,
+      hd._getInternalAddressByIndex(hd.next_free_change_address_index),
+    );
+    let tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
+    assert.strictEqual(tx.ins.length, 4);
+    assert.strictEqual(tx.outs.length, 2);
+    assert.strictEqual(tx.outs[0].value, 80000); // payee
+    assert.strictEqual(tx.outs[1].value, 19330); // change
+    let toAddress = bitcoin.address.fromOutputScript(tx.outs[0].script);
+    const changeAddress = bitcoin.address.fromOutputScript(tx.outs[1].script);
+    assert.strictEqual('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', toAddress);
+    assert.strictEqual(hd._getInternalAddressByIndex(hd.next_free_change_address_index), changeAddress);
 
-  // testing sendMax
-  txNew = hd.createTransaction(
-    utxo,
-    [{ address: '3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK' }],
-    1,
-    hd._getInternalAddressByIndex(hd.next_free_change_address_index),
-  );
-  tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-  assert.strictEqual(tx.ins.length, 4);
-  assert.strictEqual(tx.outs.length, 1);
-  toAddress = bitcoin.address.fromOutputScript(tx.outs[0].script);
-  assert.strictEqual('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', toAddress);
+    // testing sendMax
+    txNew = hd.createTransaction(
+      utxo,
+      [{ address: '3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK' }],
+      1,
+      hd._getInternalAddressByIndex(hd.next_free_change_address_index),
+    );
+    tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
+    assert.strictEqual(tx.ins.length, 4);
+    assert.strictEqual(tx.outs.length, 1);
+    toAddress = bitcoin.address.fromOutputScript(tx.outs[0].script);
+    assert.strictEqual('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', toAddress);
+  });
+
+  it('can sign and verify messages', async () => {
+    const mnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    const hd = new HDLegacyP2PKHWallet();
+    hd.setSecret(mnemonic);
+    let signature;
+
+    // external address
+    signature = hd.signMessage('vires is numeris', '1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA');
+    assert.strictEqual(signature, 'H5J8DbqvuBy8lqRW7+LTVrrtrsaqLSwRDyj+5XtCrZpdCgPlxKM4EKRD6qvdKeyEh1fiSfIVB/edPAum3gKcJZo=');
+    assert.strictEqual(hd.verifyMessage('vires is numeris', '1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA', signature), true);
+
+    // internal address
+    signature = hd.signMessage('vires is numeris', '1J3J6EvPrv8q6AC3VCjWV45Uf3nssNMRtH');
+    assert.strictEqual(signature, 'H98hmvtyPFUbR6E5Tcsqmc+eSjlYhP2vy41Y6IyHS9DVKEI5n8VEMpIEDtvlMARVce96nOqbRHXo9nD05WXH/Eo=');
+    assert.strictEqual(hd.verifyMessage('vires is numeris', '1J3J6EvPrv8q6AC3VCjWV45Uf3nssNMRtH', signature), true);
+  });
 });

--- a/tests/unit/hd-segwit-bech32-wallet.test.js
+++ b/tests/unit/hd-segwit-bech32-wallet.test.js
@@ -104,4 +104,61 @@ describe('Bech32 Segwit HD (BIP84)', () => {
     // for UTXO with no metadata .getUTXOMetadata() should return an empty object
     assert.ok(Object.keys(hd.getUTXOMetadata('22222', 0)).length === 0);
   });
+
+  it('can sign and verify messages', async () => {
+    const mnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    const hd = new HDSegwitBech32Wallet();
+    hd.setSecret(mnemonic);
+    let signature;
+
+    // external address
+    signature = hd.signMessage('vires is numeris', 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu');
+    assert.strictEqual(signature, 'KGW4FfrptS9zV3UptUWxbEf65GhC2mCUz86G0GpN/H4MUC29Y5TsRhWGIqG2lettEpZXZETuc2yL+O7/UvDhxhM=');
+    assert.strictEqual(hd.verifyMessage('vires is numeris', 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu', signature), true);
+
+    // internal address
+    signature = hd.signMessage('vires is numeris', 'bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el');
+    assert.strictEqual(signature, 'KJ5B9JkZ042FhtGeObU/MxLCzQWHbrpXNQxhfJj9wMboa/icLIIaAlsKaSkS27fZLvX3WH0qyj3aAaXscnWsfSw=');
+    assert.strictEqual(hd.verifyMessage('vires is numeris', 'bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el', signature), true);
+
+    // multiline message
+    signature = hd.signMessage('vires\nis\nnumeris', 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu');
+    assert.strictEqual(signature, 'KFI22tlJVGq2HGQM5rcBtYu+Jq8oc7QyjSBP1ZQup3a/GEw1Khu2qFbL/iLzqw95wN22a/Tll1oMLdWxg9cWMYM=');
+    assert.strictEqual(hd.verifyMessage('vires\nis\nnumeris', 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu', signature), true);
+
+    // can't sign if address doesn't belong to wallet
+    assert.throws(() => hd.signMessage('vires is numeris', '186FBQmCV5W1xY7ywaWtTZPAQNciVN8Por'));
+
+    // can't verify wrong signature
+    assert.throws(() => hd.verifyMessage('vires is numeris', 'bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el', 'wrong signature'));
+
+    // can verify electrum message signature
+    // bech32 segwit (p2wpkh)
+    assert.strictEqual(
+      hd.verifyMessage(
+        'vires is numeris',
+        'bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el',
+        'Hya6IaZGbKF83eOmC5i1CX5V42Wqkf+eSMi8S+hvJuJrDmp5F56ivrHgAzcxNIShIpY2lJv76M2LB6zLV70KxWQ=',
+      ),
+      true,
+    );
+    // p2sh-segwit (p2wpkh-p2sh)
+    assert.strictEqual(
+      hd.verifyMessage(
+        'vires is numeris',
+        '37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf',
+        'IBm8XAd/NdWjjUBXr3pkXdVk1XQBHKPkBy4DCmSG0Ox4IKOLb1O+V7cTXPQ2vm3rcYquF+6iKSPJDiE1TPrAswY=',
+      ),
+      true,
+    );
+    // legacy
+    assert.strictEqual(
+      hd.verifyMessage(
+        'vires is numeris',
+        '1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA',
+        'IDNPawFev2E+W1xhHYi6NKuj7BY2Xe9qvXfddoWL4XZcPridoizzm8pda6jGEIwHlVYe4zrGhYqUR+j2hOsQxD8=',
+      ),
+      true,
+    );
+  });
 });

--- a/tests/unit/hd-segwit-p2sh-wallet.test.js
+++ b/tests/unit/hd-segwit-p2sh-wallet.test.js
@@ -1,166 +1,185 @@
 import { SegwitP2SHWallet, SegwitBech32Wallet, HDSegwitP2SHWallet, HDLegacyP2PKHWallet, LegacyWallet } from '../../class';
 const assert = require('assert');
 
-it('can create a Segwit HD (BIP49)', async function () {
-  const mnemonic =
-    'honey risk juice trip orient galaxy win situate shoot anchor bounce remind horse traffic exotic since escape mimic ramp skin judge owner topple erode';
-  const hd = new HDSegwitP2SHWallet();
-  hd.setSecret(mnemonic);
-  assert.strictEqual('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', hd._getExternalAddressByIndex(0));
-  assert.strictEqual('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3', hd._getExternalAddressByIndex(1));
-  assert.strictEqual('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei', hd._getInternalAddressByIndex(0));
-  assert.ok(hd.getAllExternalAddresses().includes('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK'));
-  assert.ok(hd.getAllExternalAddresses().includes('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3'));
-  assert.ok(!hd.getAllExternalAddresses().includes('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei')); // not internal
-  assert.strictEqual(true, hd.validateMnemonic());
+describe('P2SH Segwit HD (BIP49)', () => {
+  it('can create a wallet', async () => {
+    const mnemonic =
+      'honey risk juice trip orient galaxy win situate shoot anchor bounce remind horse traffic exotic since escape mimic ramp skin judge owner topple erode';
+    const hd = new HDSegwitP2SHWallet();
+    hd.setSecret(mnemonic);
+    assert.strictEqual('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', hd._getExternalAddressByIndex(0));
+    assert.strictEqual('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3', hd._getExternalAddressByIndex(1));
+    assert.strictEqual('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei', hd._getInternalAddressByIndex(0));
+    assert.ok(hd.getAllExternalAddresses().includes('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK'));
+    assert.ok(hd.getAllExternalAddresses().includes('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3'));
+    assert.ok(!hd.getAllExternalAddresses().includes('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei')); // not internal
+    assert.strictEqual(true, hd.validateMnemonic());
 
-  assert.strictEqual(
-    hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex'),
-    '0348192db90b753484601aaf1e6220644ffe37d83a9a5feff32b4da43739f736be',
-  );
-  assert.strictEqual(
-    hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex'),
-    '03c107e6976d59e17490513fbed3fb321736b7231d24f3d09306c72714acf1859d',
-  );
+    assert.strictEqual(
+      hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex'),
+      '0348192db90b753484601aaf1e6220644ffe37d83a9a5feff32b4da43739f736be',
+    );
+    assert.strictEqual(
+      hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex'),
+      '03c107e6976d59e17490513fbed3fb321736b7231d24f3d09306c72714acf1859d',
+    );
 
-  assert.strictEqual(hd._getDerivationPathByAddress(hd._getExternalAddressByIndex(0)), "m/84'/0'/0'/0/0"); // wrong, FIXME
-  assert.strictEqual(hd._getDerivationPathByAddress(hd._getInternalAddressByIndex(0)), "m/84'/0'/0'/1/0"); // wrong, FIXME
+    assert.strictEqual(hd._getDerivationPathByAddress(hd._getExternalAddressByIndex(0)), "m/84'/0'/0'/0/0"); // wrong, FIXME
+    assert.strictEqual(hd._getDerivationPathByAddress(hd._getInternalAddressByIndex(0)), "m/84'/0'/0'/1/0"); // wrong, FIXME
 
-  assert.strictEqual('L4MqtwJm6hkbACLG4ho5DF8GhcXdLEbbvpJnbzA9abfD6RDpbr2m', hd._getExternalWIFByIndex(0));
-  assert.strictEqual(
-    'ypub6WhHmKBmHNjcrUVNCa3sXduH9yxutMipDcwiKW31vWjcMbfhQHjXdyx4rqXbEtVgzdbhFJ5mZJWmfWwnP4Vjzx97admTUYKQt6b9D7jjSCp',
-    hd.getXpub(),
-  );
-});
+    assert.strictEqual('L4MqtwJm6hkbACLG4ho5DF8GhcXdLEbbvpJnbzA9abfD6RDpbr2m', hd._getExternalWIFByIndex(0));
+    assert.strictEqual(
+      'ypub6WhHmKBmHNjcrUVNCa3sXduH9yxutMipDcwiKW31vWjcMbfhQHjXdyx4rqXbEtVgzdbhFJ5mZJWmfWwnP4Vjzx97admTUYKQt6b9D7jjSCp',
+      hd.getXpub(),
+    );
+  });
 
-it('can convert witness to address', () => {
-  let address = SegwitP2SHWallet.witnessToAddress('035c618df829af694cb99e664ce1b34f80ad2c3b49bcd0d9c0b1836c66b2d25fd8');
-  assert.strictEqual(address, '34ZVGb3gT8xMLT6fpqC6dNVqJtJmvdjbD7');
-  address = SegwitP2SHWallet.witnessToAddress();
-  assert.strictEqual(address, false);
-  address = SegwitP2SHWallet.witnessToAddress('trololo');
-  assert.strictEqual(address, false);
+  it('can convert witness to address', () => {
+    let address = SegwitP2SHWallet.witnessToAddress('035c618df829af694cb99e664ce1b34f80ad2c3b49bcd0d9c0b1836c66b2d25fd8');
+    assert.strictEqual(address, '34ZVGb3gT8xMLT6fpqC6dNVqJtJmvdjbD7');
+    address = SegwitP2SHWallet.witnessToAddress();
+    assert.strictEqual(address, false);
+    address = SegwitP2SHWallet.witnessToAddress('trololo');
+    assert.strictEqual(address, false);
 
-  address = SegwitP2SHWallet.scriptPubKeyToAddress('a914e286d58e53f9247a4710e51232cce0686f16873c87');
-  assert.strictEqual(address, '3NLnALo49CFEF4tCRhCvz45ySSfz3UktZC');
-  address = SegwitP2SHWallet.scriptPubKeyToAddress();
-  assert.strictEqual(address, false);
-  address = SegwitP2SHWallet.scriptPubKeyToAddress('trololo');
-  assert.strictEqual(address, false);
+    address = SegwitP2SHWallet.scriptPubKeyToAddress('a914e286d58e53f9247a4710e51232cce0686f16873c87');
+    assert.strictEqual(address, '3NLnALo49CFEF4tCRhCvz45ySSfz3UktZC');
+    address = SegwitP2SHWallet.scriptPubKeyToAddress();
+    assert.strictEqual(address, false);
+    address = SegwitP2SHWallet.scriptPubKeyToAddress('trololo');
+    assert.strictEqual(address, false);
 
-  address = SegwitBech32Wallet.witnessToAddress('035c618df829af694cb99e664ce1b34f80ad2c3b49bcd0d9c0b1836c66b2d25fd8');
-  assert.strictEqual(address, 'bc1quhnve8q4tk3unhmjts7ymxv8cd6w9xv8wy29uv');
-  address = SegwitBech32Wallet.witnessToAddress();
-  assert.strictEqual(address, false);
-  address = SegwitBech32Wallet.witnessToAddress('trololo');
-  assert.strictEqual(address, false);
+    address = SegwitBech32Wallet.witnessToAddress('035c618df829af694cb99e664ce1b34f80ad2c3b49bcd0d9c0b1836c66b2d25fd8');
+    assert.strictEqual(address, 'bc1quhnve8q4tk3unhmjts7ymxv8cd6w9xv8wy29uv');
+    address = SegwitBech32Wallet.witnessToAddress();
+    assert.strictEqual(address, false);
+    address = SegwitBech32Wallet.witnessToAddress('trololo');
+    assert.strictEqual(address, false);
 
-  address = SegwitBech32Wallet.scriptPubKeyToAddress('00144d757460da5fcaf84cc22f3847faaa1078e84f6a');
-  assert.strictEqual(address, 'bc1qf46hgcx6tl90snxz9uuy0742zpuwsnm27ysdh7');
-  address = SegwitBech32Wallet.scriptPubKeyToAddress();
-  assert.strictEqual(address, false);
-  address = SegwitBech32Wallet.scriptPubKeyToAddress('trololo');
-  assert.strictEqual(address, false);
+    address = SegwitBech32Wallet.scriptPubKeyToAddress('00144d757460da5fcaf84cc22f3847faaa1078e84f6a');
+    assert.strictEqual(address, 'bc1qf46hgcx6tl90snxz9uuy0742zpuwsnm27ysdh7');
+    address = SegwitBech32Wallet.scriptPubKeyToAddress();
+    assert.strictEqual(address, false);
+    address = SegwitBech32Wallet.scriptPubKeyToAddress('trololo');
+    assert.strictEqual(address, false);
 
-  address = LegacyWallet.scriptPubKeyToAddress('76a914d0b77eb1502c81c4093da9aa6eccfdf560cdd6b288ac');
-  assert.strictEqual(address, '1L2bNMGRQQLT2AVUek4K9L7sn3SSMioMgE');
-  address = LegacyWallet.scriptPubKeyToAddress();
-  assert.strictEqual(address, false);
-  address = LegacyWallet.scriptPubKeyToAddress('trololo');
-  assert.strictEqual(address, false);
-});
+    address = LegacyWallet.scriptPubKeyToAddress('76a914d0b77eb1502c81c4093da9aa6eccfdf560cdd6b288ac');
+    assert.strictEqual(address, '1L2bNMGRQQLT2AVUek4K9L7sn3SSMioMgE');
+    address = LegacyWallet.scriptPubKeyToAddress();
+    assert.strictEqual(address, false);
+    address = LegacyWallet.scriptPubKeyToAddress('trololo');
+    assert.strictEqual(address, false);
+  });
 
-it('Segwit HD (BIP49) can generate addressess only via ypub', function () {
-  const ypub = 'ypub6WhHmKBmHNjcrUVNCa3sXduH9yxutMipDcwiKW31vWjcMbfhQHjXdyx4rqXbEtVgzdbhFJ5mZJWmfWwnP4Vjzx97admTUYKQt6b9D7jjSCp';
-  const hd = new HDSegwitP2SHWallet();
-  hd._xpub = ypub;
-  assert.strictEqual('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', hd._getExternalAddressByIndex(0));
-  assert.strictEqual('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3', hd._getExternalAddressByIndex(1));
-  assert.strictEqual('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei', hd._getInternalAddressByIndex(0));
-  assert.ok(hd.getAllExternalAddresses().includes('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK'));
-  assert.ok(hd.getAllExternalAddresses().includes('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3'));
-  assert.ok(!hd.getAllExternalAddresses().includes('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei')); // not internal
-});
+  it('Segwit HD (BIP49) can generate addressess only via ypub', function () {
+    const ypub = 'ypub6WhHmKBmHNjcrUVNCa3sXduH9yxutMipDcwiKW31vWjcMbfhQHjXdyx4rqXbEtVgzdbhFJ5mZJWmfWwnP4Vjzx97admTUYKQt6b9D7jjSCp';
+    const hd = new HDSegwitP2SHWallet();
+    hd._xpub = ypub;
+    assert.strictEqual('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', hd._getExternalAddressByIndex(0));
+    assert.strictEqual('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3', hd._getExternalAddressByIndex(1));
+    assert.strictEqual('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei', hd._getInternalAddressByIndex(0));
+    assert.ok(hd.getAllExternalAddresses().includes('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK'));
+    assert.ok(hd.getAllExternalAddresses().includes('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3'));
+    assert.ok(!hd.getAllExternalAddresses().includes('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei')); // not internal
+  });
 
-it('can generate Segwit HD (BIP49)', async () => {
-  const hd = new HDSegwitP2SHWallet();
-  const hashmap = {};
-  for (let c = 0; c < 1000; c++) {
-    await hd.generate();
-    const secret = hd.getSecret();
-    if (hashmap[secret]) {
-      throw new Error('Duplicate secret generated!');
+  it('can generate Segwit HD (BIP49)', async () => {
+    const hd = new HDSegwitP2SHWallet();
+    const hashmap = {};
+    for (let c = 0; c < 1000; c++) {
+      await hd.generate();
+      const secret = hd.getSecret();
+      if (hashmap[secret]) {
+        throw new Error('Duplicate secret generated!');
+      }
+      hashmap[secret] = 1;
+      assert.ok(secret.split(' ').length === 12 || secret.split(' ').length === 24);
     }
-    hashmap[secret] = 1;
+
+    const hd2 = new HDSegwitP2SHWallet();
+    hd2.setSecret(hd.getSecret());
+    assert.ok(hd2.validateMnemonic());
+  });
+
+  it('can work with malformed mnemonic', () => {
+    let mnemonic =
+      'honey risk juice trip orient galaxy win situate shoot anchor bounce remind horse traffic exotic since escape mimic ramp skin judge owner topple erode';
+    let hd = new HDSegwitP2SHWallet();
+    hd.setSecret(mnemonic);
+    const seed1 = hd.getMnemonicToSeedHex();
+    assert.ok(hd.validateMnemonic());
+
+    mnemonic = 'hell';
+    hd = new HDSegwitP2SHWallet();
+    hd.setSecret(mnemonic);
+    assert.ok(!hd.validateMnemonic());
+
+    // now, malformed mnemonic
+
+    mnemonic =
+      '    honey  risk   juice    trip     orient      galaxy win !situate ;; shoot   ;;;   anchor Bounce remind\nhorse \n traffic exotic since escape mimic ramp skin judge owner topple erode ';
+    hd = new HDSegwitP2SHWallet();
+    hd.setSecret(mnemonic);
+    const seed2 = hd.getMnemonicToSeedHex();
+    assert.strictEqual(seed1, seed2);
+    assert.ok(hd.validateMnemonic());
+  });
+
+  it('can generate addressess based on xpub', async function () {
+    const xpub = 'xpub6CQdfC3v9gU86eaSn7AhUFcBVxiGhdtYxdC5Cw2vLmFkfth2KXCMmYcPpvZviA89X6DXDs4PJDk5QVL2G2xaVjv7SM4roWHr1gR4xB3Z7Ps';
+    const hd = new HDLegacyP2PKHWallet();
+    hd._xpub = xpub;
+    assert.strictEqual(hd._getExternalAddressByIndex(0), '12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG');
+    assert.strictEqual(hd._getInternalAddressByIndex(0), '1KZjqYHm7a1DjhjcdcjfQvYfF2h6PqatjX');
+    assert.strictEqual(hd._getExternalAddressByIndex(1), '1QDCFcpnrZ4yrAQxmbvSgeUC9iZZ8ehcR5');
+    assert.strictEqual(hd._getInternalAddressByIndex(1), '13CW9WWBsWpDUvLtbFqYziWBWTYUoQb4nU');
+    assert.ok(hd.getAllExternalAddresses().includes('12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG'));
+    assert.ok(hd.getAllExternalAddresses().includes('1QDCFcpnrZ4yrAQxmbvSgeUC9iZZ8ehcR5'));
+    assert.ok(!hd.getAllExternalAddresses().includes('1KZjqYHm7a1DjhjcdcjfQvYfF2h6PqatjX')); // not internal
+  });
+
+  it('can consume user generated entropy', async () => {
+    const hd = new HDSegwitP2SHWallet();
+    const zeroes = [...Array(32)].map(() => 0);
+    await hd.generateFromEntropy(Buffer.from(zeroes));
+    assert.strictEqual(
+      hd.getSecret(),
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art',
+    );
+  });
+
+  it('can fullfill user generated entropy if less than 32 bytes provided', async () => {
+    const hd = new HDSegwitP2SHWallet();
+    const zeroes = [...Array(16)].map(() => 0);
+    await hd.generateFromEntropy(Buffer.from(zeroes));
+    const secret = hd.getSecret();
+    assert.strictEqual(secret.startsWith('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon'), true);
+
+    let secretWithoutChecksum = secret.split(' ');
+    secretWithoutChecksum.pop();
+    secretWithoutChecksum = secretWithoutChecksum.join(' ');
+    assert.strictEqual(
+      secretWithoutChecksum.endsWith('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon'),
+      false,
+    );
+
     assert.ok(secret.split(' ').length === 12 || secret.split(' ').length === 24);
-  }
+  });
 
-  const hd2 = new HDSegwitP2SHWallet();
-  hd2.setSecret(hd.getSecret());
-  assert.ok(hd2.validateMnemonic());
-});
+  it('can sign and verify messages', async () => {
+    const mnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    const hd = new HDSegwitP2SHWallet();
+    hd.setSecret(mnemonic);
+    let signature;
 
-it('can work with malformed mnemonic', () => {
-  let mnemonic =
-    'honey risk juice trip orient galaxy win situate shoot anchor bounce remind horse traffic exotic since escape mimic ramp skin judge owner topple erode';
-  let hd = new HDSegwitP2SHWallet();
-  hd.setSecret(mnemonic);
-  const seed1 = hd.getMnemonicToSeedHex();
-  assert.ok(hd.validateMnemonic());
+    // external address
+    signature = hd.signMessage('vires is numeris', '37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf');
+    assert.strictEqual(signature, 'JMgoRSlLLLw6mw/Gbbg8Uj3fACkIJ85CZ52T5ZQfBnpUBkz0myRju6Rmgvmq7ugytc4WyYbzdGEc3wufNbjP09g=');
+    assert.strictEqual(hd.verifyMessage('vires is numeris', '37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf', signature), true);
 
-  mnemonic = 'hell';
-  hd = new HDSegwitP2SHWallet();
-  hd.setSecret(mnemonic);
-  assert.ok(!hd.validateMnemonic());
-
-  // now, malformed mnemonic
-
-  mnemonic =
-    '    honey  risk   juice    trip     orient      galaxy win !situate ;; shoot   ;;;   anchor Bounce remind\nhorse \n traffic exotic since escape mimic ramp skin judge owner topple erode ';
-  hd = new HDSegwitP2SHWallet();
-  hd.setSecret(mnemonic);
-  const seed2 = hd.getMnemonicToSeedHex();
-  assert.strictEqual(seed1, seed2);
-  assert.ok(hd.validateMnemonic());
-});
-
-it('Legacy HD (BIP44) can generate addressess based on xpub', async function () {
-  const xpub = 'xpub6CQdfC3v9gU86eaSn7AhUFcBVxiGhdtYxdC5Cw2vLmFkfth2KXCMmYcPpvZviA89X6DXDs4PJDk5QVL2G2xaVjv7SM4roWHr1gR4xB3Z7Ps';
-  const hd = new HDLegacyP2PKHWallet();
-  hd._xpub = xpub;
-  assert.strictEqual(hd._getExternalAddressByIndex(0), '12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG');
-  assert.strictEqual(hd._getInternalAddressByIndex(0), '1KZjqYHm7a1DjhjcdcjfQvYfF2h6PqatjX');
-  assert.strictEqual(hd._getExternalAddressByIndex(1), '1QDCFcpnrZ4yrAQxmbvSgeUC9iZZ8ehcR5');
-  assert.strictEqual(hd._getInternalAddressByIndex(1), '13CW9WWBsWpDUvLtbFqYziWBWTYUoQb4nU');
-  assert.ok(hd.getAllExternalAddresses().includes('12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG'));
-  assert.ok(hd.getAllExternalAddresses().includes('1QDCFcpnrZ4yrAQxmbvSgeUC9iZZ8ehcR5'));
-  assert.ok(!hd.getAllExternalAddresses().includes('1KZjqYHm7a1DjhjcdcjfQvYfF2h6PqatjX')); // not internal
-});
-
-it('can consume user generated entropy', async () => {
-  const hd = new HDSegwitP2SHWallet();
-  const zeroes = [...Array(32)].map(() => 0);
-  await hd.generateFromEntropy(Buffer.from(zeroes));
-  assert.strictEqual(
-    hd.getSecret(),
-    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art',
-  );
-});
-
-it('can fullfill user generated entropy if less than 32 bytes provided', async () => {
-  const hd = new HDSegwitP2SHWallet();
-  const zeroes = [...Array(16)].map(() => 0);
-  await hd.generateFromEntropy(Buffer.from(zeroes));
-  const secret = hd.getSecret();
-  assert.strictEqual(secret.startsWith('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon'), true);
-
-  let secretWithoutChecksum = secret.split(' ');
-  secretWithoutChecksum.pop();
-  secretWithoutChecksum = secretWithoutChecksum.join(' ');
-  assert.strictEqual(
-    secretWithoutChecksum.endsWith('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon'),
-    false,
-  );
-
-  assert.ok(secret.split(' ').length === 12 || secret.split(' ').length === 24);
+    // internal address
+    signature = hd.signMessage('vires is numeris', '34K56kSjgUCUSD8GTtuF7c9Zzwokbs6uZ7');
+    assert.strictEqual(signature, 'I5WkniWTnJhTW74t3kTAkHq3HdiupTNgOZLpMp0hvUfAJw2HMuyRiNLl2pbNWobNCCrmvffSWM7IgkOBz/J9fYA=');
+    assert.strictEqual(hd.verifyMessage('vires is numeris', '34K56kSjgUCUSD8GTtuF7c9Zzwokbs6uZ7', signature), true);
+  });
 });

--- a/tests/unit/legacy-wallet.test.js
+++ b/tests/unit/legacy-wallet.test.js
@@ -40,7 +40,7 @@ describe('Legacy wallet', () => {
     assert.strictEqual('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB', bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
   });
 
-  it("throws error if you can 't create wallet from this entropy", async () => {
+  it("throws error if you can't create wallet from this entropy", async () => {
     const l = new LegacyWallet();
     const zeroes = [...Array(32)].map(() => 0);
     await assert.rejects(async () => await l.generateFromEntropy(Buffer.from(zeroes)), {
@@ -67,5 +67,14 @@ describe('Legacy wallet', () => {
     assert.strictEqual(keyPair.privateKey.toString('hex').endsWith('01010101'), false);
     assert.strictEqual(keyPair.privateKey.toString('hex').endsWith('00000000'), false);
     assert.strictEqual(keyPair.privateKey.toString('hex').endsWith('ffffffff'), false);
+  });
+
+  it('can sign and verify messages', async () => {
+    const l = new LegacyWallet();
+    l.setSecret('L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1'); // from bitcoinjs-message examples
+
+    const signature = l.signMessage('This is an example of a signed message.');
+    assert.strictEqual(signature, 'H9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk=');
+    assert.strictEqual(l.verifyMessage('This is an example of a signed message.', '1F3sAm6ZtwLAUnj7d38pGFxtP3RVEvtsbV', signature), true);
   });
 });

--- a/tests/unit/segwit-bech32-wallet.test.js
+++ b/tests/unit/segwit-bech32-wallet.test.js
@@ -36,4 +36,15 @@ describe('Segwit P2SH wallet', () => {
     assert.strictEqual(tx.outs.length, 1);
     assert.strictEqual('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB', bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
   });
+
+  it('can sign and verify messages', async () => {
+    const l = new SegwitBech32Wallet();
+    l.setSecret('L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1'); // from bitcoinjs-message examples
+
+    console.info('add', l.getAddress())
+
+    const signature = l.signMessage('This is an example of a signed message.');
+    assert.strictEqual(signature, 'J9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk=');
+    assert.strictEqual(l.verifyMessage('This is an example of a signed message.', 'bc1qngw83fg8dz0k749cg7k3emc7v98wy0c74dlrkd', signature), true);
+  });
 });

--- a/tests/unit/segwit-p2sh-wallet.test.js
+++ b/tests/unit/segwit-p2sh-wallet.test.js
@@ -37,4 +37,13 @@ describe('Segwit P2SH wallet', () => {
     assert.strictEqual(tx.outs.length, 1);
     assert.strictEqual('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB', bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
   });
+
+  it('can sign and verify messages', async () => {
+    const l = new SegwitP2SHWallet();
+    l.setSecret('L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1'); // from bitcoinjs-message examples
+
+    const signature = l.signMessage('This is an example of a signed message.');
+    assert.strictEqual(signature, 'I9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk=');
+    assert.strictEqual(l.verifyMessage('This is an example of a signed message.', '3DnW8JGpPViEZdpqat8qky1zc26EKbXnmM', signature), true);
+  });
 });


### PR DESCRIPTION
Since bitcoin core only has signing/verifying only for legacies addresses there are 2 alternative approaches (Trezor and Electrum) to sign with `p2sh(p2wpkh)` and `p2wpkh` addresses. We are using https://github.com/bitcoinjs/bitcoinjs-message and it implements Trezor variant. But it can also verify Electrum messages.

All explained here https://github.com/bitcoinjs/bitcoinjs-message/pull/12

For HD wallets I've tested it all with Trezor/Spectrum wallets. For Single addresses tests are from bitcoinjs-message

