### PR TITLE
FIX: recieve/details screen typo

### DIFF
--- a/screen/receive/details.js
+++ b/screen/receive/details.js
@@ -212,7 +212,7 @@ const ReceiveDetails = () => {
         try {
           newAddress = await Promise.race([wallet.getAddressAsync(), sleep(1000)]);
         } catch (_) {}
-        if (address === undefined) {
+        if (newAddress === undefined) {
           // either sleep expired or getAddressAsync threw an exception
           console.warn('either sleep expired or getAddressAsync threw an exception');
           newAddress = wallet._getExternalAddressByIndex(wallet.getNextFreeAddressIndex());
@@ -224,7 +224,7 @@ const ReceiveDetails = () => {
           await Promise.race([wallet.getAddressAsync(), sleep(1000)]);
           newAddress = wallet.getAddress();
         } catch (_) {}
-        if (address === undefined) {
+        if (newAddress === undefined) {
           // either sleep expired or getAddressAsync threw an exception
           console.warn('either sleep expired or getAddressAsync threw an exception');
           newAddress = wallet.getAddress();


### PR DESCRIPTION
Looks like `newAddress` should be checked for `undefined`, not `address`.

related to #2976