### PR TITLE
Electrum cache

### DIFF
--- a/BlueComponents.js
+++ b/BlueComponents.js
@@ -44,7 +44,6 @@ import Lnurl from './class/lnurl';
 import { BlueStorageContext } from './blue_modules/storage-context';
 import ToolTipMenu from './components/TooltipMenu';
 
-/** @type {AppStorage} */
 const { height, width } = Dimensions.get('window');
 const aspectRatio = height / width;
 let isIpad;

--- a/UnlockWith.js
+++ b/UnlockWith.js
@@ -7,7 +7,6 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { StackActions, useNavigation, useRoute } from '@react-navigation/native';
 import { BlueStorageContext } from './blue_modules/storage-context';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
-/** @type {AppStorage} */
 
 const styles = StyleSheet.create({
   root: {

--- a/class/wallets/abstract-hd-electrum-wallet.js
+++ b/class/wallets/abstract-hd-electrum-wallet.js
@@ -44,16 +44,6 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
   }
 
   /**
-   * @inheritDoc
-   */
-  timeToRefreshTransaction() {
-    for (const tx of this.getTransactions()) {
-      if (tx.confirmations < 7) return true;
-    }
-    return false;
-  }
-
-  /**
    *
    * @inheritDoc
    */

--- a/class/wallets/legacy-wallet.js
+++ b/class/wallets/legacy-wallet.js
@@ -37,7 +37,7 @@ export class LegacyWallet extends AbstractWallet {
    */
   timeToRefreshTransaction() {
     for (const tx of this.getTransactions()) {
-      if (tx.confirmations < 7) {
+      if (tx.confirmations < 7 && this._lastTxFetch < +new Date() - 5 * 60 * 1000) {
         return true;
       }
     }

--- a/class/wallets/watch-only-wallet.js
+++ b/class/wallets/watch-only-wallet.js
@@ -24,6 +24,16 @@ export class WatchOnlyWallet extends LegacyWallet {
     return super.getLastTxFetch();
   }
 
+  timeToRefreshTransaction() {
+    if (this._hdWalletInstance) return this._hdWalletInstance.timeToRefreshTransaction();
+    return super.timeToRefreshTransaction();
+  }
+
+  timeToRefreshBalance() {
+    if (this._hdWalletInstance) return this._hdWalletInstance.timeToRefreshBalance();
+    return super.timeToRefreshBalance();
+  }
+
   allowSend() {
     return this.useWithHardwareWalletEnabled() && this.isHd() && this._hdWalletInstance.allowSend();
   }

--- a/screen/send/details.js
+++ b/screen/send/details.js
@@ -443,7 +443,7 @@ const SendDetails = () => {
     const changeAddress = await getChangeAddressAsync();
     const requestedSatPerByte = Number(feeRate);
     const lutxo = utxo || wallet.getUtxo();
-    console.log({ requestedSatPerByte, utxo });
+    console.log({ requestedSatPerByte, lutxo });
 
     const targets = [];
     for (const transaction of addresses) {

--- a/screen/send/psbtWithHardwareWallet.js
+++ b/screen/send/psbtWithHardwareWallet.js
@@ -37,7 +37,6 @@ import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import Notifications from '../../blue_modules/notifications';
 const BlueElectrum = require('../../blue_modules/BlueElectrum');
-/** @type {AppStorage} */
 const bitcoin = require('bitcoinjs-lib');
 const fs = require('../../blue_modules/fs');
 

--- a/screen/wallets/addMultisigHelp.js
+++ b/screen/wallets/addMultisigHelp.js
@@ -3,7 +3,6 @@ import { Image, View, Text, ScrollView, StyleSheet } from 'react-native';
 import { useTheme } from '@react-navigation/native';
 import { SafeBlueArea, BlueLoading } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
-/** @type {AppStorage} */
 import loc from '../../loc';
 
 const WalletsAddMultisigHelp = () => {

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -95,6 +95,8 @@ jest.mock('react-native-haptic-feedback', () => ({}));
 
 const realmInstanceMock = {
   close: function () {},
+  write: function () {},
+  objectForPrimaryKey: function () { return {}; },
   objects: function () {
     const wallets = {
       filtered: function () {


### PR DESCRIPTION
in this PR we introduce a long-overdue electrum cache for `multiGetTransactionByTxid` call.
only transactions with >7 confirmations are cached.
this should greatly improve network fetch for batched transactions: sometimes exchange withdrawals have _thousands_ of inputs, and our code has to fetch each one of them to correctly calculate input amounts and thus, transaction value. they are now cached and repeated wallet refresh will take less time (in my case for my wallet, from 100 sec to 3 sec).
cache resides in a separate realm database file.