### PR TITLE
FIX: Disable enable screens

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,9 @@ import './shim.js';
 import { AppRegistry } from 'react-native';
 import App from './App';
 import { BlueStorageProvider } from './blue_modules/storage-context';
+import { enableScreens } from 'react-native-screens';
 const A = require('./blue_modules/analytics');
-
+enableScreens(false)
 if (!Error.captureStackTrace) {
   // captureStackTrace is only available when debugging
   Error.captureStackTrace = () => {};


### PR DESCRIPTION
https://github.com/software-mansion/react-native-screens/issues/1017

RNScreens v3 enabled screens by default resulting in slow behavior on low end android devices. Previous versions required devs to manually enable it. Disabling for now until issue is resolved.