### PR TITLE
REF: storage improvements

### DIFF
--- a/BlueApp.js
+++ b/BlueApp.js
@@ -15,6 +15,7 @@ const startAndDecrypt = async retry => {
     console.log('App already has some wallets, so we are in already started state, exiting startAndDecrypt');
     return true;
   }
+  await BlueApp.migrateKeys();
   let password = false;
   if (await BlueApp.storageIsEncrypted()) {
     do {

--- a/blue_modules/BlueElectrum.js
+++ b/blue_modules/BlueElectrum.js
@@ -1,7 +1,7 @@
 /* global alert */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Alert } from 'react-native';
-import { AppStorage, LegacyWallet, SegwitBech32Wallet, SegwitP2SHWallet } from '../class';
+import { LegacyWallet, SegwitBech32Wallet, SegwitP2SHWallet } from '../class';
 import DefaultPreference from 'react-native-default-preference';
 import RNWidgetCenter from 'react-native-widget-center';
 import loc from '../loc';
@@ -11,6 +11,11 @@ const reverse = require('buffer-reverse');
 const BigNumber = require('bignumber.js');
 const torrific = require('../blue_modules/torrific');
 const Realm = require('realm');
+
+const ELECTRUM_HOST = 'electrum_host';
+const ELECTRUM_TCP_PORT = 'electrum_tcp_port';
+const ELECTRUM_SSL_PORT = 'electrum_ssl_port';
+const ELECTRUM_SERVER_HISTORY = 'electrum_server_history';
 
 let _realm;
 async function _getRealm() {
@@ -79,13 +84,13 @@ async function connectMain() {
   try {
     if (usingPeer.host.endsWith('onion')) {
       const randomPeer = await getRandomHardcodedPeer();
-      await DefaultPreference.set(AppStorage.ELECTRUM_HOST, randomPeer.host);
-      await DefaultPreference.set(AppStorage.ELECTRUM_TCP_PORT, randomPeer.tcp);
-      await DefaultPreference.set(AppStorage.ELECTRUM_SSL_PORT, randomPeer.ssl);
+      await DefaultPreference.set(ELECTRUM_HOST, randomPeer.host);
+      await DefaultPreference.set(ELECTRUM_TCP_PORT, randomPeer.tcp);
+      await DefaultPreference.set(ELECTRUM_SSL_PORT, randomPeer.ssl);
     } else {
-      await DefaultPreference.set(AppStorage.ELECTRUM_HOST, usingPeer.host);
-      await DefaultPreference.set(AppStorage.ELECTRUM_TCP_PORT, usingPeer.tcp);
-      await DefaultPreference.set(AppStorage.ELECTRUM_SSL_PORT, usingPeer.ssl);
+      await DefaultPreference.set(ELECTRUM_HOST, usingPeer.host);
+      await DefaultPreference.set(ELECTRUM_TCP_PORT, usingPeer.tcp);
+      await DefaultPreference.set(ELECTRUM_SSL_PORT, usingPeer.ssl);
     }
 
     RNWidgetCenter.reloadAllTimelines();
@@ -187,14 +192,14 @@ async function presentNetworkErrorAlert(usingPeer) {
                 text: loc._.ok,
                 style: 'destructive',
                 onPress: async () => {
-                  await AsyncStorage.setItem(AppStorage.ELECTRUM_HOST, '');
-                  await AsyncStorage.setItem(AppStorage.ELECTRUM_TCP_PORT, '');
-                  await AsyncStorage.setItem(AppStorage.ELECTRUM_SSL_PORT, '');
+                  await AsyncStorage.setItem(ELECTRUM_HOST, '');
+                  await AsyncStorage.setItem(ELECTRUM_TCP_PORT, '');
+                  await AsyncStorage.setItem(ELECTRUM_SSL_PORT, '');
                   try {
                     await DefaultPreference.setName('group.io.bluewallet.bluewallet');
-                    await DefaultPreference.clear(AppStorage.ELECTRUM_HOST);
-                    await DefaultPreference.clear(AppStorage.ELECTRUM_SSL_PORT);
-                    await DefaultPreference.clear(AppStorage.ELECTRUM_TCP_PORT);
+                    await DefaultPreference.clear(ELECTRUM_HOST);
+                    await DefaultPreference.clear(ELECTRUM_SSL_PORT);
+                    await DefaultPreference.clear(ELECTRUM_TCP_PORT);
                     RNWidgetCenter.reloadAllTimelines();
                   } catch (e) {
                     // Must be running on Android
@@ -236,9 +241,9 @@ async function getRandomHardcodedPeer() {
 }
 
 async function getSavedPeer() {
-  const host = await AsyncStorage.getItem(AppStorage.ELECTRUM_HOST);
-  const port = await AsyncStorage.getItem(AppStorage.ELECTRUM_TCP_PORT);
-  const sslPort = await AsyncStorage.getItem(AppStorage.ELECTRUM_SSL_PORT);
+  const host = await AsyncStorage.getItem(ELECTRUM_HOST);
+  const port = await AsyncStorage.getItem(ELECTRUM_TCP_PORT);
+  const sslPort = await AsyncStorage.getItem(ELECTRUM_SSL_PORT);
   return { host, tcp: port, ssl: sslPort };
 }
 
@@ -845,6 +850,10 @@ module.exports.setBatchingEnabled = () => {
 
 module.exports.hardcodedPeers = hardcodedPeers;
 module.exports.getRandomHardcodedPeer = getRandomHardcodedPeer;
+module.exports.ELECTRUM_HOST = ELECTRUM_HOST;
+module.exports.ELECTRUM_TCP_PORT = ELECTRUM_TCP_PORT;
+module.exports.ELECTRUM_SSL_PORT = ELECTRUM_SSL_PORT;
+module.exports.ELECTRUM_SERVER_HISTORY = ELECTRUM_SERVER_HISTORY;
 
 const splitIntoChunks = function (arr, chunkSize) {
   const groups = [];

--- a/blue_modules/currency.js
+++ b/blue_modules/currency.js
@@ -4,8 +4,10 @@ import RNWidgetCenter from 'react-native-widget-center';
 import * as RNLocalize from 'react-native-localize';
 import BigNumber from 'bignumber.js';
 
-import { AppStorage } from '../class';
 import { FiatUnit, getFiatRate } from '../models/fiatUnit';
+
+const PREFERRED_CURRENCY = 'preferredCurrency';
+const EXCHANGE_RATES = 'currency';
 
 let preferredFiatCurrency = FiatUnit.USD;
 const exchangeRates = {};
@@ -22,7 +24,7 @@ const STRUCT = {
  * @returns {Promise<void>}
  */
 async function setPrefferedCurrency(item) {
-  await AsyncStorage.setItem(AppStorage.PREFERRED_CURRENCY, JSON.stringify(item));
+  await AsyncStorage.setItem(PREFERRED_CURRENCY, JSON.stringify(item));
   await DefaultPreference.setName('group.io.bluewallet.bluewallet');
   await DefaultPreference.set('preferredCurrency', item.endPointKey);
   await DefaultPreference.set('preferredCurrencyLocale', item.locale.replace('-', '_'));
@@ -30,7 +32,7 @@ async function setPrefferedCurrency(item) {
 }
 
 async function getPreferredCurrency() {
-  const preferredCurrency = await JSON.parse(await AsyncStorage.getItem(AppStorage.PREFERRED_CURRENCY));
+  const preferredCurrency = await JSON.parse(await AsyncStorage.getItem(PREFERRED_CURRENCY));
   await DefaultPreference.setName('group.io.bluewallet.bluewallet');
   await DefaultPreference.set('preferredCurrency', preferredCurrency.endPointKey);
   await DefaultPreference.set('preferredCurrencyLocale', preferredCurrency.locale.replace('-', '_'));
@@ -44,7 +46,7 @@ async function updateExchangeRate() {
   }
 
   try {
-    preferredFiatCurrency = JSON.parse(await AsyncStorage.getItem(AppStorage.PREFERRED_CURRENCY));
+    preferredFiatCurrency = JSON.parse(await AsyncStorage.getItem(PREFERRED_CURRENCY));
     if (preferredFiatCurrency === null) {
       throw Error('No Preferred Fiat selected');
     }
@@ -61,15 +63,15 @@ async function updateExchangeRate() {
   try {
     rate = await getFiatRate(preferredFiatCurrency.endPointKey);
   } catch (Err) {
-    const lastSavedExchangeRate = JSON.parse(await AsyncStorage.getItem(AppStorage.EXCHANGE_RATES));
+    const lastSavedExchangeRate = JSON.parse(await AsyncStorage.getItem(EXCHANGE_RATES));
     exchangeRates['BTC_' + preferredFiatCurrency.endPointKey] = lastSavedExchangeRate['BTC_' + preferredFiatCurrency.endPointKey] * 1;
     return;
   }
 
   exchangeRates[STRUCT.LAST_UPDATED] = +new Date();
   exchangeRates['BTC_' + preferredFiatCurrency.endPointKey] = rate;
-  await AsyncStorage.setItem(AppStorage.EXCHANGE_RATES, JSON.stringify(exchangeRates));
-  await AsyncStorage.setItem(AppStorage.PREFERRED_CURRENCY, JSON.stringify(preferredFiatCurrency));
+  await AsyncStorage.setItem(EXCHANGE_RATES, JSON.stringify(exchangeRates));
+  await AsyncStorage.setItem(PREFERRED_CURRENCY, JSON.stringify(preferredFiatCurrency));
   await setPrefferedCurrency(preferredFiatCurrency);
 }
 
@@ -179,3 +181,5 @@ module.exports.btcToSatoshi = btcToSatoshi;
 module.exports.getCurrencySymbol = getCurrencySymbol;
 module.exports._setPreferredFiatCurrency = _setPreferredFiatCurrency; // export it to mock data in tests
 module.exports._setExchangeRate = _setExchangeRate; // export it to mock data in tests
+module.exports.PREFERRED_CURRENCY = PREFERRED_CURRENCY;
+module.exports.EXCHANGE_RATES = EXCHANGE_RATES;

--- a/blue_modules/storage-context.js
+++ b/blue_modules/storage-context.js
@@ -2,10 +2,11 @@
 import { useAsyncStorage } from '@react-native-async-storage/async-storage';
 import React, { createContext, useEffect, useState } from 'react';
 import { LayoutAnimation } from 'react-native';
-import { AppStorage } from '../class';
 import { FiatUnit } from '../models/fiatUnit';
+import loc from '../loc';
 const BlueApp = require('../BlueApp');
 const BlueElectrum = require('./BlueElectrum');
+const currency = require('../blue_modules/currency');
 
 const _lastTimeTriedToRefetchWallet = {}; // hashmap of timestamps we _started_ refetching some wallet
 
@@ -19,14 +20,14 @@ export const BlueStorageProvider = ({ children }) => {
   const [walletsInitialized, setWalletsInitialized] = useState(false);
   const [preferredFiatCurrency, _setPreferredFiatCurrency] = useState(FiatUnit.USD);
   const [language, _setLanguage] = useState();
-  const getPreferredCurrencyAsyncStorage = useAsyncStorage(AppStorage.PREFERRED_CURRENCY).getItem;
-  const getLanguageAsyncStorage = useAsyncStorage(AppStorage.LANG).getItem;
+  const getPreferredCurrencyAsyncStorage = useAsyncStorage(currency.PREFERRED_CURRENCY).getItem;
+  const getLanguageAsyncStorage = useAsyncStorage(loc.LANG).getItem;
   const [isHandOffUseEnabled, setIsHandOffUseEnabled] = useState(false);
   const [isDrawerListBlurred, _setIsDrawerListBlurred] = useState(false);
 
   const setIsHandOffUseEnabledAsyncStorage = value => {
     setIsHandOffUseEnabled(value);
-    return BlueApp.setItem(AppStorage.HANDOFF_STORAGE_KEY, value === true ? '1' : '');
+    return BlueApp.setIsHandoffEnabled(value);
   };
 
   const saveToDisk = async () => {
@@ -43,7 +44,7 @@ export const BlueStorageProvider = ({ children }) => {
   useEffect(() => {
     (async () => {
       try {
-        const enabledHandoff = await BlueApp.getItem(AppStorage.HANDOFF_STORAGE_KEY);
+        const enabledHandoff = await BlueApp.isHandoffEnabled();
         setIsHandOffUseEnabled(!!enabledHandoff);
       } catch (_e) {
         setIsHandOffUseEnabledAsyncStorage(false);

--- a/class/app-storage.js
+++ b/class/app-storage.js
@@ -27,14 +27,7 @@ let usedBucketNum = false;
 
 export class AppStorage {
   static FLAG_ENCRYPTED = 'data_encrypted';
-  static LANG = 'lang';
-  static EXCHANGE_RATES = 'currency';
   static LNDHUB = 'lndhub';
-  static ELECTRUM_HOST = 'electrum_host';
-  static ELECTRUM_TCP_PORT = 'electrum_tcp_port';
-  static ELECTRUM_SSL_PORT = 'electrum_ssl_port';
-  static ELECTRUM_SERVER_HISTORY = 'electrum_server_history';
-  static PREFERRED_CURRENCY = 'preferredCurrency';
   static ADVANCED_MODE_ENABLED = 'advancedmodeenabled';
   static DO_NOT_TRACK = 'donottrack';
   static HODL_HODL_API_KEY = 'HODL_HODL_API_KEY';
@@ -42,11 +35,26 @@ export class AppStorage {
   static HODL_HODL_CONTRACTS = 'HODL_HODL_CONTRACTS';
   static HANDOFF_STORAGE_KEY = 'HandOff';
 
+  static keys2migrate = [AppStorage.HANDOFF_STORAGE_KEY, AppStorage.DO_NOT_TRACK, AppStorage.ADVANCED_MODE_ENABLED];
+
   constructor() {
     /** {Array.<AbstractWallet>} */
     this.wallets = [];
     this.tx_metadata = {};
     this.cachedPassword = false;
+  }
+
+  async migrateKeys() {
+    if (!(typeof navigator !== 'undefined' && navigator.product === 'ReactNative')) return;
+    for (const key of this.constructor.keys2migrate) {
+      try {
+        const value = await RNSecureKeyStore.get(key);
+        if (value) {
+          await AsyncStorage.setItem(key, value);
+          await RNSecureKeyStore.remove(key);
+        }
+      } catch (_) {}
+    }
   }
 
   /**
@@ -645,24 +653,35 @@ export class AppStorage {
 
   isAdancedModeEnabled = async () => {
     try {
-      return !!(await this.getItem(AppStorage.ADVANCED_MODE_ENABLED));
+      return !!(await AsyncStorage.getItem(AppStorage.ADVANCED_MODE_ENABLED));
     } catch (_) {}
     return false;
   };
 
   setIsAdancedModeEnabled = async value => {
-    await this.setItem(AppStorage.ADVANCED_MODE_ENABLED, value ? '1' : '');
+    await AsyncStorage.setItem(AppStorage.ADVANCED_MODE_ENABLED, value ? '1' : '');
+  };
+
+  isHandoffEnabled = async () => {
+    try {
+      return !!(await AsyncStorage.getItem(AppStorage.HANDOFF_STORAGE_KEY));
+    } catch (_) {}
+    return false;
+  };
+
+  setIsHandoffEnabled = async value => {
+    await AsyncStorage.setItem(AppStorage.HANDOFF_STORAGE_KEY, value ? '1' : '');
   };
 
   isDoNotTrackEnabled = async () => {
     try {
-      return !!(await this.getItem(AppStorage.DO_NOT_TRACK));
+      return !!(await AsyncStorage.getItem(AppStorage.DO_NOT_TRACK));
     } catch (_) {}
     return false;
   };
 
   setDoNotTrack = async value => {
-    await this.setItem(AppStorage.DO_NOT_TRACK, value ? '1' : '');
+    await AsyncStorage.setItem(AppStorage.DO_NOT_TRACK, value ? '1' : '');
   };
 
   /**

--- a/class/biometrics.js
+++ b/class/biometrics.js
@@ -8,9 +8,10 @@ import RNSecureKeyStore from 'react-native-secure-key-store';
 import loc from '../loc';
 import { useContext } from 'react';
 import { BlueStorageContext } from '../blue_modules/storage-context';
+import * as Sentry from '@sentry/react-native';
 
 function Biometric() {
-  const { getItem, setItem, setResetOnAppUninstallTo } = useContext(BlueStorageContext);
+  const { getItem, setItem } = useContext(BlueStorageContext);
   Biometric.STORAGEKEY = 'Biometrics';
   Biometric.FaceID = 'Face ID';
   Biometric.TouchID = 'Touch ID';
@@ -42,10 +43,9 @@ function Biometric() {
     try {
       const enabledBiometrics = await getItem(Biometric.STORAGEKEY);
       return !!enabledBiometrics;
-    } catch (_e) {
-      await setItem(Biometric.STORAGEKEY, '');
-      return false;
-    }
+    } catch (_) {}
+
+    return false;
   };
 
   Biometric.isBiometricUseCapableAndEnabled = async () => {
@@ -72,10 +72,10 @@ function Biometric() {
   };
 
   Biometric.clearKeychain = async () => {
+    Sentry.captureMessage('Biometric.clearKeychain()');
     await RNSecureKeyStore.remove('data');
     await RNSecureKeyStore.remove('data_encrypted');
     await RNSecureKeyStore.remove(Biometric.STORAGEKEY);
-    await setResetOnAppUninstallTo(true);
     NavigationService.dispatch(StackActions.replace('WalletsRoot'));
   };
 

--- a/loc/index.js
+++ b/loc/index.js
@@ -6,11 +6,12 @@ import localizedFormat from 'dayjs/plugin/localizedFormat';
 import * as RNLocalize from 'react-native-localize';
 import BigNumber from 'bignumber.js';
 
-import { AppStorage } from '../class';
 import { BitcoinUnit } from '../models/bitcoinUnits';
 import { AvailableLanguages } from './languages';
 import { I18nManager } from 'react-native';
 const currency = require('../blue_modules/currency');
+
+const LANG = 'lang';
 
 dayjs.extend(relativeTime);
 dayjs.extend(localizedFormat);
@@ -158,8 +159,7 @@ const setDateTimeLocale = async () => {
 
 const setLanguageLocale = async () => {
   // finding out whether lang preference was saved
-  // For some reason using the AppStorage.LANG constant is not working. Hard coding string for now.
-  const lang = await AsyncStorage.getItem('lang');
+  const lang = await AsyncStorage.getItem(LANG);
   if (lang) {
     strings.setLanguage(lang);
     await setDateTimeLocale();
@@ -222,7 +222,7 @@ const strings = new Localization({
 });
 
 strings.saveLanguage = async lang => {
-  await AsyncStorage.setItem(AppStorage.LANG, lang);
+  await AsyncStorage.setItem(LANG, lang);
   strings.setLanguage(lang);
   await setDateTimeLocale();
 };
@@ -324,4 +324,5 @@ export function _leaveNumbersAndDots(newInputValue) {
   return newInputValue;
 }
 
+strings.LANG = LANG;
 export default strings;

--- a/screen/settings/electrumSettings.js
+++ b/screen/settings/electrumSettings.js
@@ -18,7 +18,6 @@ import RNWidgetCenter from 'react-native-widget-center';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import loc from '../../loc';
-import { AppStorage } from '../../class';
 import DeeplinkSchemaMatch from '../../class/deeplink-schema-match';
 import navigationStyle from '../../components/navigationStyle';
 import {
@@ -55,10 +54,10 @@ export default class ElectrumSettings extends Component {
   }
 
   async componentDidMount() {
-    const host = await AsyncStorage.getItem(AppStorage.ELECTRUM_HOST);
-    const port = await AsyncStorage.getItem(AppStorage.ELECTRUM_TCP_PORT);
-    const sslPort = await AsyncStorage.getItem(AppStorage.ELECTRUM_SSL_PORT);
-    const serverHistoryStr = await AsyncStorage.getItem(AppStorage.ELECTRUM_SERVER_HISTORY);
+    const host = await AsyncStorage.getItem(BlueElectrum.ELECTRUM_HOST);
+    const port = await AsyncStorage.getItem(BlueElectrum.ELECTRUM_TCP_PORT);
+    const sslPort = await AsyncStorage.getItem(BlueElectrum.ELECTRUM_SSL_PORT);
+    const serverHistoryStr = await AsyncStorage.getItem(BlueElectrum.ELECTRUM_SERVER_HISTORY);
     const serverHistory = JSON.parse(serverHistoryStr) || [];
 
     this.setState({
@@ -127,7 +126,7 @@ export default class ElectrumSettings extends Component {
 
   clearHistory = async () => {
     this.setState({ isLoading: true }, async () => {
-      await AsyncStorage.setItem(AppStorage.ELECTRUM_SERVER_HISTORY, JSON.stringify([]));
+      await AsyncStorage.setItem(BlueElectrum.ELECTRUM_SERVER_HISTORY, JSON.stringify([]));
       this.setState({
         serverHistory: [],
         isLoading: false,
@@ -157,14 +156,14 @@ export default class ElectrumSettings extends Component {
     this.setState({ isLoading: true }, async () => {
       try {
         if (!host && !port && !sslPort) {
-          await AsyncStorage.setItem(AppStorage.ELECTRUM_HOST, '');
-          await AsyncStorage.setItem(AppStorage.ELECTRUM_TCP_PORT, '');
-          await AsyncStorage.setItem(AppStorage.ELECTRUM_SSL_PORT, '');
+          await AsyncStorage.setItem(BlueElectrum.ELECTRUM_HOST, '');
+          await AsyncStorage.setItem(BlueElectrum.ELECTRUM_TCP_PORT, '');
+          await AsyncStorage.setItem(BlueElectrum.ELECTRUM_SSL_PORT, '');
           try {
             await DefaultPreference.setName('group.io.bluewallet.bluewallet');
-            await DefaultPreference.clear(AppStorage.ELECTRUM_HOST);
-            await DefaultPreference.clear(AppStorage.ELECTRUM_SSL_PORT);
-            await DefaultPreference.clear(AppStorage.ELECTRUM_TCP_PORT);
+            await DefaultPreference.clear(BlueElectrum.ELECTRUM_HOST);
+            await DefaultPreference.clear(BlueElectrum.ELECTRUM_SSL_PORT);
+            await DefaultPreference.clear(BlueElectrum.ELECTRUM_TCP_PORT);
             RNWidgetCenter.reloadAllTimelines();
           } catch (e) {
             // Must be running on Android
@@ -176,9 +175,9 @@ export default class ElectrumSettings extends Component {
           ReactNativeHapticFeedback.trigger('notificationError', { ignoreAndroidSystemSettings: false });
           alert(loc.settings.electrum_error_connect);
         } else {
-          await AsyncStorage.setItem(AppStorage.ELECTRUM_HOST, host);
-          await AsyncStorage.setItem(AppStorage.ELECTRUM_TCP_PORT, port);
-          await AsyncStorage.setItem(AppStorage.ELECTRUM_SSL_PORT, sslPort);
+          await AsyncStorage.setItem(BlueElectrum.ELECTRUM_HOST, host);
+          await AsyncStorage.setItem(BlueElectrum.ELECTRUM_TCP_PORT, port);
+          await AsyncStorage.setItem(BlueElectrum.ELECTRUM_SSL_PORT, sslPort);
 
           if (!this.serverExists({ host, port, sslPort })) {
             serverHistory.push({
@@ -186,14 +185,14 @@ export default class ElectrumSettings extends Component {
               port,
               sslPort,
             });
-            await AsyncStorage.setItem(AppStorage.ELECTRUM_SERVER_HISTORY, JSON.stringify(serverHistory));
+            await AsyncStorage.setItem(BlueElectrum.ELECTRUM_SERVER_HISTORY, JSON.stringify(serverHistory));
           }
 
           try {
             await DefaultPreference.setName('group.io.bluewallet.bluewallet');
-            await DefaultPreference.set(AppStorage.ELECTRUM_HOST, host);
-            await DefaultPreference.set(AppStorage.ELECTRUM_TCP_PORT, port);
-            await DefaultPreference.set(AppStorage.ELECTRUM_SSL_PORT, sslPort);
+            await DefaultPreference.set(BlueElectrum.ELECTRUM_HOST, host);
+            await DefaultPreference.set(BlueElectrum.ELECTRUM_TCP_PORT, port);
+            await DefaultPreference.set(BlueElectrum.ELECTRUM_SSL_PORT, sslPort);
             RNWidgetCenter.reloadAllTimelines();
           } catch (e) {
             // Must be running on Android

--- a/tests/integration/Currency.test.js
+++ b/tests/integration/Currency.test.js
@@ -1,4 +1,3 @@
-import { AppStorage } from '../../class';
 import { FiatUnit } from '../../models/fiatUnit';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 const assert = require('assert');
@@ -9,16 +8,16 @@ describe('currency', () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
     const currency = require('../../blue_modules/currency');
     await currency.startUpdater();
-    let cur = await AsyncStorage.getItem(AppStorage.EXCHANGE_RATES);
+    let cur = await AsyncStorage.getItem(currency.EXCHANGE_RATES);
     cur = JSON.parse(cur);
     assert.ok(Number.isInteger(cur[currency.STRUCT.LAST_UPDATED]));
     assert.ok(cur[currency.STRUCT.LAST_UPDATED] > 0);
     assert.ok(cur.BTC_USD > 0);
 
     // now, setting other currency as default
-    await AsyncStorage.setItem(AppStorage.PREFERRED_CURRENCY, JSON.stringify(FiatUnit.JPY));
+    await AsyncStorage.setItem(currency.PREFERRED_CURRENCY, JSON.stringify(FiatUnit.JPY));
     await currency.startUpdater();
-    cur = JSON.parse(await AsyncStorage.getItem(AppStorage.EXCHANGE_RATES));
+    cur = JSON.parse(await AsyncStorage.getItem(currency.EXCHANGE_RATES));
     assert.ok(cur.BTC_JPY > 0);
 
     // now setting with a proper setter
@@ -26,13 +25,13 @@ describe('currency', () => {
     await currency.startUpdater();
     const preferred = await currency.getPreferredCurrency();
     assert.strictEqual(preferred.endPointKey, 'EUR');
-    cur = JSON.parse(await AsyncStorage.getItem(AppStorage.EXCHANGE_RATES));
+    cur = JSON.parse(await AsyncStorage.getItem(currency.EXCHANGE_RATES));
     assert.ok(cur.BTC_EUR > 0);
 
     // test Yadio rate source
     await currency.setPrefferedCurrency(FiatUnit.ARS);
     await currency.startUpdater();
-    cur = JSON.parse(await AsyncStorage.getItem(AppStorage.EXCHANGE_RATES));
+    cur = JSON.parse(await AsyncStorage.getItem(currency.EXCHANGE_RATES));
     assert.ok(cur.BTC_ARS > 0);
 
     // test BitcoinduLiban rate source

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -9,12 +9,14 @@ jest.mock('react-native-watch-connectivity', () => {
 });
 
 jest.mock('react-native-secure-key-store', () => {
-  return {
-    setResetOnAppUninstallTo: jest.fn(),
-  };
+  return {};
 });
 
 jest.mock('@react-native-community/push-notification-ios', () => {
+  return {};
+});
+
+jest.mock('@sentry/react-native', () => {
   return {};
 });
 
@@ -96,7 +98,9 @@ jest.mock('react-native-haptic-feedback', () => ({}));
 const realmInstanceMock = {
   close: function () {},
   write: function () {},
-  objectForPrimaryKey: function () { return {}; },
+  objectForPrimaryKey: function () {
+    return {};
+  },
   objects: function () {
     const wallets = {
       filtered: function () {


### PR DESCRIPTION
long story short, we have this issue with random storage drop: https://github.com/BlueWallet/BlueWallet/issues/3177

in attempt to fix it, we will try to use less secure keystore and more asyncstorage.

we have this AppStorage singleton, which was supposed to handle all data persisnce when bw was created, but in retrospective it was a bad idea:
there were no advantages in keeping data management centralized (and all we do is simple key-value anyway), and all surrounding code turned into legacy mess.
probably a better approach is to let each piece of functionality (like a separate module like currency) to handle its data on its own.

so in this PR we are trying to achieve exactly that: 

1) some keys constants moved where they make more sense 

2) three storage keys that used to be stored in keystore migrated to asyncstorage (AppStorage.HANDOFF_STORAGE_KEY, AppStorage.DO_NOT_TRACK, AppStorage.ADVANCED_MODE_ENABLED). i wanted to add biometrics as well, but refrained due to minor security concerns.

3) experimental change in `Biometric.isBiometricUseEnabled` - @marcosrdz claims that because of that it will be possible to make app stuck in forever locked state (how, btw? disable biometrics in OS settings and then try relogin in BW..?)



PS. further refactoring of storage would be nice, but atm I'm out of ideas how to make it better.