### PR TITLE
ADD: show zpub for electrum seed segwit wallets

### DIFF
--- a/class/wallets/hd-segwit-electrum-seed-p2wpkh-wallet.js
+++ b/class/wallets/hd-segwit-electrum-seed-p2wpkh-wallet.js
@@ -1,3 +1,4 @@
+import b58 from 'bs58check';
 import { HDSegwitBech32Wallet } from './hd-segwit-bech32-wallet';
 
 const bitcoin = require('bitcoinjs-lib');
@@ -33,7 +34,14 @@ export class HDSegwitElectrumSeedP2WPKHWallet extends HDSegwitBech32Wallet {
       return this._xpub; // cache hit
     }
     const root = bitcoin.bip32.fromSeed(mn.mnemonicToSeedSync(this.secret, MNEMONIC_TO_SEED_OPTS));
-    this._xpub = root.derivePath("m/0'").neutered().toBase58();
+    const xpub = root.derivePath("m/0'").neutered().toBase58();
+
+    // bitcoinjs does not support zpub yet, so we just convert it from xpub
+    let data = b58.decode(xpub);
+    data = data.slice(4);
+    data = Buffer.concat([Buffer.from('04b24746', 'hex'), data]);
+    this._xpub = b58.encode(data);
+
     return this._xpub;
   }
 
@@ -41,7 +49,8 @@ export class HDSegwitElectrumSeedP2WPKHWallet extends HDSegwitBech32Wallet {
     index = index * 1; // cast to int
     if (this.internal_addresses_cache[index]) return this.internal_addresses_cache[index]; // cache hit
 
-    const node = bitcoin.bip32.fromBase58(this.getXpub());
+    const xpub = this.constructor._zpubToXpub(this.getXpub());
+    const node = bitcoin.bip32.fromBase58(xpub);
     const address = bitcoin.payments.p2wpkh({
       pubkey: node.derive(1).derive(index).publicKey,
     }).address;
@@ -53,7 +62,8 @@ export class HDSegwitElectrumSeedP2WPKHWallet extends HDSegwitBech32Wallet {
     index = index * 1; // cast to int
     if (this.external_addresses_cache[index]) return this.external_addresses_cache[index]; // cache hit
 
-    const node = bitcoin.bip32.fromBase58(this.getXpub());
+    const xpub = this.constructor._zpubToXpub(this.getXpub());
+    const node = bitcoin.bip32.fromBase58(xpub);
     const address = bitcoin.payments.p2wpkh({
       pubkey: node.derive(0).derive(index).publicKey,
     }).address;
@@ -74,13 +84,13 @@ export class HDSegwitElectrumSeedP2WPKHWallet extends HDSegwitBech32Wallet {
     index = index * 1; // cast to int
 
     if (node === 0 && !this._node0) {
-      const xpub = this.getXpub();
+      const xpub = this.constructor._zpubToXpub(this.getXpub());
       const hdNode = HDNode.fromBase58(xpub);
       this._node0 = hdNode.derive(node);
     }
 
     if (node === 1 && !this._node1) {
-      const xpub = this.getXpub();
+      const xpub = this.constructor._zpubToXpub(this.getXpub());
       const hdNode = HDNode.fromBase58(xpub);
       this._node1 = hdNode.derive(node);
     }

--- a/tests/unit/hd-segwit-electrum-seed-p2wpkh-wallet.test.js
+++ b/tests/unit/hd-segwit-electrum-seed-p2wpkh-wallet.test.js
@@ -20,7 +20,7 @@ describe('HDSegwitElectrumSeedP2WPKHWallet', () => {
     assert.ok(hd.validateMnemonic());
     assert.strictEqual(
       hd.getXpub(),
-      'xpub68RzTumZwSbVWwETioxTSk2PhBvBRDGNRHepHUC5x2gptbSVWhkezF3NKbq9sCJhnNKcPx2McNWJtFFdXLx97cknHhuDTDQsFg5cG7MSMY7',
+      'zpub6n6X5F7QEogTDXchPXXhrvDQ38D5JTFNFWhFrFyri3Sazo4x225nENMeN1kKs1cYbeZDtuDUXhDQepUkxjnAi67z2PJ4d33qo8Cu3HLw74c',
     );
 
     let address = hd._getExternalAddressByIndex(0);


### PR DESCRIPTION
Right now BW shows incorrect Xpub for bech32 electrum wallets. I've fixed it, and now it shows correct Zpub.

closes #2941