### PR TITLE
FIX: for slip39 wallets import bech32 even if no tx found

### DIFF
--- a/class/wallet-import.js
+++ b/class/wallet-import.js
@@ -298,9 +298,7 @@ function WalletImport() {
 
         const s3 = new SLIP39SegwitBech32Wallet();
         s3.setSecret(importText);
-        if (await s3.wasEverUsed()) {
-          return WalletImport._saveWallet(s3);
-        }
+        return WalletImport._saveWallet(s3);
       }
     }
 


### PR DESCRIPTION
Disable `wallet.wasEverUsed()` check for bech32 slip39 wallets. So BW will import bech32 wallet for fresh seed.

closes #3297