### PR TITLE
REF: coincontrol truncate addresses middle

### DIFF
--- a/screen/send/coinControl.js
+++ b/screen/send/coinControl.js
@@ -73,7 +73,6 @@ const OutputList = ({
   const { colors } = useTheme();
   const { txMetadata } = useContext(BlueStorageContext);
   const memo = oMemo || txMetadata[txid]?.memo || '';
-  const shortId = `${address.substring(0, 9)}...${address.substr(address.length - 9)}`;
   const color = `#${txid.substring(0, 6)}`;
   const amount = formatBalance(value, balanceUnit, true);
 
@@ -103,8 +102,8 @@ const OutputList = ({
       />
       <ListItem.Content>
         <ListItem.Title style={oStyles.amount}>{amount}</ListItem.Title>
-        <ListItem.Subtitle style={oStyles.memo} numberOfLines={1}>
-          {memo || shortId}
+        <ListItem.Subtitle style={oStyles.memo} numberOfLines={1} ellipsizeMode="middle">
+          {memo || address}
         </ListItem.Subtitle>
       </ListItem.Content>
       {change && <ChangeBadge />}


### PR DESCRIPTION
Use `numberOfLines={1} ellipsizeMode="middle"` to truncate load addresses in the middle. 
This way text fills all available space.

Before
<img width="300" alt="Screenshot 2021-04-14 at 17 28 26" src="https://user-images.githubusercontent.com/155891/114728023-63f26180-9d47-11eb-9cca-26484607c421.png">

After
<img width="300" alt="Screenshot 2021-04-14 at 17 26 12" src="https://user-images.githubusercontent.com/155891/114728051-6a80d900-9d47-11eb-80be-357c5c045436.png">

