### PR TITLE
REF: upgrade react-native-reanimated to v2

### DIFF
--- a/android/app/src/main/java/io/bluewallet/bluewallet/MainApplication.java
+++ b/android/app/src/main/java/io/bluewallet/bluewallet/MainApplication.java
@@ -7,7 +7,9 @@ import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JSIModulePackage; // required by react-native-reanimated v2 https://docs.swmansion.com/react-native-reanimated/docs/installation/
 import com.facebook.soloader.SoLoader;
+import com.swmansion.reanimated.ReanimatedJSIModulePackage; // required by react-native-reanimated v2 https://docs.swmansion.com/react-native-reanimated/docs/installation/
 import java.lang.reflect.InvocationTargetException;
 import com.facebook.react.modules.i18nmanager.I18nUtil;
 import java.util.List;
@@ -33,6 +35,12 @@ public class MainApplication extends Application implements ReactApplication {
         @Override
         protected String getJSMainModuleName() {
           return "index";
+        }
+
+        // required by react-native-reanimated v2 https://docs.swmansion.com/react-native-reanimated/docs/installation/
+        @Override
+        protected JSIModulePackage getJSIModulePackage() {
+          return new ReanimatedJSIModulePackage();
         }
       };
 
@@ -81,4 +89,3 @@ public class MainApplication extends Application implements ReactApplication {
     }
   }
 }
- 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
+  plugins: ['react-native-reanimated/plugin'], // required by react-native-reanimated v2 https://docs.swmansion.com/react-native-reanimated/docs/installation/
 };

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -386,7 +386,7 @@ PODS:
     - React
   - RNReactNativeHapticFeedback (1.11.0):
     - React-Core
-  - RNReanimated (2.0.1):
+  - RNReanimated (2.1.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -774,7 +774,7 @@ SPEC CHECKSUMS:
   RNQuickAction: 6d404a869dc872cde841ad3147416a670d13fa93
   RNRate: 2b31dad120cd1b78e33c6034808561c386a3dddf
   RNReactNativeHapticFeedback: 653a8c126a0f5e88ce15ffe280b3ff37e1fbb285
-  RNReanimated: c5e9d841d33ed7f83861462756cec7146e73afaa
+  RNReanimated: 70f662b5232dd5d19ccff581e919a54ea73df51c
   RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
   RNSecureKeyStore: f1ad870e53806453039f650720d2845c678d89c8
   RNSentry: 1868bcfe8c69b2c3b2451439a38b3ebea0a7510f

--- a/package-lock.json
+++ b/package-lock.json
@@ -17781,9 +17781,9 @@
       }
     },
     "react-native-reanimated": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.0.1.tgz",
-      "integrity": "sha512-Wg/mEdI8xMRDQHYkgNGztJDjAcx1EFR5OMMtXrLSMmT0qzqcRWcVZgDHBN2MEAJqem/HkPAoOFutWzibwvinVg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.1.0.tgz",
+      "integrity": "sha512-tlPvvcdf+X7HGQ7g/7npBFhwMznfdk7MHUc9gUB/kp2abSscXNe/kOVKlrNEOO4DS11rNOXc+llFxVFMuNk0zA==",
       "requires": {
         "@babel/plugin-transform-object-assign": "^7.10.4",
         "fbjs": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "react-native-quick-actions": "0.3.13",
     "react-native-randombytes": "3.6.0",
     "react-native-rate": "1.2.4",
-    "react-native-reanimated": "2.0.1",
+    "react-native-reanimated": "2.1.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "2.18.1",
     "react-native-secure-key-store": "https://github.com/BlueWallet/react-native-secure-key-store#4828fd1a67d12e4c0e21eee0bee673fde75e6f9a",


### PR DESCRIPTION
On Android react-native-reanimated shows warning that to use it, you need to finish setup. So I've followed the [docs](https://docs.swmansion.com/react-native-reanimated/docs/installation/) and added what is needed to `MainApplication.java` and babel config. Warning disappeared.

In docs it says that react-native-reanimated@2 requires Hermes, but actually it supports JSC since v2.1.0