### PR TITLE
FIX: avoid scientific notation on tx send screens

### DIFF
--- a/screen/send/create.js
+++ b/screen/send/create.js
@@ -21,6 +21,7 @@ import { Icon } from 'react-native-elements';
 import Share from 'react-native-share';
 import RNFS from 'react-native-fs';
 import isCatalyst from 'react-native-is-catalyst';
+import BigNumber from 'bignumber.js';
 
 import { SafeBlueArea, BlueCard, BlueText } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
@@ -162,7 +163,7 @@ export default class SendCreate extends Component {
               />
               <Text style={styles.transactionDetailsTitle}>{loc.send.create_fee}</Text>
               <Text style={styles.transactionDetailsSubtitle}>
-                {this.state.fee} {BitcoinUnit.BTC}
+                {new BigNumber(this.state.fee).toFixed()} {BitcoinUnit.BTC}
               </Text>
 
               <Text style={styles.transactionDetailsTitle}>{loc.send.create_tx_size}</Text>

--- a/screen/send/success.js
+++ b/screen/send/success.js
@@ -1,13 +1,15 @@
 import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
 import LottieView from 'lottie-react-native';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import { View, StyleSheet, SafeAreaView } from 'react-native';
 import { Text } from 'react-native-elements';
+import BigNumber from 'bignumber.js';
+import { useNavigation, useRoute, useTheme } from '@react-navigation/native';
+
 import { BlueButton, BlueCard } from '../../BlueComponents';
 import { BitcoinUnit } from '../../models/bitcoinUnits';
 import loc from '../../loc';
-import PropTypes from 'prop-types';
-import { useNavigation, useRoute, useTheme } from '@react-navigation/native';
 
 const Success = () => {
   const pop = () => {
@@ -85,7 +87,7 @@ export const SuccessView = ({ amount, amountUnit, fee, invoiceDescription, shoul
         </View>
         {fee > 0 && (
           <Text style={styles.feeText}>
-            {loc.send.create_fee}: {fee} {loc.units[BitcoinUnit.BTC]}
+            {loc.send.create_fee}: {new BigNumber(fee).toFixed()} {loc.units[BitcoinUnit.BTC]}
           </Text>
         )}
         <Text numberOfLines={0} style={styles.feeText}>


### PR DESCRIPTION
Show `0.00000001`, not `1e-8` 