### PR TITLE
ADD: opt-out of analytics tracking in settings/privacy (rel #3084)

### DIFF
--- a/blue_modules/WidgetCommunication.android.js
+++ b/blue_modules/WidgetCommunication.android.js
@@ -1,5 +1,5 @@
 function WidgetCommunication(props) {
-  WidgetCommunication.isBalanceDisplayAllowed = false;
+  WidgetCommunication.isBalanceDisplayAllowed = () => {};
   WidgetCommunication.setBalanceDisplayAllowed = () => {};
   return null;
 }

--- a/blue_modules/analytics.js
+++ b/blue_modules/analytics.js
@@ -1,6 +1,8 @@
+import * as Sentry from '@sentry/react-native';
 import amplitude from 'amplitude-js';
 import { getVersion, getSystemName } from 'react-native-device-info';
 import { Platform } from 'react-native';
+const BlueApp = require('../BlueApp');
 
 amplitude.getInstance().init('8b7cf19e8eea3cdcf16340f5fbf16330', null, {
   useNativeDeviceInfo: true,
@@ -8,6 +10,10 @@ amplitude.getInstance().init('8b7cf19e8eea3cdcf16340f5fbf16330', null, {
 });
 amplitude.getInstance().setVersionName(getVersion());
 amplitude.getInstance().options.apiEndpoint = 'api2.amplitude.com';
+BlueApp.isDoNotTrackEnabled().then(value => {
+  if (value) Sentry.close();
+  amplitude.getInstance().setOptOut(value);
+});
 
 const A = async event => {
   console.log('posting analytics...', event);
@@ -26,6 +32,11 @@ A.ENUM = {
   CREATED_LIGHTNING_WALLET: 'CREATED_LIGHTNING_WALLET',
   APP_UNSUSPENDED: 'APP_UNSUSPENDED',
   NAVIGATED_TO_WALLETS_HODLHODL: 'NAVIGATED_TO_WALLETS_HODLHODL',
+};
+
+A.setOptOut = value => {
+  if (value) Sentry.close();
+  return amplitude.getInstance().setOptOut(value);
 };
 
 module.exports = A;

--- a/blue_modules/storage-context.js
+++ b/blue_modules/storage-context.js
@@ -175,6 +175,8 @@ export const BlueStorageProvider = ({ children }) => {
   const getHodlHodlSignatureKey = BlueApp.getHodlHodlSignatureKey;
   const addHodlHodlContract = BlueApp.addHodlHodlContract;
   const getHodlHodlContracts = BlueApp.getHodlHodlContracts;
+  const setDoNotTrack = BlueApp.setDoNotTrack;
+  const isDoNotTrackEnabled = BlueApp.isDoNotTrackEnabled;
   const getItem = BlueApp.getItem;
   const setItem = BlueApp.setItem;
 
@@ -227,6 +229,8 @@ export const BlueStorageProvider = ({ children }) => {
         setWalletTransactionUpdateStatus,
         isDrawerListBlurred,
         setIsDrawerListBlurred,
+        setDoNotTrack,
+        isDoNotTrackEnabled,
       }}
     >
       {children}

--- a/class/app-storage.js
+++ b/class/app-storage.js
@@ -36,6 +36,7 @@ export class AppStorage {
   static ELECTRUM_SERVER_HISTORY = 'electrum_server_history';
   static PREFERRED_CURRENCY = 'preferredCurrency';
   static ADVANCED_MODE_ENABLED = 'advancedmodeenabled';
+  static DO_NOT_TRACK = 'donottrack';
   static HODL_HODL_API_KEY = 'HODL_HODL_API_KEY';
   static HODL_HODL_SIGNATURE_KEY = 'HODL_HODL_SIGNATURE_KEY';
   static HODL_HODL_CONTRACTS = 'HODL_HODL_CONTRACTS';
@@ -651,6 +652,17 @@ export class AppStorage {
 
   setIsAdancedModeEnabled = async value => {
     await this.setItem(AppStorage.ADVANCED_MODE_ENABLED, value ? '1' : '');
+  };
+
+  isDoNotTrackEnabled = async () => {
+    try {
+      return !!(await this.getItem(AppStorage.DO_NOT_TRACK));
+    } catch (_) {}
+    return false;
+  };
+
+  setDoNotTrack = async value => {
+    await this.setItem(AppStorage.DO_NOT_TRACK, value ? '1' : '');
   };
 
   /**

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -260,13 +260,13 @@ PODS:
     - React
   - react-native-blur (0.8.0):
     - React
-  - react-native-camera (3.43.2):
+  - react-native-camera (3.43.5):
     - React-Core
-    - react-native-camera/RCT (= 3.43.2)
-    - react-native-camera/RN (= 3.43.2)
-  - react-native-camera/RCT (3.43.2):
+    - react-native-camera/RCT (= 3.43.5)
+    - react-native-camera/RN (= 3.43.5)
+  - react-native-camera/RCT (3.43.5):
     - React-Core
-  - react-native-camera/RN (3.43.2):
+  - react-native-camera/RN (3.43.5):
     - React-Core
   - react-native-document-picker (3.5.4):
     - React
@@ -366,7 +366,7 @@ PODS:
     - React-Core
   - RNDefaultPreference (1.4.3):
     - React
-  - RNDeviceInfo (8.0.7):
+  - RNDeviceInfo (8.1.0):
     - React-Core
   - RNFS (2.16.6):
     - React
@@ -419,9 +419,9 @@ PODS:
     - React-Core
   - RNSecureKeyStore (1.0.0):
     - React
-  - RNSentry (2.4.0):
+  - RNSentry (2.5.0-beta.1):
     - React-Core
-    - Sentry (= 6.1.4)
+    - Sentry (= 7.0.0)
   - RNShare (5.2.2):
     - React-Core
   - RNSVG (12.1.0):
@@ -430,9 +430,9 @@ PODS:
     - React
   - RNWatch (1.0.3):
     - React
-  - Sentry (6.1.4):
-    - Sentry/Core (= 6.1.4)
-  - Sentry/Core (6.1.4)
+  - Sentry (7.0.0):
+    - Sentry/Core (= 7.0.0)
+  - Sentry/Core (7.0.0)
   - SwiftSocket (2.0.2)
   - ToolTipMenu (5.2.0):
     - React
@@ -735,7 +735,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
   react-native-blue-crypto: 23f1558ad3d38d7a2edb7e2f6ed1bc520ed93e56
   react-native-blur: cad4d93b364f91e7b7931b3fa935455487e5c33c
-  react-native-camera: 3333256bb222adc7592b4a8f153ee392b5b0ddf1
+  react-native-camera: 8a79f048c146e08e416c542bcf57984cbc7ed404
   react-native-document-picker: c5752781fbc0c126c627c1549b037c139444a4cf
   react-native-fingerprint-scanner: c68136ca57e3704d7bdf5faa554ea535ce15b1d0
   react-native-idle-timer: 97b8283237d45146a7a5c25bdebe9e1e85f3687b
@@ -764,7 +764,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: f5c7d14d6847b7b44853f7acb6284c1da30a3459
   RNCPushNotificationIOS: 5b1cf9ad2aaa107ecb92d5d2d7005ba521b2b97a
   RNDefaultPreference: 21816c0a6f61a2829ccc0cef034392e9b509ee5f
-  RNDeviceInfo: 0550f15928f92d062238ea412b645d00548fd809
+  RNDeviceInfo: 77944ee74f4464aa4672b62e3239e4fa69ab534f
   RNFS: 2bd9eb49dc82fa9676382f0585b992c424cd59df
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNHandoff: d3b0754cca3a6bcd9b25f544f733f7f033ccf5fa
@@ -777,12 +777,12 @@ SPEC CHECKSUMS:
   RNReanimated: c5e9d841d33ed7f83861462756cec7146e73afaa
   RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
   RNSecureKeyStore: f1ad870e53806453039f650720d2845c678d89c8
-  RNSentry: b0d55027200c96f52e26b9bfb20296d47fc5051d
+  RNSentry: 1868bcfe8c69b2c3b2451439a38b3ebea0a7510f
   RNShare: 5cfe16bfd42cd2c4869a7692462181ac8cc15a6d
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
   RNVectorIcons: bc69e6a278b14842063605de32bec61f0b251a59
   RNWatch: e4c5d19506c94506860032fb68aedd5991beb985
-  Sentry: 9d055e2de30a77685e86b219acf02e59b82091fc
+  Sentry: 89d26e036063b9cb9caa59b6951dd2f8277aa13b
   SwiftSocket: c8d482e867ae4d3eb4c769e9382e123c1f1f833b
   ToolTipMenu: 4d89d95ddffd7539230bdbe02ee51bbde362e37e
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6

--- a/loc/en.json
+++ b/loc/en.json
@@ -316,6 +316,8 @@
     "privacy_quickactions": "Wallet Shortcuts",
     "privacy_quickactions_explanation": "Touch and hold the BlueWallet app icon on your Home Screen to quickly view your wallet’s balance.",
     "privacy_clipboard_explanation": "Provide shortcuts if an address or invoice is found in your clipboard.",
+    "privacy_do_not_track": "Do Not Track",
+    "privacy_do_not_track_explanation": "Some anonymized analytics and debug data won't be sent to analytics service.",
     "push_notifications": "Push Notifications",
     "retype_password": "Re-type password",
     "selfTest": "Self-Test",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3564,9 +3564,9 @@
       }
     },
     "@sentry/react-native": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-2.4.0.tgz",
-      "integrity": "sha512-yRUN36tKRSsGEtNHihEzl0KqGh7pmWfNV0h3jf5Q1VKXNHA9iO2ABcmr47wScrbrK2MDL1umO1AQNq2+6z24QA==",
+      "version": "2.5.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-2.5.0-beta.1.tgz",
+      "integrity": "sha512-q+WQwFRBl/3uKIdB+NExfPMoDzQzdHuA+W3p9ZPfBdsNX3t3iHa3JHT6t0EYRf46NlAmFmnHaQNqHxP7u9I6LQ==",
       "requires": {
         "@sentry/browser": "6.2.1",
         "@sentry/core": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@react-navigation/drawer": "5.12.5",
     "@react-navigation/stack": "5.14.3",
     "@remobile/react-native-qrcode-local-image": "https://github.com/BlueWallet/react-native-qrcode-local-image",
-    "@sentry/react-native": "2.4.0",
+    "@sentry/react-native": "2.5.0-beta.1",
     "aez": "1.0.1",
     "amplitude-js": "7.4.4",
     "assert": "1.5.0",


### PR DESCRIPTION
added a switch in settings/general/privacy to disable tracking.
should prevent sending data to amplitude & sentry.

@marcosrdz pay attention to how I used context, I might have done it wrong 

![image](https://user-images.githubusercontent.com/1913337/117476769-21423480-af55-11eb-8b51-c3eb95f4d5ef.png)
