### PR TITLE
REF: remove assert dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "@sentry/react-native": "2.6.0",
     "aez": "1.0.1",
     "amplitude-js": "7.4.4",
-    "assert": "2.0.0",
     "base-x": "3.0.8",
     "bc-bech32": "file:blue_modules/bc-bech32",
     "bech32": "2.0.0",

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -1,5 +1,4 @@
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
+import * as bitcoin from 'bitcoinjs-lib';
 const createHash = require('create-hash');
 
 jasmine.getEnv().addReporter({
@@ -527,22 +526,22 @@ describe('BlueWallet UI Tests', () => {
     await yo('TransactionValue');
     expect(element(by.id('TransactionValue'))).toHaveText('0.0001');
     const transactionFee = await extractTextFromElementById('TransactionFee');
-    assert.ok(transactionFee.startsWith('Fee: 0.00000452 BTC'), 'Unexpected tx fee: ' + transactionFee);
+    expect(transactionFee.startsWith('Fee: 0.00000452 BTC')).toBeTruthy();
     await element(by.id('TransactionDetailsButton')).tap();
 
     let txhex = await extractTextFromElementById('TxhexInput');
 
     let transaction = bitcoin.Transaction.fromHex(txhex);
-    assert.ok(transaction.ins.length === 1 || transaction.ins.length === 2); // depending on current fees gona use either 1 or 2 inputs
-    assert.strictEqual(transaction.outs.length, 2);
-    assert.strictEqual(bitcoin.address.fromOutputScript(transaction.outs[0].script), 'bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl'); // to address
-    assert.strictEqual(transaction.outs[0].value, 10000);
+    expect(transaction.ins.length === 1 || transaction.ins.length === 2).toBeTruthy(); // depending on current fees gona use either 1 or 2 inputs
+    expect(transaction.outs.length).toBe(2);
+    expect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl'); // to address
+    expect(transaction.outs[0].value).toBe(10000);
 
     // checking fee rate:
     const totalIns = 100000; // we hardcode it since we know it in advance
     const totalOuts = transaction.outs.map(el => el.value).reduce((a, b) => a + b, 0);
-    assert.strictEqual(Math.round((totalIns - totalOuts) / (txhex.length / 2)), feeRate);
-    assert.strictEqual(transactionFee.split(' ')[1] * 100000000, totalIns - totalOuts);
+    expect(Math.round((totalIns - totalOuts) / (txhex.length / 2))).toBe(feeRate);
+    expect(transactionFee.split(' ')[1] * 100000000).toBe(totalIns - totalOuts);
 
     if (device.getPlatform() === 'ios') {
       console.warn('rest of the test is Android only, skipped');
@@ -576,8 +575,8 @@ describe('BlueWallet UI Tests', () => {
     await element(by.id('TransactionDetailsButton')).tap();
     txhex = await extractTextFromElementById('TxhexInput');
     transaction = bitcoin.Transaction.fromHex(txhex);
-    assert.strictEqual(bitcoin.address.fromOutputScript(transaction.outs[0].script), 'bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
-    assert.strictEqual(transaction.outs[0].value, 15000);
+    expect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
+    expect(transaction.outs[0].value).toBe(15000);
 
     // now, testing scanQR with just address after amount set to 1.1 USD. Denomination should not change after qrcode scan
 
@@ -607,9 +606,9 @@ describe('BlueWallet UI Tests', () => {
     await element(by.id('TransactionDetailsButton')).tap();
     txhex = await extractTextFromElementById('TxhexInput');
     transaction = bitcoin.Transaction.fromHex(txhex);
-    assert.strictEqual(bitcoin.address.fromOutputScript(transaction.outs[0].script), 'bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
-    assert.notEqual(transaction.outs[0].value, 110000000); // check that it is 1.1 USD, not 1 BTC
-    assert.ok(transaction.outs[0].value < 10000); // 1.1 USD ~ 0,00001964 sats in march 2021
+    expect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
+    expect(transaction.outs[0].value).not.toBe(110000000); // check that it is 1.1 USD, not 1 BTC
+    expect(transaction.outs[0].value < 10000).toBeTruthy(); // 1.1 USD ~ 0,00001964 sats in march 2021
 
     // now, testing units switching, and then creating tx with SATS:
 
@@ -618,10 +617,10 @@ describe('BlueWallet UI Tests', () => {
     await element(by.id('changeAmountUnitButton')).tap(); // switched to BTC
     await element(by.id('BitcoinAmountInput')).replaceText('0.00015');
     await element(by.id('changeAmountUnitButton')).tap(); // switched to sats
-    assert.strictEqual(await extractTextFromElementById('BitcoinAmountInput'), '15000');
+    expect(await extractTextFromElementById('BitcoinAmountInput')).toBe('15000');
     await element(by.id('changeAmountUnitButton')).tap(); // switched to FIAT
     await element(by.id('changeAmountUnitButton')).tap(); // switched to BTC
-    assert.strictEqual(await extractTextFromElementById('BitcoinAmountInput'), '0.00015');
+    expect(await extractTextFromElementById('BitcoinAmountInput')).toBe('0.00015');
     await element(by.id('changeAmountUnitButton')).tap(); // switched to sats
     await element(by.id('BitcoinAmountInput')).replaceText('50000');
 
@@ -634,8 +633,8 @@ describe('BlueWallet UI Tests', () => {
     await element(by.id('TransactionDetailsButton')).tap();
     txhex = await extractTextFromElementById('TxhexInput');
     transaction = bitcoin.Transaction.fromHex(txhex);
-    assert.strictEqual(transaction.outs.length, 2);
-    assert.strictEqual(transaction.outs[0].value, 50000);
+    expect(transaction.outs.length).toBe(2);
+    expect(transaction.outs[0].value).toBe(50000);
 
     // now, testing send many feature
 
@@ -677,11 +676,11 @@ describe('BlueWallet UI Tests', () => {
     await element(by.id('TransactionDetailsButton')).tap();
     txhex = await extractTextFromElementById('TxhexInput');
     transaction = bitcoin.Transaction.fromHex(txhex);
-    assert.strictEqual(transaction.outs.length, 3);
-    assert.strictEqual(bitcoin.address.fromOutputScript(transaction.outs[0].script), 'bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
-    assert.strictEqual(transaction.outs[0].value, 50000);
-    assert.strictEqual(bitcoin.address.fromOutputScript(transaction.outs[1].script), 'bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
-    assert.strictEqual(transaction.outs[1].value, 30000);
+    expect(transaction.outs.length).toBe(3);
+    expect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
+    expect(transaction.outs[0].value).toBe(50000);
+    expect(bitcoin.address.fromOutputScript(transaction.outs[1].script)).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
+    expect(transaction.outs[1].value).toBe(30000);
 
     // now, testing sendMAX feature:
 
@@ -712,8 +711,8 @@ describe('BlueWallet UI Tests', () => {
     await element(by.id('TransactionDetailsButton')).tap();
     txhex = await extractTextFromElementById('TxhexInput');
     transaction = bitcoin.Transaction.fromHex(txhex);
-    assert.strictEqual(transaction.outs.length, 1, 'should be single output, no change');
-    assert.ok(transaction.outs[0].value > 100000);
+    expect(transaction.outs.length).toBe(1);
+    expect(transaction.outs[0].value > 100000).toBeTruthy();
 
     // add second output with amount
     await device.pressBack();
@@ -733,11 +732,11 @@ describe('BlueWallet UI Tests', () => {
     await element(by.id('TransactionDetailsButton')).tap();
     txhex = await extractTextFromElementById('TxhexInput');
     transaction = bitcoin.Transaction.fromHex(txhex);
-    assert.strictEqual(transaction.outs.length, 2, 'should be single output, no change');
-    assert.strictEqual(bitcoin.address.fromOutputScript(transaction.outs[0].script), 'bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
-    assert.ok(transaction.outs[0].value > 50000);
-    assert.strictEqual(bitcoin.address.fromOutputScript(transaction.outs[1].script), 'bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
-    assert.strictEqual(transaction.outs[1].value, 10000);
+    expect(transaction.outs.length).toBe(2);
+    expect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
+    expect(transaction.outs[0].value > 50000).toBeTruthy();
+    expect(bitcoin.address.fromOutputScript(transaction.outs[1].script)).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
+    expect(transaction.outs[1].value).toBe(10000);
 
     // now, testing cosign psbt:
 
@@ -1035,10 +1034,10 @@ describe('BlueWallet UI Tests', () => {
     const txhex = await extractTextFromElementById('TxhexInput');
 
     const transaction = bitcoin.Transaction.fromHex(txhex);
-    assert.ok(transaction.ins.length === 1 || transaction.ins.length === 2); // depending on current fees gona use either 1 or 2 inputs
-    assert.strictEqual(transaction.outs.length, 2);
-    assert.strictEqual(bitcoin.address.fromOutputScript(transaction.outs[0].script), 'bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl'); // to address
-    assert.strictEqual(transaction.outs[0].value, 50000);
+    expect(transaction.ins.length === 1 || transaction.ins.length === 2).toBeTruthy(); // depending on current fees gona use either 1 or 2 inputs
+    expect(transaction.outs.length).toBe(2);
+    expect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl'); // to address
+    expect(transaction.outs[0].value).toBe(50000);
 
     process.env.TRAVIS && require('fs').writeFileSync(lockFile, '1');
   });
@@ -1110,11 +1109,11 @@ describe('BlueWallet UI Tests', () => {
 
     const psbthex1 = await extractTextFromElementById('PSBTHex');
     const psbt1 = bitcoin.Psbt.fromHex(psbthex1);
-    assert.strictEqual(psbt1.txOutputs.length, 1);
-    assert.strictEqual(psbt1.txOutputs[0].address, 'bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
-    assert.strictEqual(psbt1.txOutputs[0].value, 99808);
-    assert.strictEqual(psbt1.data.inputs.length, 1);
-    assert.strictEqual(psbt1.data.inputs[0].witnessUtxo.value, 100000);
+    expect(psbt1.txOutputs.length).toBe(1);
+    expect(psbt1.txOutputs[0].address).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
+    expect(psbt1.txOutputs[0].value).toBe(99808);
+    expect(psbt1.data.inputs.length).toBe(1);
+    expect(psbt1.data.inputs[0].witnessUtxo.value).toBe(100000);
 
     // back to wallet screen
     await device.pressBack();
@@ -1137,11 +1136,11 @@ describe('BlueWallet UI Tests', () => {
 
     const psbthex2 = await extractTextFromElementById('PSBTHex');
     const psbt2 = bitcoin.Psbt.fromHex(psbthex2);
-    assert.strictEqual(psbt2.txOutputs.length, 1);
-    assert.strictEqual(psbt2.txOutputs[0].address, 'bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
-    assert.strictEqual(psbt2.txOutputs[0].value, 5334);
-    assert.strictEqual(psbt2.data.inputs.length, 1);
-    assert.strictEqual(psbt2.data.inputs[0].witnessUtxo.value, 5526);
+    expect(psbt2.txOutputs.length).toBe(1);
+    expect(psbt2.txOutputs[0].address).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
+    expect(psbt2.txOutputs[0].value).toBe(5334);
+    expect(psbt2.data.inputs.length).toBe(1);
+    expect(psbt2.data.inputs[0].witnessUtxo.value).toBe(5526);
 
     process.env.TRAVIS && require('fs').writeFileSync(lockFile, '1');
   });

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -618,10 +618,10 @@ describe('BlueWallet UI Tests', () => {
     await element(by.id('changeAmountUnitButton')).tap(); // switched to BTC
     await element(by.id('BitcoinAmountInput')).replaceText('0.00015');
     await element(by.id('changeAmountUnitButton')).tap(); // switched to sats
-    expect(await extractTextFromElementById('BitcoinAmountInput')).toBe('15000');
+    jestExpect(await extractTextFromElementById('BitcoinAmountInput')).toBe('15000');
     await element(by.id('changeAmountUnitButton')).tap(); // switched to FIAT
     await element(by.id('changeAmountUnitButton')).tap(); // switched to BTC
-    expect(await extractTextFromElementById('BitcoinAmountInput')).toBe('0.00015');
+    jestExpect(await extractTextFromElementById('BitcoinAmountInput')).toBe('0.00015');
     await element(by.id('changeAmountUnitButton')).tap(); // switched to sats
     await element(by.id('BitcoinAmountInput')).replaceText('50000');
 

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -1,4 +1,5 @@
 import * as bitcoin from 'bitcoinjs-lib';
+import jestExpect from 'expect'; // detox patches jest expect, so we need original to check numbers, strings and etc
 const createHash = require('create-hash');
 
 jasmine.getEnv().addReporter({
@@ -526,22 +527,22 @@ describe('BlueWallet UI Tests', () => {
     await yo('TransactionValue');
     expect(element(by.id('TransactionValue'))).toHaveText('0.0001');
     const transactionFee = await extractTextFromElementById('TransactionFee');
-    expect(transactionFee.startsWith('Fee: 0.00000452 BTC')).toBeTruthy();
+    jestExpect(transactionFee.startsWith('Fee: 0.00000452 BTC')).toBeTruthy();
     await element(by.id('TransactionDetailsButton')).tap();
 
     let txhex = await extractTextFromElementById('TxhexInput');
 
     let transaction = bitcoin.Transaction.fromHex(txhex);
-    expect(transaction.ins.length === 1 || transaction.ins.length === 2).toBeTruthy(); // depending on current fees gona use either 1 or 2 inputs
-    expect(transaction.outs.length).toBe(2);
-    expect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl'); // to address
-    expect(transaction.outs[0].value).toBe(10000);
+    jestExpect(transaction.ins.length === 1 || transaction.ins.length === 2).toBeTruthy(); // depending on current fees gona use either 1 or 2 inputs
+    jestExpect(transaction.outs.length).toBe(2);
+    jestExpect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl'); // to address
+    jestExpect(transaction.outs[0].value).toBe(10000);
 
     // checking fee rate:
     const totalIns = 100000; // we hardcode it since we know it in advance
     const totalOuts = transaction.outs.map(el => el.value).reduce((a, b) => a + b, 0);
-    expect(Math.round((totalIns - totalOuts) / (txhex.length / 2))).toBe(feeRate);
-    expect(transactionFee.split(' ')[1] * 100000000).toBe(totalIns - totalOuts);
+    jestExpect(Math.round((totalIns - totalOuts) / (txhex.length / 2))).toBe(feeRate);
+    jestExpect(transactionFee.split(' ')[1] * 100000000).toBe(totalIns - totalOuts);
 
     if (device.getPlatform() === 'ios') {
       console.warn('rest of the test is Android only, skipped');
@@ -575,8 +576,8 @@ describe('BlueWallet UI Tests', () => {
     await element(by.id('TransactionDetailsButton')).tap();
     txhex = await extractTextFromElementById('TxhexInput');
     transaction = bitcoin.Transaction.fromHex(txhex);
-    expect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
-    expect(transaction.outs[0].value).toBe(15000);
+    jestExpect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
+    jestExpect(transaction.outs[0].value).toBe(15000);
 
     // now, testing scanQR with just address after amount set to 1.1 USD. Denomination should not change after qrcode scan
 
@@ -606,9 +607,9 @@ describe('BlueWallet UI Tests', () => {
     await element(by.id('TransactionDetailsButton')).tap();
     txhex = await extractTextFromElementById('TxhexInput');
     transaction = bitcoin.Transaction.fromHex(txhex);
-    expect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
-    expect(transaction.outs[0].value).not.toBe(110000000); // check that it is 1.1 USD, not 1 BTC
-    expect(transaction.outs[0].value < 10000).toBeTruthy(); // 1.1 USD ~ 0,00001964 sats in march 2021
+    jestExpect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
+    jestExpect(transaction.outs[0].value).not.toBe(110000000); // check that it is 1.1 USD, not 1 BTC
+    jestExpect(transaction.outs[0].value < 10000).toBeTruthy(); // 1.1 USD ~ 0,00001964 sats in march 2021
 
     // now, testing units switching, and then creating tx with SATS:
 
@@ -633,8 +634,8 @@ describe('BlueWallet UI Tests', () => {
     await element(by.id('TransactionDetailsButton')).tap();
     txhex = await extractTextFromElementById('TxhexInput');
     transaction = bitcoin.Transaction.fromHex(txhex);
-    expect(transaction.outs.length).toBe(2);
-    expect(transaction.outs[0].value).toBe(50000);
+    jestExpect(transaction.outs.length).toBe(2);
+    jestExpect(transaction.outs[0].value).toBe(50000);
 
     // now, testing send many feature
 
@@ -676,11 +677,11 @@ describe('BlueWallet UI Tests', () => {
     await element(by.id('TransactionDetailsButton')).tap();
     txhex = await extractTextFromElementById('TxhexInput');
     transaction = bitcoin.Transaction.fromHex(txhex);
-    expect(transaction.outs.length).toBe(3);
-    expect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
-    expect(transaction.outs[0].value).toBe(50000);
-    expect(bitcoin.address.fromOutputScript(transaction.outs[1].script)).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
-    expect(transaction.outs[1].value).toBe(30000);
+    jestExpect(transaction.outs.length).toBe(3);
+    jestExpect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
+    jestExpect(transaction.outs[0].value).toBe(50000);
+    jestExpect(bitcoin.address.fromOutputScript(transaction.outs[1].script)).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
+    jestExpect(transaction.outs[1].value).toBe(30000);
 
     // now, testing sendMAX feature:
 
@@ -711,8 +712,8 @@ describe('BlueWallet UI Tests', () => {
     await element(by.id('TransactionDetailsButton')).tap();
     txhex = await extractTextFromElementById('TxhexInput');
     transaction = bitcoin.Transaction.fromHex(txhex);
-    expect(transaction.outs.length).toBe(1);
-    expect(transaction.outs[0].value > 100000).toBeTruthy();
+    jestExpect(transaction.outs.length).toBe(1);
+    jestExpect(transaction.outs[0].value > 100000).toBeTruthy();
 
     // add second output with amount
     await device.pressBack();
@@ -732,11 +733,11 @@ describe('BlueWallet UI Tests', () => {
     await element(by.id('TransactionDetailsButton')).tap();
     txhex = await extractTextFromElementById('TxhexInput');
     transaction = bitcoin.Transaction.fromHex(txhex);
-    expect(transaction.outs.length).toBe(2);
-    expect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
-    expect(transaction.outs[0].value > 50000).toBeTruthy();
-    expect(bitcoin.address.fromOutputScript(transaction.outs[1].script)).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
-    expect(transaction.outs[1].value).toBe(10000);
+    jestExpect(transaction.outs.length).toBe(2);
+    jestExpect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
+    jestExpect(transaction.outs[0].value > 50000).toBeTruthy();
+    jestExpect(bitcoin.address.fromOutputScript(transaction.outs[1].script)).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
+    jestExpect(transaction.outs[1].value).toBe(10000);
 
     // now, testing cosign psbt:
 
@@ -1034,10 +1035,10 @@ describe('BlueWallet UI Tests', () => {
     const txhex = await extractTextFromElementById('TxhexInput');
 
     const transaction = bitcoin.Transaction.fromHex(txhex);
-    expect(transaction.ins.length === 1 || transaction.ins.length === 2).toBeTruthy(); // depending on current fees gona use either 1 or 2 inputs
-    expect(transaction.outs.length).toBe(2);
-    expect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl'); // to address
-    expect(transaction.outs[0].value).toBe(50000);
+    jestExpect(transaction.ins.length === 1 || transaction.ins.length === 2).toBeTruthy(); // depending on current fees gona use either 1 or 2 inputs
+    jestExpect(transaction.outs.length).toBe(2);
+    jestExpect(bitcoin.address.fromOutputScript(transaction.outs[0].script)).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl'); // to address
+    jestExpect(transaction.outs[0].value).toBe(50000);
 
     process.env.TRAVIS && require('fs').writeFileSync(lockFile, '1');
   });
@@ -1109,11 +1110,11 @@ describe('BlueWallet UI Tests', () => {
 
     const psbthex1 = await extractTextFromElementById('PSBTHex');
     const psbt1 = bitcoin.Psbt.fromHex(psbthex1);
-    expect(psbt1.txOutputs.length).toBe(1);
-    expect(psbt1.txOutputs[0].address).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
-    expect(psbt1.txOutputs[0].value).toBe(99808);
-    expect(psbt1.data.inputs.length).toBe(1);
-    expect(psbt1.data.inputs[0].witnessUtxo.value).toBe(100000);
+    jestExpect(psbt1.txOutputs.length).toBe(1);
+    jestExpect(psbt1.txOutputs[0].address).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
+    jestExpect(psbt1.txOutputs[0].value).toBe(99808);
+    jestExpect(psbt1.data.inputs.length).toBe(1);
+    jestExpect(psbt1.data.inputs[0].witnessUtxo.value).toBe(100000);
 
     // back to wallet screen
     await device.pressBack();
@@ -1136,11 +1137,11 @@ describe('BlueWallet UI Tests', () => {
 
     const psbthex2 = await extractTextFromElementById('PSBTHex');
     const psbt2 = bitcoin.Psbt.fromHex(psbthex2);
-    expect(psbt2.txOutputs.length).toBe(1);
-    expect(psbt2.txOutputs[0].address).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
-    expect(psbt2.txOutputs[0].value).toBe(5334);
-    expect(psbt2.data.inputs.length).toBe(1);
-    expect(psbt2.data.inputs[0].witnessUtxo.value).toBe(5526);
+    jestExpect(psbt2.txOutputs.length).toBe(1);
+    jestExpect(psbt2.txOutputs[0].address).toBe('bc1q063ctu6jhe5k4v8ka99qac8rcm2tzjjnuktyrl');
+    jestExpect(psbt2.txOutputs[0].value).toBe(5334);
+    jestExpect(psbt2.data.inputs.length).toBe(1);
+    jestExpect(psbt2.data.inputs[0].witnessUtxo.value).toBe(5526);
 
     process.env.TRAVIS && require('fs').writeFileSync(lockFile, '1');
   });

--- a/tests/integration/App.test.js
+++ b/tests/integration/App.test.js
@@ -3,7 +3,7 @@ import TestRenderer from 'react-test-renderer';
 import Settings from '../../screen/settings/settings';
 import Selftest from '../../screen/selftest';
 import { BlueHeader } from '../../BlueComponents';
-const assert = require('assert');
+
 jest.mock('react-native-qrcode-svg', () => 'Video');
 jest.useFakeTimers();
 
@@ -47,5 +47,5 @@ it('Selftest work', () => {
     // console.log(text);
   }
 
-  assert.ok(okFound, 'OK not found. Got: ' + allTests.join('; '));
+  expect(okFound).toBeTruthy();
 });

--- a/tests/integration/BlueElectrum.test.js
+++ b/tests/integration/BlueElectrum.test.js
@@ -1,7 +1,6 @@
 global.net = require('net');
 global.tls = require('tls');
 const BlueElectrum = require('../../blue_modules/BlueElectrum');
-const assert = require('assert');
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 150 * 1000;
 
 afterAll(() => {
@@ -22,7 +21,7 @@ beforeAll(async () => {
 
 describe('BlueElectrum', () => {
   it('ElectrumClient can estimate fees from histogram', async () => {
-    assert.strictEqual(
+    expect(
       BlueElectrum.calcEstimateFeeFromFeeHistorgam(1, [
         [96, 105086],
         [83, 124591],
@@ -42,9 +41,8 @@ describe('BlueElectrum', () => {
         [2, 590559],
         [1, 1648473],
       ]),
-      22,
-    );
-    assert.strictEqual(
+    ).toBe(22);
+    expect(
       BlueElectrum.calcEstimateFeeFromFeeHistorgam(18, [
         [96, 105086],
         [83, 124591],
@@ -64,9 +62,8 @@ describe('BlueElectrum', () => {
         [2, 590559],
         [1, 1648473],
       ]),
-      4,
-    );
-    assert.strictEqual(
+    ).toBe(4);
+    expect(
       BlueElectrum.calcEstimateFeeFromFeeHistorgam(144, [
         [96, 105086],
         [83, 124591],
@@ -86,73 +83,72 @@ describe('BlueElectrum', () => {
         [2, 590559],
         [1, 1648473],
       ]),
-      4,
-    );
+    ).toBe(4);
   });
 
   it('ElectrumClient can test connection', async () => {
-    assert.ok(!(await BlueElectrum.testConnection('electrum1.bluewallet.io', 444, false)));
-    assert.ok(!(await BlueElectrum.testConnection('electrum1.bluewallet.io', false, 444)));
-    assert.ok(!(await BlueElectrum.testConnection('ya.ru', 444, false)));
-    assert.ok(!(await BlueElectrum.testConnection('google.com', false, 80)));
-    assert.ok(!(await BlueElectrum.testConnection('google.com', 80, false)));
-    assert.ok(!(await BlueElectrum.testConnection('google.com', false, 443)));
-    assert.ok(!(await BlueElectrum.testConnection('google.com', 443, false)));
-    assert.ok(!(await BlueElectrum.testConnection('joyreactor.cc', false, 443)));
-    assert.ok(!(await BlueElectrum.testConnection('joyreactor.cc', 443, false)));
-    assert.ok(!(await BlueElectrum.testConnection('joyreactor.cc', 80, false)));
-    assert.ok(!(await BlueElectrum.testConnection('joyreactor.cc', false, 80)));
+    expect(!(await BlueElectrum.testConnection('electrum1.bluewallet.io', 444, false))).toBeTruthy();
+    expect(!(await BlueElectrum.testConnection('electrum1.bluewallet.io', false, 444))).toBeTruthy();
+    expect(!(await BlueElectrum.testConnection('ya.ru', 444, false))).toBeTruthy();
+    expect(!(await BlueElectrum.testConnection('google.com', false, 80))).toBeTruthy();
+    expect(!(await BlueElectrum.testConnection('google.com', 80, false))).toBeTruthy();
+    expect(!(await BlueElectrum.testConnection('google.com', false, 443))).toBeTruthy();
+    expect(!(await BlueElectrum.testConnection('google.com', 443, false))).toBeTruthy();
+    expect(!(await BlueElectrum.testConnection('joyreactor.cc', false, 443))).toBeTruthy();
+    expect(!(await BlueElectrum.testConnection('joyreactor.cc', 443, false))).toBeTruthy();
+    expect(!(await BlueElectrum.testConnection('joyreactor.cc', 80, false))).toBeTruthy();
+    expect(!(await BlueElectrum.testConnection('joyreactor.cc', false, 80))).toBeTruthy();
 
-    assert.ok(await BlueElectrum.testConnection('electrum1.bluewallet.io', '50001'));
-    assert.ok(await BlueElectrum.testConnection('electrum1.bluewallet.io', false, 443));
+    expect(await BlueElectrum.testConnection('electrum1.bluewallet.io', '50001')).toBeTruthy();
+    expect(await BlueElectrum.testConnection('electrum1.bluewallet.io', false, 443)).toBeTruthy();
   });
 
   it('ElectrumClient can estimate fees', async () => {
-    assert.ok((await BlueElectrum.estimateFee(1)) > 1);
+    expect((await BlueElectrum.estimateFee(1)) > 1).toBeTruthy();
     const fees = await BlueElectrum.estimateFees();
-    assert.ok(fees.fast > 0);
-    assert.ok(fees.medium > 0);
-    assert.ok(fees.slow > 0);
+    expect(fees.fast > 0).toBeTruthy();
+    expect(fees.medium > 0).toBeTruthy();
+    expect(fees.slow > 0).toBeTruthy();
   });
 
   it('ElectrumClient can request server features', async () => {
     const features = await BlueElectrum.serverFeatures();
     // console.warn({features});
-    assert.ok(features.server_version);
-    assert.ok(features.protocol_min);
-    assert.ok(features.protocol_max);
+    expect(features.server_version).toBeTruthy();
+    expect(features.protocol_min).toBeTruthy();
+    expect(features.protocol_max).toBeTruthy();
   });
 
   it('BlueElectrum can do getBalanceByAddress()', async function () {
     const address = '3GCvDBAktgQQtsbN6x5DYiQCMmgZ9Yk8BK';
     const balance = await BlueElectrum.getBalanceByAddress(address);
-    assert.strictEqual(balance.confirmed, 51432);
-    assert.strictEqual(balance.unconfirmed, 0);
-    assert.strictEqual(balance.addr, address);
+    expect(balance.confirmed).toBe(51432);
+    expect(balance.unconfirmed).toBe(0);
+    expect(balance.addr).toBe(address);
   });
 
   it('BlueElectrum can do getTransactionsByAddress()', async function () {
     const txs = await BlueElectrum.getTransactionsByAddress('bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
-    assert.strictEqual(txs.length, 1);
-    assert.strictEqual(txs[0].tx_hash, 'ad00a92409d8982a1d7f877056dbed0c4337d2ebab70b30463e2802279fb936d');
-    assert.strictEqual(txs[0].height, 563077);
+    expect(txs.length).toBe(1);
+    expect(txs[0].tx_hash).toBe('ad00a92409d8982a1d7f877056dbed0c4337d2ebab70b30463e2802279fb936d');
+    expect(txs[0].height).toBe(563077);
   });
 
   it('BlueElectrum can do getTransactionsFullByAddress()', async function () {
     const txs = await BlueElectrum.getTransactionsFullByAddress('bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
     for (const tx of txs) {
-      assert.ok(tx.address === 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
-      assert.ok(tx.txid);
-      assert.ok(tx.confirmations);
-      assert.ok(!tx.vin);
-      assert.ok(!tx.vout);
-      assert.ok(tx.inputs);
-      assert.ok(tx.inputs[0].addresses.length > 0);
-      assert.ok(tx.inputs[0].value > 0);
-      assert.ok(tx.outputs);
-      assert.ok(tx.outputs[0].value > 0);
-      assert.ok(tx.outputs[0].scriptPubKey);
-      assert.ok(tx.outputs[0].addresses.length > 0);
+      expect(tx.address === 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh').toBeTruthy();
+      expect(tx.txid).toBeTruthy();
+      expect(tx.confirmations).toBeTruthy();
+      expect(!tx.vin).toBeTruthy();
+      expect(!tx.vout).toBeTruthy();
+      expect(tx.inputs).toBeTruthy();
+      expect(tx.inputs[0].addresses.length > 0).toBeTruthy();
+      expect(tx.inputs[0].value > 0).toBeTruthy();
+      expect(tx.outputs).toBeTruthy();
+      expect(tx.outputs[0].value > 0).toBeTruthy();
+      expect(tx.outputs[0].scriptPubKey).toBeTruthy();
+      expect(tx.outputs[0].addresses.length > 0).toBeTruthy();
     }
   });
 
@@ -166,18 +162,18 @@ describe('BlueElectrum', () => {
       'bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy',
     ]);
 
-    assert.strictEqual(balances.balance, 200000 + 51432);
-    assert.strictEqual(balances.unconfirmed_balance, 0);
-    assert.strictEqual(balances.addresses.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh.confirmed, 50000);
-    assert.strictEqual(balances.addresses.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh.unconfirmed, 0);
-    assert.strictEqual(balances.addresses.bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p.confirmed, 50000);
-    assert.strictEqual(balances.addresses.bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p.unconfirmed, 0);
-    assert.strictEqual(balances.addresses.bc1qwp58x4c9e5cplsnw5096qzdkae036ug7a34x3r.confirmed, 50000);
-    assert.strictEqual(balances.addresses.bc1qwp58x4c9e5cplsnw5096qzdkae036ug7a34x3r.unconfirmed, 0);
-    assert.strictEqual(balances.addresses.bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy.confirmed, 50000);
-    assert.strictEqual(balances.addresses.bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy.unconfirmed, 0);
-    assert.strictEqual(balances.addresses['3GCvDBAktgQQtsbN6x5DYiQCMmgZ9Yk8BK'].confirmed, 51432);
-    assert.strictEqual(balances.addresses['3GCvDBAktgQQtsbN6x5DYiQCMmgZ9Yk8BK'].unconfirmed, 0);
+    expect(balances.balance).toBe(200000 + 51432);
+    expect(balances.unconfirmed_balance).toBe(0);
+    expect(balances.addresses.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh.confirmed).toBe(50000);
+    expect(balances.addresses.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh.unconfirmed).toBe(0);
+    expect(balances.addresses.bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p.confirmed).toBe(50000);
+    expect(balances.addresses.bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p.unconfirmed).toBe(0);
+    expect(balances.addresses.bc1qwp58x4c9e5cplsnw5096qzdkae036ug7a34x3r.confirmed).toBe(50000);
+    expect(balances.addresses.bc1qwp58x4c9e5cplsnw5096qzdkae036ug7a34x3r.unconfirmed).toBe(0);
+    expect(balances.addresses.bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy.confirmed).toBe(50000);
+    expect(balances.addresses.bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy.unconfirmed).toBe(0);
+    expect(balances.addresses['3GCvDBAktgQQtsbN6x5DYiQCMmgZ9Yk8BK'].confirmed).toBe(51432);
+    expect(balances.addresses['3GCvDBAktgQQtsbN6x5DYiQCMmgZ9Yk8BK'].unconfirmed).toBe(0);
     if (diableBatching) BlueElectrum.setBatchingEnabled();
   });
 
@@ -192,14 +188,13 @@ describe('BlueElectrum', () => {
       3,
     );
 
-    assert.strictEqual(Object.keys(utxos).length, 4);
-    assert.strictEqual(
-      utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].txId,
+    expect(Object.keys(utxos).length).toBe(4);
+    expect(utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].txId).toBe(
       'ad00a92409d8982a1d7f877056dbed0c4337d2ebab70b30463e2802279fb936d',
     );
-    assert.strictEqual(utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].vout, 1);
-    assert.strictEqual(utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].value, 50000);
-    assert.strictEqual(utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].address, 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
+    expect(utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].vout).toBe(1);
+    expect(utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].value).toBe(50000);
+    expect(utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].address).toBe('bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
   });
 
   it.each([false, true])('ElectrumClient can do multiGetHistoryByAddress(), disableBatching=%p', async disableBatching => {
@@ -215,15 +210,15 @@ describe('BlueElectrum', () => {
       3,
     );
 
-    assert.ok(
+    expect(
       histories.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].tx_hash ===
         'ad00a92409d8982a1d7f877056dbed0c4337d2ebab70b30463e2802279fb936d',
-    );
-    assert.ok(
+    ).toBeTruthy();
+    expect(
       histories.bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy[0].tx_hash ===
         '5e2fa84148a7389537434b3ad12fcae71ed43ce5fb0f016a7f154a9b99a973df',
-    );
-    assert.ok(Object.keys(histories).length === 4);
+    ).toBeTruthy();
+    expect(Object.keys(histories).length === 4).toBeTruthy();
     if (disableBatching) BlueElectrum.setBatchingEnabled();
   });
 
@@ -240,19 +235,19 @@ describe('BlueElectrum', () => {
       3,
     );
 
-    assert.ok(
+    expect(
       txdatas.ad00a92409d8982a1d7f877056dbed0c4337d2ebab70b30463e2802279fb936d.txid ===
         'ad00a92409d8982a1d7f877056dbed0c4337d2ebab70b30463e2802279fb936d',
-    );
-    assert.ok(
+    ).toBeTruthy();
+    expect(
       txdatas['5e2fa84148a7389537434b3ad12fcae71ed43ce5fb0f016a7f154a9b99a973df'].txid ===
         '5e2fa84148a7389537434b3ad12fcae71ed43ce5fb0f016a7f154a9b99a973df',
-    );
-    assert.ok(txdatas['5e2fa84148a7389537434b3ad12fcae71ed43ce5fb0f016a7f154a9b99a973df'].size);
-    assert.ok(txdatas['5e2fa84148a7389537434b3ad12fcae71ed43ce5fb0f016a7f154a9b99a973df'].vin);
-    assert.ok(txdatas['5e2fa84148a7389537434b3ad12fcae71ed43ce5fb0f016a7f154a9b99a973df'].vout);
-    assert.ok(txdatas['5e2fa84148a7389537434b3ad12fcae71ed43ce5fb0f016a7f154a9b99a973df'].blocktime);
-    assert.ok(Object.keys(txdatas).length === 4);
+    ).toBeTruthy();
+    expect(txdatas['5e2fa84148a7389537434b3ad12fcae71ed43ce5fb0f016a7f154a9b99a973df'].size).toBeTruthy();
+    expect(txdatas['5e2fa84148a7389537434b3ad12fcae71ed43ce5fb0f016a7f154a9b99a973df'].vin).toBeTruthy();
+    expect(txdatas['5e2fa84148a7389537434b3ad12fcae71ed43ce5fb0f016a7f154a9b99a973df'].vout).toBeTruthy();
+    expect(txdatas['5e2fa84148a7389537434b3ad12fcae71ed43ce5fb0f016a7f154a9b99a973df'].blocktime).toBeTruthy();
+    expect(Object.keys(txdatas).length === 4).toBeTruthy();
     if (disableBatching) BlueElectrum.setBatchingEnabled();
   });
 
@@ -260,7 +255,7 @@ describe('BlueElectrum', () => {
     // eslint-disable-next-line
     let vinTxids = ["fb083ca5fb98451314836bbf31d08bf658deddcc8947d76eefe44b5aa49f3a48","5f0f4ac816af5717f6e049454ef698c5d46b2303b1622a17b42eed0d914ea412","8f58af45a9375ed2516237e6910186f4c9c5655a873396e71721057bdd68b3f2","e3cca3df55a880adbe639955c68772d2c491b36e28368380241ac096d9967095","5aef653da43618151ea24ed13b26e67415a397212a60dbb3609a67ba1c01373b","b67c9ce40020584b82085f4093d066c2759542d9aa612bd1cc2e561548e2f9bb","28f29df4660afa58dd6e0f9c31d3e3c204b575029c4b429dbab7da834748f097","147aa266b25fb24bfd7f2e66a1d8eeaa5086c35922c59a36a7a7c4e6a7805d5d","40f00b01d2173c46fc1b4f462132f183beb368bd43df7b88869a8bb7a8bb3b5f","b67c9ce40020584b82085f4093d066c2759542d9aa612bd1cc2e561548e2f9bb","147aa266b25fb24bfd7f2e66a1d8eeaa5086c35922c59a36a7a7c4e6a7805d5d","ba4a6c71c3b3d738609526693bdf87ed5b441f3546d70a2a83128cf6645c10dd","b1b7410fb84def2a3fa0ba54e587e3ce373c4f6e1972b5a7044c804e53101131","a4a0790f7d00ad7da97e349062cff61da12bc2b1ee06223a41d4960621ad6781","b1b7410fb84def2a3fa0ba54e587e3ce373c4f6e1972b5a7044c804e53101131","15e499177b871ac205bf509e1abd81c29a72475661957ea82db69f4afde6cc3f","6702bf9dc679c9086d0cb3f43c10d48bb200e1b29d73b4b4a399bd3eae31f4d0","51c07c5c882b49931d18adf2f62afed25db53ef4264b1f3144152b6c4dfeda1c","38eba464479c79a230e0256b7e9cc9b9cc8539b9a7297bc9961046df29d63b4a","5d29eef47330797e9b37cf0d57e48a871a6e249a0102e4744ec9d30613b054b8","3af7c1fa064a2c74e0d34972895daba4b78f32eae596774bb4bb35d44cf069c1","cc5485827920ea5de1375c9806a1b6f7db1f87f2e4074481778d1e44183b3cf6","38eba464479c79a230e0256b7e9cc9b9cc8539b9a7297bc9961046df29d63b4a","217b99f47c1a05076b68e98cf65b08df8aa485c28c74e43a0ab5a4aa98a89fa0","fb2b8dcb2997c331bd8d9f4d611293874bde116184ef38dfd5a0d5745f9d475d","2ef35d16748d56d4ec19fb458bc0147e85dd1d78e25f71f0ddd71ba22f0f49ec","05b4009d2ec7c6472a10d652efdbd7e4fa72a2e2448287e386c4d68864ba75af","cd801bc012c361fd6be0bc5b440c71d656d2fa14af90af1f469fc91ca3be0967","24807d3563342275bee7cc4b98dc2fadb9e39d074534e79c7921b46596988344","2b29aaa43d344393769f38e1d3dc0ba1d89b2f9868311ff9ec9eb44183d21250","b07747a598d4f1f0beae08332568292104f4360929057396c5637c1900e4f3ff","f13a237529bfd21edad34678f1da8ebd4606422a85b5f92ee270f3808c286e44","20264987b20aa1d6975cf9bad62855c3f8c1492e38ea7a73963eb355bd18b77f","65e0a29033eb3cea6b4c9eaa7448754e468585cf1877e0b228281138421f30cb","133874b546cdc715439d1d1dba865419a9640ee740f8a72191d1221ac29d066b","b056e86b160b08d3e944f1d61368d3523e9c0820ebc8f755b98ac38eb3e307d1","4bb01e9b0388441442a04bb36fe932c3e3da525c4c09413c90f0a6a74c57d280","2fc80afde86a45f5f113067f44433d44da28d6e17dd8dbe19f511bc371863a1c","e7650f7fa769c2b1aee41477278633a342017c81009feff8b6566b3f3664b6dc","01315e63a7b852f1dfd83bc7a405351492c076d88f2ae4adc3c32d3431fd5a35","7cb1e59903fb72e4f618ba7ab078765e9117d8aca2421268fe24b41986df37ba","7fd27c38816b461eba58b547a524747b28eec2b58e2c8fd29fa9858de96265f5","38b95ee03adf62feb5188c1a8c5ac6334e95e0e21bba6b30e667b54f6ad7b728","8927bc71680f4a9f25af6f2c0c4e1956e0e703124ac725d842c64bba5e92a6e5","48d0b1d45f8e228d41f01f71e56618d0f2ce8263bbd9b59352760640eb2df66c","8f41920019edb0924b861daa6feaf2922d0ce0a9c45b777ba88f6e026cb9a6ea","7a4dad8678a23b608ce8acacd9a2f4c24929bc68037fb2991a43cc022e977b60","684daad794ebc87661f8250eb42621db03f6b3f31185e0f760ee3db73286e6c9","69080677f9b643e100e62a2edf12e2dbd529b047d584ff922e5458381761a05d","ccc4c5111cc02d243b67fc20fd93026d88add65c6fd2055602152227903c703c","242fc7936d4480e5fba4b9515aca0b97de121a9effcc1be26d4e455c7adef9f1","833db41cd8b9c20470bc3b5e70249d243aacfcf6b69593ac460a0029467689b9","5fd098cace35e4c0d08f10059d520bae1b2b074ac1059d2980a1be82a8f77f31","e445ff4d77e50cd5d04d2dd3c482677c5531c2198494768dacb624d4f7f7bfc5","c4e521e8f00cc3979bdd0e0c99970374fa1f92ff742a3e9fdf52c1e4bbcfd78d","a1d6296a9801ee538e0d27feb10f8be41b00b0fccc6c83fcb49e98f23c42dcd3","aa368285e0e05d9bc3f957b89b95260349684cc872b167f36a61982bf63c2201","f4fa04c284d1f3eb907f9e7f8adf6e1e832a21ed763d6d23857e45926f9ce10a","fb9e869cf8465c71c8f4a1756a6dbd8dcd1eca4246d8645b037ad0cc65e800f0","e059ad921e8a07dacd01727774bd17821768e61d3f7062f77131f517a9197e50","8736be2b2a646ce5a471e16baf9d11aadd818a71dfe790395b0b2809e115c1e6","4fe6b558e435fdad3843b2db5d14915501c147148dbeb4985e3e596feda17d99","e8318e5e612c6d48b4711e5414abc396ab3d7633a2529eaabe3a82d7c851ccb4","804b049e776174f3eded63d18185d769841f7abc5b0751109a5942862c939fdf","3d263a914bb8e82f1566490d2e8d20ab66542f223089cc4cce9b034930e775f1","1daf03c9dabfd10483a637b59f18d44b8e5fc8a4b2d44e72ffa610824f71879b","3bd025508217aeba5c4a616ea6c30969f252f58231087ce11714db7110b2005c","1a66088cb7d460aeb56c00dd069156adc5cef549648e5481ee5c5e589879b731","4ff1cc8b15a09062bed7a53124c3af351ceda82d439aa3606fe3ca277a20bc2a","ca2095f1eced85cb8e07f785b4e1b8c3f7d9e8ee60f87458c40bdfe731d09c30","d7f31a681b35a7012ced38f106f3b478e9a31f8d58fbf244c721ca1ba89cb394","4bd47e0c626359950fc09888e1a505dfe7286800d0ec0a21b49c66d8de32c901","1a66088cb7d460aeb56c00dd069156adc5cef549648e5481ee5c5e589879b731","3bd025508217aeba5c4a616ea6c30969f252f58231087ce11714db7110b2005c","19ebfbba4c51e79099c031e91a36621312a50c46d0f87d83183a71a0834afe3f","e8ebe53a94ee73fa803f0f144c8ac31d5075de45e2f798b383a6d88164d6113a","944569d8a887d238cf2d7c104ea3fe558bdea38e961b73a0378bfd7969e13157","a08897fe730d7de1f2d5376e1d6e9e500c6e20dce4bd9225c5694667464bf8eb","472a92ca21fe52d676dca31266943a87745bec8b04450b83e5ea29559253e902","3c86ca512b36c13218249dede37b9ed2813b368115926931c08df7dfb049822b","b49c0fce3665545d887872e927e76d7df0927e4baec27c7106181651611424ab","8881027cfa2be033b7a9724b5547b710f5ba8aef1becb3ed53d34d614a54e3bc","bb5ee6ed47f61fc2cc33c29540f1e778a9c9583083e2441c9b23439c5e46820f","cbd9c2e1782d72fae42254f615caba2cc28de5f222ba142ff2020c5499990cc4","52b39e96c6672ecc70554cea0a10c57ad4636526a8f51477d2108bdda78d30e8","c2c4cb3164f6576cf559ab0e7180ad3d1f5ba27156727085ddf3ec36b4fccf33","af940582b1416ab699abc542994f2f8da43c0af0c5518e57c2087eb33dc0503d","d7eace81b9bb79318113d2f30f9d18d90d78f0dffaee7f3bacbcc343ee0101cd","aaf156826bb506f93fc4aaee3bed00172819f02a06ecd5a446afce5321f93ba3","ca2e3b7dde57407212bc4017621f6433908dc2f8b725d365fc7109c7b8067097","d6fdbf77be6e2979543798f41b6cf36fca557c17d0a9d367cc52701770eb2d46","1af6c454434e19d802f83f600982e083de6b4f925c90938783c55236174640b2","66a5abcb3210724cc93b9e4eb537ef9f28e987f2915f00620eb887a419521125","91df6caa3a703fbaebaf35a3ed61d7b80eae59e0daf3f4443c41e2ed69d8cadf","cf62992c60c36cd327652e93bfb0fb7fa14d1f80195616907128ca7fd2b8b24c","1cf9269f1c03276f21bd0f939ee83f9319df7516f9efb06cdbc8ad4f2e985d15","39e051909a54e187a21500c3ab48966058414320a881dbb90517ef770e18b553","696d6bab49f36a42c10486bb4db41f6c7ab89e1f615c221a3c8115b9813246d6","ce01648dfa0c14f86836404e745a9d071c992675d8899b837233a1ccf6e8d9d1","6e60a751d87946c28cbbd6d19115a036edc083b61d981efe513327bbe4e035cf","c73a7a623ffe18351b51942f10371950a5afc5b967ad8e831fc1b4339078b004","2ababd951785b88b19c609338df9bf5f3b25f33d85196410533dc02f6e3d2e60","4edfa2ade6895b198d53dfe5070148c920cc55e810ab4b7c109192d045289669","be8e83fa02962e432fea91f9d49fade6a781c8e85d277ac4f90ab73d7ec1c75e","297256d3db749c28489984d33e3a44118068c71dee801f6c8f7e61dec30e7103","7df23870105909c9c390e97527ea9a37f5fc4dab7a2d11b5bce48ac97e81fcb5","5fcef9d6d418f7a47bbbff082d97b4cf789403df2a0eb75f1ae18b873362f8fb","b3ca2274cc0a5bd844df396ee075344a210fa95b50738d6f8938a76b865fe874","fd2606fc511fa58038c9e9511f3db2d0163ee4615b1c58af53ad1c419b85a7b7","75386c3230b6eab0dd67207ade52679d6fb3c8f9003bca870e0bde8980971146","35c7d91dfcecac4ea844a26f4650e0c7455722359d2299f265ab609da6a7e885","7d67395f69c72c319b991b8c0a8c550cdc7124aa73b86edb5dc78125c8cb2b06","45c7b3879a07324548d034d5698166f8e0fcfcfdf596c18640fe3f7636913bdb","a069791dbb92acabe3ade5dcc6f88f4310abcd6e77927764c71db4c850190542","60c8f1368add0de87f0849d0e93a92d707fecd6f476a850f242dd2c283e05fcc","8d32423d43a5a22332c312975ed03e1e8131dc35c846a16a7cfc3abc255b8eb5","9717ce2d17c080a6bbc635ec15295d0b6567442f8f6e247e56d61a35fed8f574","618d565513599b0cfcee5ab01f6ef86aabaf11615eafd56f66eaba29df6073ca","e53cde1fccab2a904f542a9cad704843a71964be0223113d8c229a706b1d3120","ced6089c414f9deceb70228e42ad0281ec8b13ef4f3a8b3952b6417f9f69346e","b1cb1f5a8b04e3cd5d4e736ed3c703dac8db6376bfa74f4ca5ed0264ffcb6992","326b5964ab27e31c3952520bae0e06c66daf576e3a70faca2a891228831cc3ee","40a0b058213a2e3540c9fc3a5dcbd1eb5bd876c9748f81bb12dc89a944e45a29","12bc66fa8c86611d2785bec80faad4b880cd48bc4ff30f337022d9e8675e30c4","3a7ef749c28ab552daa4fb7e54c3980e86aefa92506caded4feedb4bb70a03c9","4ed789a4d9adc6777c585653267b1d22292d992adfb5224faa1115a1c2b3734c","dc0de14bc6290725ef57d2a54a4044dbb83b425af4a94d609ed7ef516d4d03b1","bc83071647ec91f147f83635bcf99faf8f3431b0af41094ad9a574f117618adc","adce7a0971cd0a515e31e761f4f76113347548d792e0d14cedd683c9221a006a","8fbc8775ab4a90aabc860679fa9ec02be810d1076b607f0f0573baa37ca759fe","ad24ecdfbacb2e8f49425aec400f028e3cc26fb2f0bb7e1dda3ca9ccd98b2c65","01864c0c6901c8e0214987703d75b6f7248bde19964d1c3460dcb8b447296c52","91bcfb9559bb4ea9890c403cc8d0420b4312b4f1f233838636b1f1cf0d03cca1","74ea7961e345714f014bea53111b23952f5309f318af4c373388308971c481ab","1a0df705f0bdf61d9474d949395fbed08f9ffa73668b1201ff6eb4be6ecc94a8","d65d0447197ac25105c8b6fed1675be1940e595eed94aa552140d0027c3a14ae","52d1fcdb4899521daf0b36fd46e0daf8a0e3d1fcd80246f8ac6bd9b92e1bf814","fc26e159b9ba609a0c3abb098f800ddfdc124f0150f6bcd6ef28a73edcfc46b1","fa04269ada73e905ae9b70e0b348c04e980ce0c9a5f92813642691c90fff9b4c","6f67910e966aed715c97a3f34123895e5f12cc3eac821b35519f14410ed84217","2e3f3493cacf15681f4587b2ddccf16bf24c93025cb62b5c9c7c725303c18e42","ff5aaeb07738cecc1ec9c5959254005fa20ca2fd331dd2f15dc80ad6dd8810d2","de1e6715cd6c6ab48a4fed996c168d40cbaa8a47356deb9729ae3df1430e6ccd","b005828433393021f9db66d6e8ad6928f0a9d5c3dc2cf4dbfa0e264b6d4f9e3f","8e67b23999d09515a11fcb142bd1c843580eba1e07df1a89e97bfc61db430739","9a69f53c94388a60f1b16f7d2861bd554fcd7f6aceef6b1c1e3f48ca9030fbff","65ead8101d45973f10664e840193ae01ff8179a81e0a143e6a4cb90a4f0a78f8","ffa35cc1ab3169651692b80f3c91a16ff5136d7c15fba57f43101fc31b9c45f7","c3f038db69e3d5f661f109b711ad04e7f596b68b2d555a081ea422a18109016b","2a07e0970916588dc3d1cf8274c0e54672232a55cc01437deea383fbc9fd8903","6ef42127f51e88ba7505c920e77897d5b983bc86955439492094f1966bb17dd0","d22a5dfe87c858a69e1470dcc8d2fb14dc7b1c30002ca6c2ab85ee8d11f26c01","088131dc57db44873dca6ecc79ac8fbef7d37dccb1618ce9373526512956dde6","4ef88767cc4a4234fd487165ca4d733eac96f5d0f69d0da3668509ad8322a6e7","0b9171dd1de9b00df7c5ca401acf9d715cc5a1c4a77082996beb166e661197a8","dab64e620f07903bd218338db299f48cd21a578e18b54d21d75d9f887d4cdee5","0f357a93a11c2921ac7d078ba2fc01ed6142141ad27170a70d6ca1e7bcd216da","935d138f548875f2700aad732286be9f9b7a27950e49b8a9d9a26d4a04984849","97049b7cc03e75ca4d88e5fc499d028e0efd36426f983e7cc62e79ac25bacd74","29ce849f696e358d3d191165dd0b5a0fe877551d8076a13545bb42e4c1f2628a","d612e39e947aaa4ead5ba2b9f117f9f0f66eaa7b6f8e9ce3fad27840d048c4bb","2f9e1b6669b51121d81ee2f8e7ff070d55501e478b27d9bcd5b517037dbb907a","09fb6c5cf76713fc1aa2cba8cff23a15706ebc69a0ace264ab97b1d27f87b25b","dfe8efc67c47bc2a09806ef1a7b795223b7d200fce0a41173382c8d5d15f4e1d","25c9af80002c3cafcf9a71a115d5cf1fb52ee5e2bbb92e7fe5af2ac498bdade1","dfe8efc67c47bc2a09806ef1a7b795223b7d200fce0a41173382c8d5d15f4e1d","d3f431413d390d24af4f8bfa5f72768f4e1dfd2d84ae1235a27961405c6b8660","d3f431413d390d24af4f8bfa5f72768f4e1dfd2d84ae1235a27961405c6b8660","4bbbbc9591fe8270da47b29df25e14322e6560ac547382ae2a42ee35ecaa44bf","d56c5203a816443e1823372533b711434c45e25a09e5cedad076c9d8038065e9","44c9d492e1374aafb3f6d71f8f408eb74394550ad8e4665c0169bb7dd930ffea","11610aae481891ec2a0fc552d7f3c569d6ebcd8150c322c1d58b94f3a0f1c3df","3dac2a5afb3d345b6276c42ed4a69aee7b9600e0562ad6d3a9828fcbdba78267","67c759d4395f8b91e82a43a13be121e6924def3f3ce88c6a62bd45ec04e2a0a8","d6a7a8d9fe420579dd5351ac769cbd5c1d2454ef8f1b142a71cef10ecc70ec56","7f34eecdda77971fc96007d90eebd2f7addc85c214e0442f40990a28b840a032","153b939a629f12f0802d21bc0b335bb49daef00c6b9c4535c6144883a02a05a3","2f61964ca74a3b0f3c845426395a2d4cefa51ff5b0716bf1d9933274c40cefe9","83cb85c0863bc46fbac3879b4c67a60629008c02eaa88ddd1d51cf8d6013eadc","1e7c81072f87b7d817c8583a78a4d4056178b21f9ecf3d237b19bcc8cee1d391","736af4be184ea560f3010dd6bd796846e773e223f14ba13c1b9cec272788126a","0addef1e4c530c74fbaa56d65b00e9a0929bf64375fa6bf848d8afc8e1da3c3d","77bfab96a52e4fbf3b9afac9447ca6be2c64564f2c58fc560f7104611e646128","af32a73e481f2825f2dd83e5aa06fea0ee2d064a997a203af95d5e33ccf91ad5","37974afcd645a15237810a6785d78cfb51d791d6cd074b96770781248675a838","e0374bccc25125fb6b18555d7ec9761df443bd5801185359534ecdbae8c34a05","e26c3a19188fc8e9fee4962df6d30cf57d238463e79e92c7c65e77dcbd317d8f","17a4fafbf186721a4088d5f3d4373c74bd00af9a86e09bf5f056ba72c36748a4","41a0d9e099ee0c58affff9765cb0536174b98eda38bf403eaeb4d7f014180a48","b032980d1dfdf8f6692c1eac85f7d24134c075e6071e1cc1453a340ce04c94c2","a2fa19621c26c64773920e21c5ddd2758bdd992759a5124e1b4ae761d31d81b6","2a97222ee8383b85a17cdf9e868d1a04eedc5a7bd2b9813f1333fda730fd8149","7e278244c39cea3270f540d7add70595cb73204951030e9a6062ab9f3528a20a","f7be68d1757c477d837c754a5aebb96d44e7668d74204a6e471101acc2e3c331","0de6045abf24a55ffbe03db5517e1b619239e76d9308681899e6c115f10936bb","dfb894c450cef578aa27499be753b8945b759a6006f498e8a808da9362e60420","99727700bf127721388f7ebbe23188da7e87beaee64f775b0d6dff3e6ee9f499","09bbfdb57c117eb7b11b386d388923f8e6caf2a3c6b29fff81041c5ce427f6f3","3d3a1c0602c0e00c01efd86425ae6cdf9abc81fff15679bdcdaccea56cf992ac","4bf67246834d6fa98ec500cb519f39afd2159b4f932f7438c3f8afca62781215","8d2c3da3e0514f5f4dc88c4157bd320f89101c392be1a323b6eb42e94a47c415","fcf5d4d250a4967064b3c571f7e63decf50802e2ca6ac841cefe66aee6b6f1a9","fc44a49a0431b10c27c130da37ee6dcd1b0dc695d0b65ca6f57b89ca32030d69","ac58809688940109655913fea3cd3f4c37dc3192124d4b3bd6597cff4a9a6fc4","034243891e1c94fdf12a7008ed3db1e162c39a6b722e2226615e9d28ab233a38","acc6c6cd91d8cc9b37bcccd7385d98a95708b79ebd3a048b84499e33a988329c","90fb75c59748fd82c8052bb7ead9623d5a8cd1f8d0d75b743678b750a61d5647","071c3b31cca18e2c879dff4a8202cd2fdcb25045b64b6f1a035c5a712ba6f4e7","327e9f1a1b1d630314b5fe11e3cd5b2b2288e1044d3b98cc553523cdb765c5c8","6fe963af6a8576cc6190979a7fa46f71100d7468f01ae6fd3a1f60d293d95fec","d6adfc9ada50609dbfd6f598a9402a235f270aeb895cbd3433bfa1611301313a","0dd9f649e2f2afa45cd17181f55a01c76cb3f631770ea75952c4ad48fbd57d72","89622477e7d7cf0ff4ad038876b2231878a4f21976f6949af7b6876e0a0ccaf0","ddee132dd2a5b78962d0e6195a4990646e8d4567df5df058eb8280c2854b1b8d","d030c924c80a977415ba752a59eb8c359fc255608a72d137e5a3995e4f3dd09a","55e93a772bb8fd4851dfb79014d40f11d9dd714eff39acef6045776d6ee7abb7","79f0fe9adab2a9c45054ca0665649f702284d435fcecf6963f426494c4685177","9350f517362ea8d2e2a14ad23e77820b7f811a57b740ac145aa9607aebfbbcc1","f20bd6e5f63e3751b65cc0f69f800d1386b71f7bcf831df63a3e0a1980940f3a","e58d90563ede6de8f27a04736ae935f918c840b8c4d3ba2e9fd37197bd6dd776","a26368de811b9f9b4982bf58d3dcf926929b1768c9140cf52e6628f75699c92c","70b58e0eedf00c7424eee4693ed777f70cce8d9db6a3d41e7e7f911e1f3b7f94","eb5768d60f8b0323f07f7e89c0879617fedc960c37c85cf7c25c50e0165f0597","a90e6b3648ef7e2cd8951ee712a1b186c1092a11a149a1ddd96b97e01ce7d4f0","d2641c4410d3add40bf7a4dbdbc80c3f056c2a5b15fff09282eb06022c951ed7","8732005fd6e34080693fa81e4227187c05e70cefa43726fe459ae1b80a041437","124e5d8278708bd1a32a51c452508e15dfd06e7191c3994933cadb8f072fec4f","27f82563dc1dfcf0172267da16a4adae713cd2980e02577450530f36fd9aceba","e5dd6efb0064688f3857440b97e231045c4a1b3f708a00cd18ee721b4ac71db0","1aa08a948bc8b6bd3285973f97a14e4ad4a04b8c1cd696dbc4654f2689b3b4a4","20acd54cc349c30313c76e850d2d9a381540514d6330722fbb4d17c1d94fffcc","d934c22a6d997a8a1ecbc6c085587a52ec21a29d56803eb6e40d0c5f7bf79761","02ab03784d559a467cb4b720a8ce8f203f6968c2ecff93a79114fa13f7f8a3b6","01fc012c78c3f28beaa494e3b3cc45aaeea52923e24c1ea0bf5aaf6715fbddb8","e737cc7650ebe1801bbd87523a015431a9a2b44d090af8d84ff780e2fc0a7570","d8ee63e1d52dc44c682966ff8fc53b0d00646400a92df4adf02cfa0418c2823e","b6dfc2022e2a716dcf0e5c8057126c03fa75844e893bcd9461d2c24172ca0e0f","231cc8f40e3456165c8667715a40b9538bfb73d48668aca51db481b0b485bccd","f289532af57cb7e80c0f670205b64d27d2b9c6cdb6f78df475b585cbbc2d1a69","0a766fd0048fd37119a4bdad28dc2c952369a3e8fcc04892dd39adbd3700f818","d1cd8572518e8bbd33be0c841ced2e9bbe9d67471f27e4b9374c26b8e62473d9","5fcef9d6d418f7a47bbbff082d97b4cf789403df2a0eb75f1ae18b873362f8fb","42362a794b85db5592eaab0e21c9b6894a932653d59a97f3e081a7f9760ece61","70631829bbf1208cb277a988224efeedff692a6a44bb0d33b99a5750652cc2e3","269c8261cc14dd76365a9ed49f71332c0ce95198a51746c4343e6a8c99842bc7","7219f03e489efd3648c5182bc96a3f7bd9d39c1d656d25ae57314ab281eadb79","09fb6c5cf76713fc1aa2cba8cff23a15706ebc69a0ace264ab97b1d27f87b25b","2f9e1b6669b51121d81ee2f8e7ff070d55501e478b27d9bcd5b517037dbb907a","3879367de390469ac48196f22e461e58e03545f79e4ec5f6c4f935db5f26c7a8","4e65324ae5d788ba5e8982eb9af30ef9db63d454576aee979b183bdbf822bd10","18f46b4609876d1d108434c8207317f0f11a602aba8f899e3371f91887442bd9","23fd40eaa32f83a635fdba9ee1dbcb2308a3f6f651428c339dbe083bc10b1379","4785d461d01c6c9ad6fb294478df3ff76f677bb239b1434eea096f18e82508e1","f402bac0eae54e6d72b832962e2224eeddd330ae8df85bc1e02c4e47c831fd9a","d2da86368f860bd524a9bc9a6a3fc68fd822e18d921e20a68843e41946aaea20","07377d1ffb0e5f4582c311e11e5d5598ffd9d4b40d6b431a783d89d34e9597ff","a06e59909846a40b8ff6936ccb25279ae7152f0d1213cbcc52bc702601b1af1b","3632eb0ec85c5d95efeafca8a6237cb594d83f98779bdd763edf2e79b4e9e19a","387eb7e0dad26484d9f00d39e40658e4271d1c82b9f0c0365a211a12a536353a","090ce294c0ba760c0338591af254b03ed4310defe2fa6c4ff8096de17d3ee856","e0b84355712e3f0c4cc076a40e96c5991667ee17b746db73f52e67f5b1d59b1c","5444a9606d8aacf4b8f4779a00df1fb9f28b6d275f519011b6c511ff2419b745","f59ea6fd64694fdb9d7e94577a33a95725967b72bc01069a285e52caf78704ab"];
     const vintxdatas = await BlueElectrum.multiGetTransactionByTxid(vinTxids);
-    assert.ok(vintxdatas['8881027cfa2be033b7a9724b5547b710f5ba8aef1becb3ed53d34d614a54e3bc']);
+    expect(vintxdatas['8881027cfa2be033b7a9724b5547b710f5ba8aef1becb3ed53d34d614a54e3bc']).toBeTruthy();
   });
 
   it.skip('multiGetTransactionByTxid() can work with huge tx', async () => {
@@ -273,7 +268,7 @@ describe('BlueElectrum', () => {
     // so whoever uses it should be prepared for this.
     // tbh consumer wallets dont usually work with such big txs, so probably we dont need it
     const txdatas = await BlueElectrum.multiGetTransactionByTxid(['484a11c5e086a281413b9192b4f60c06abf745f08c2c28c4b4daefe6df3b9e5c']);
-    assert.ok(txdatas['484a11c5e086a281413b9192b4f60c06abf745f08c2c28c4b4daefe6df3b9e5c']);
+    expect(txdatas['484a11c5e086a281413b9192b4f60c06abf745f08c2c28c4b4daefe6df3b9e5c']).toBeTruthy();
   });
 
   it.each([false, true])('ElectrumClient can do multiGetHistoryByAddress() to obtain txhex, disableBatching=%p', async disableBatching => {
@@ -284,8 +279,7 @@ describe('BlueElectrum', () => {
       false,
     );
 
-    assert.strictEqual(
-      txdatas['881c54edd95cbdd1583d6b9148eb35128a47b64a2e67a5368a649d6be960f08e'],
+    expect(txdatas['881c54edd95cbdd1583d6b9148eb35128a47b64a2e67a5368a649d6be960f08e']).toBe(
       '02000000000102f1155666b534f7cb476a0523a45dc8731d38d56b5b08e877c968812423fbd7f3010000000000000000d8a2882a692ee759b43e6af48ac152dd3410cc4b7d25031e83b3396c16ffbc8900000000000000000002400d03000000000017a914e286d58e53f9247a4710e51232cce0686f16873c870695010000000000160014d3e2ecbf4d91321794e0297e0284c47527cf878b02483045022100d18dc865fb4d087004d021d480b983b8afb177a1934ce4cd11cf97b03e17944f02206d7310687a84aab5d4696d535bca69c2db4449b48feb55fff028aa004f2d1744012103af4b208608c75f38e78f6e5abfbcad9c360fb60d3e035193b2cd0cdc8fc0155c0247304402207556e859845df41d897fe442f59b6106c8fa39c74ba5b7b8e3268ab0aebf186f0220048a9f3742339c44a1e5c78b491822b96070bcfda3f64db9dc6434f8e8068475012102456e5223ed3884dc6b0e152067fd836e3eb1485422eda45558bf83f59c6ad09f00000000',
     );
     if (disableBatching) BlueElectrum.setBatchingEnabled();

--- a/tests/integration/Currency.test.js
+++ b/tests/integration/Currency.test.js
@@ -1,6 +1,6 @@
-import { FiatUnit } from '../../models/fiatUnit';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-const assert = require('assert');
+import { FiatUnit } from '../../models/fiatUnit';
+
 jest.useFakeTimers();
 
 describe('currency', () => {
@@ -10,29 +10,29 @@ describe('currency', () => {
     await currency.startUpdater();
     let cur = await AsyncStorage.getItem(currency.EXCHANGE_RATES);
     cur = JSON.parse(cur);
-    assert.ok(Number.isInteger(cur[currency.STRUCT.LAST_UPDATED]));
-    assert.ok(cur[currency.STRUCT.LAST_UPDATED] > 0);
-    assert.ok(cur.BTC_USD > 0);
+    expect(Number.isInteger(cur[currency.STRUCT.LAST_UPDATED])).toBeTruthy();
+    expect(cur[currency.STRUCT.LAST_UPDATED] > 0).toBeTruthy();
+    expect(cur.BTC_USD > 0).toBeTruthy();
 
     // now, setting other currency as default
     await AsyncStorage.setItem(currency.PREFERRED_CURRENCY, JSON.stringify(FiatUnit.JPY));
     await currency.startUpdater();
     cur = JSON.parse(await AsyncStorage.getItem(currency.EXCHANGE_RATES));
-    assert.ok(cur.BTC_JPY > 0);
+    expect(cur.BTC_JPY > 0).toBeTruthy();
 
     // now setting with a proper setter
     await currency.setPrefferedCurrency(FiatUnit.EUR);
     await currency.startUpdater();
     const preferred = await currency.getPreferredCurrency();
-    assert.strictEqual(preferred.endPointKey, 'EUR');
+    expect(preferred.endPointKey).toBe('EUR');
     cur = JSON.parse(await AsyncStorage.getItem(currency.EXCHANGE_RATES));
-    assert.ok(cur.BTC_EUR > 0);
+    expect(cur.BTC_EUR > 0).toBeTruthy();
 
     // test Yadio rate source
     await currency.setPrefferedCurrency(FiatUnit.ARS);
     await currency.startUpdater();
     cur = JSON.parse(await AsyncStorage.getItem(currency.EXCHANGE_RATES));
-    assert.ok(cur.BTC_ARS > 0);
+    expect(cur.BTC_ARS > 0).toBeTruthy();
 
     // test BitcoinduLiban rate source
     // disabled, because it throws "Service Temporarily Unavailable" on circleci
@@ -45,6 +45,6 @@ describe('currency', () => {
     await currency.setPrefferedCurrency(FiatUnit.IRR);
     await currency.startUpdater();
     cur = JSON.parse(await AsyncStorage.getItem(currency.EXCHANGE_RATES));
-    assert.ok(cur.BTC_IRR > 0);
+    expect(cur.BTC_IRR > 0).toBeTruthy();
   });
 });

--- a/tests/integration/ElectrumClient.test.js
+++ b/tests/integration/ElectrumClient.test.js
@@ -1,8 +1,7 @@
-const bitcoin = require('bitcoinjs-lib');
+import * as bitcoin from 'bitcoinjs-lib';
 const net = require('net');
 const tls = require('tls');
 
-const assert = require('assert');
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 150 * 1000;
 
 const hardcodedPeers = [
@@ -38,7 +37,7 @@ describe('ElectrumClient', () => {
       let balance = await mainClient.blockchainScripthash_getBalance(reversedHash.toString('hex'));
       const end = +new Date();
       end - start > 1000 && console.warn(peer.host, 'took', (end - start) / 1000, 'seconds to fetch balance');
-      assert.ok(balance.confirmed > 0);
+      expect(balance.confirmed > 0).toBeTruthy();
 
       addr4elect = '3GCvDBAktgQQtsbN6x5DYiQCMmgZ9Yk8BK';
       script = bitcoin.address.toOutputScript(addr4elect);

--- a/tests/integration/aopp.test.js
+++ b/tests/integration/aopp.test.js
@@ -1,34 +1,32 @@
-import assert from 'assert';
-
 import { HDLegacyP2PKHWallet, HDSegwitP2SHWallet } from '../../class';
 import AOPP from '../../class/aopp';
 
 describe('AOPP', () => {
   it('can validate uri', async () => {
     const a = new AOPP('aopp:?v=0&msg=vasp-chosen-msg&asset=btc&format=p2wpkh&callback=https://vasp.com/proofs/vasp-chosen-token');
-    assert.strictEqual(a.v, 0);
-    assert.strictEqual(a.msg, 'vasp-chosen-msg');
-    assert.strictEqual(a.format, 'p2wpkh');
-    assert.strictEqual(a.callback, 'https://vasp.com/proofs/vasp-chosen-token');
-    assert.strictEqual(a.callbackHostname, 'vasp.com');
+    expect(a.v).toBe(0);
+    expect(a.msg).toBe('vasp-chosen-msg');
+    expect(a.format).toBe('p2wpkh');
+    expect(a.callback).toBe('https://vasp.com/proofs/vasp-chosen-token');
+    expect(a.callbackHostname).toBe('vasp.com');
 
     // wrong version
-    assert.throws(() => new AOPP('aopp:?v=1&msg=vasp-chosen-msg&asset=btc&format=p2wpkh&callback=https://vasp.com/'));
+    expect(() => new AOPP('aopp:?v=1&msg=vasp-chosen-msg&asset=btc&format=p2wpkh&callback=https://vasp.com/')).toThrow();
 
     // wrong asset
-    assert.throws(() => new AOPP('aopp:?v=0&msg=vasp-chosen-msg&asset=bch&format=p2wpkh&callback=https://vasp.com/'));
+    expect(() => new AOPP('aopp:?v=0&msg=vasp-chosen-msg&asset=bch&format=p2wpkh&callback=https://vasp.com/')).toThrow();
 
     // wrong format
-    assert.throws(() => new AOPP('aopp:?v=0&msg=vasp-chosen-msg&asset=btc&format=erc20&callback=https://vasp.com/'));
+    expect(() => new AOPP('aopp:?v=0&msg=vasp-chosen-msg&asset=btc&format=erc20&callback=https://vasp.com/')).toThrow();
   });
 
   it('can cast address format to our internal segwitType', () => {
-    assert.throws(() => AOPP.getSegwitByAddressFormat('any'));
-    assert.throws(() => AOPP.getSegwitByAddressFormat('blablabla'));
+    expect(() => AOPP.getSegwitByAddressFormat('any')).toThrow();
+    expect(() => AOPP.getSegwitByAddressFormat('blablabla')).toThrow();
 
-    assert.strictEqual(AOPP.getSegwitByAddressFormat('p2wpkh'), 'p2wpkh');
-    assert.strictEqual(AOPP.getSegwitByAddressFormat('p2sh'), 'p2sh(p2wpkh)');
-    assert.strictEqual(AOPP.getSegwitByAddressFormat('p2pkh'), undefined);
+    expect(AOPP.getSegwitByAddressFormat('p2wpkh')).toBe('p2wpkh');
+    expect(AOPP.getSegwitByAddressFormat('p2sh')).toBe('p2sh(p2wpkh)');
+    expect(AOPP.getSegwitByAddressFormat('p2pkh')).toBe(undefined);
   });
 
   // these tests depends on unstable https://testing.21analytics.ch/ ( link can be found at https://testing.aopp.group/) so we don't want to run chem all the time

--- a/tests/integration/hd-legacy-breadwallet.test.js
+++ b/tests/integration/hd-legacy-breadwallet.test.js
@@ -1,6 +1,5 @@
 import * as bitcoin from 'bitcoinjs-lib';
 import { HDLegacyBreadwalletWallet } from '../../class';
-import assert from 'assert';
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
 const BlueElectrum = require('../../blue_modules/BlueElectrum'); // so it connects ASAP
@@ -35,7 +34,7 @@ it('Legacy HD Breadwallet can fetch balance and create transaction', async () =>
   // m/0'/1/0 1A9Sc4opR6c7Ui6NazECiGmsmnUPh2WeHJ x 0.00016378 BTC
   // m/0'/1/1 bc1qksn08tz44fvnnrpgrrexvs9526t6jg3xnj9tpc x 0.00012422
   // 0.0001 + 0.00016378 + 0.00012422 + 0.00032084 = 0.00070884
-  assert.strictEqual(wallet.getBalance(), 70884);
+  expect(wallet.getBalance()).toBe(70884);
 
   // try to create a tx
   await wallet.fetchUtxo();
@@ -47,6 +46,6 @@ it('Legacy HD Breadwallet can fetch balance and create transaction', async () =>
   );
 
   const transaction = bitcoin.Transaction.fromHex(tx.toHex());
-  assert.ok(transaction.ins.length === 4);
-  assert.strictEqual(transaction.outs.length, 1);
+  expect(transaction.ins.length === 4).toBeTruthy();
+  expect(transaction.outs.length).toBe(1);
 });

--- a/tests/integration/hd-segwit-bech32-transaction.test.js
+++ b/tests/integration/hd-segwit-bech32-transaction.test.js
@@ -1,6 +1,5 @@
+import * as bitcoin from 'bitcoinjs-lib';
 import { HDSegwitBech32Wallet, SegwitP2SHWallet, HDSegwitBech32Transaction, SegwitBech32Wallet } from '../../class';
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
 const BlueElectrum = require('../../blue_modules/BlueElectrum');
@@ -35,17 +34,17 @@ async function _getHdWallet() {
 describe('HDSegwitBech32Transaction', () => {
   it('can decode & check sequence', async function () {
     let T = new HDSegwitBech32Transaction(null, 'e9ef58baf4cff3ad55913a360c2fa1fd124309c59dcd720cdb172ce46582097b');
-    assert.strictEqual(await T.getMaxUsedSequence(), 0xffffffff);
-    assert.strictEqual(await T.isSequenceReplaceable(), false);
+    expect(await T.getMaxUsedSequence()).toBe(0xffffffff);
+    expect(await T.isSequenceReplaceable()).toBe(false);
 
     // 881c54edd95cbdd1583d6b9148eb35128a47b64a2e67a5368a649d6be960f08e
     T = new HDSegwitBech32Transaction(
       '02000000000102f1155666b534f7cb476a0523a45dc8731d38d56b5b08e877c968812423fbd7f3010000000000000000d8a2882a692ee759b43e6af48ac152dd3410cc4b7d25031e83b3396c16ffbc8900000000000000000002400d03000000000017a914e286d58e53f9247a4710e51232cce0686f16873c870695010000000000160014d3e2ecbf4d91321794e0297e0284c47527cf878b02483045022100d18dc865fb4d087004d021d480b983b8afb177a1934ce4cd11cf97b03e17944f02206d7310687a84aab5d4696d535bca69c2db4449b48feb55fff028aa004f2d1744012103af4b208608c75f38e78f6e5abfbcad9c360fb60d3e035193b2cd0cdc8fc0155c0247304402207556e859845df41d897fe442f59b6106c8fa39c74ba5b7b8e3268ab0aebf186f0220048a9f3742339c44a1e5c78b491822b96070bcfda3f64db9dc6434f8e8068475012102456e5223ed3884dc6b0e152067fd836e3eb1485422eda45558bf83f59c6ad09f00000000',
     );
-    assert.strictEqual(await T.getMaxUsedSequence(), 0);
-    assert.strictEqual(await T.isSequenceReplaceable(), true);
+    expect(await T.getMaxUsedSequence()).toBe(0);
+    expect(await T.isSequenceReplaceable()).toBe(true);
 
-    assert.ok((await T.getRemoteConfirmationsNum()) >= 292);
+    expect((await T.getRemoteConfirmationsNum()) >= 292).toBeTruthy();
   });
 
   it('can tell if its our transaction', async function () {
@@ -58,11 +57,11 @@ describe('HDSegwitBech32Transaction', () => {
 
     let tt = new HDSegwitBech32Transaction(null, '881c54edd95cbdd1583d6b9148eb35128a47b64a2e67a5368a649d6be960f08e', hd);
 
-    assert.ok(await tt.isOurTransaction());
+    expect(await tt.isOurTransaction()).toBeTruthy();
 
     tt = new HDSegwitBech32Transaction(null, '89bcff166c39b3831e03257d4bcc1034dd52c18af46a3eb459e72e692a88a2d8', hd);
 
-    assert.ok(!(await tt.isOurTransaction()));
+    expect(!(await tt.isOurTransaction())).toBeTruthy();
   });
 
   it('can tell tx info', async function () {
@@ -76,14 +75,13 @@ describe('HDSegwitBech32Transaction', () => {
     const tt = new HDSegwitBech32Transaction(null, '881c54edd95cbdd1583d6b9148eb35128a47b64a2e67a5368a649d6be960f08e', hd);
 
     const { fee, feeRate, targets, changeAmount, utxos } = await tt.getInfo();
-    assert.strictEqual(fee, 4464);
-    assert.strictEqual(changeAmount, 103686);
-    assert.strictEqual(feeRate, 12);
-    assert.strictEqual(targets.length, 1);
-    assert.strictEqual(targets[0].value, 200000);
-    assert.strictEqual(targets[0].address, '3NLnALo49CFEF4tCRhCvz45ySSfz3UktZC');
-    assert.strictEqual(
-      JSON.stringify(utxos),
+    expect(fee).toBe(4464);
+    expect(changeAmount).toBe(103686);
+    expect(feeRate).toBe(12);
+    expect(targets.length).toBe(1);
+    expect(targets[0].value).toBe(200000);
+    expect(targets[0].address).toBe('3NLnALo49CFEF4tCRhCvz45ySSfz3UktZC');
+    expect(JSON.stringify(utxos)).toBe(
       JSON.stringify([
         {
           vout: 1,
@@ -111,21 +109,21 @@ describe('HDSegwitBech32Transaction', () => {
 
     const tt = new HDSegwitBech32Transaction(null, '881c54edd95cbdd1583d6b9148eb35128a47b64a2e67a5368a649d6be960f08e', hd);
 
-    assert.strictEqual(await tt.canCancelTx(), true);
+    expect(await tt.canCancelTx()).toBe(true);
 
     const { tx } = await tt.createRBFcancelTx(15);
 
     const createdTx = bitcoin.Transaction.fromHex(tx.toHex());
-    assert.strictEqual(createdTx.ins.length, 2);
-    assert.strictEqual(createdTx.outs.length, 1);
+    expect(createdTx.ins.length).toBe(2);
+    expect(createdTx.outs.length).toBe(1);
     const addr = SegwitBech32Wallet.scriptPubKeyToAddress(createdTx.outs[0].script);
-    assert.ok(hd.weOwnAddress(addr));
+    expect(hd.weOwnAddress(addr)).toBeTruthy();
 
     const actualFeerate = (108150 + 200000 - createdTx.outs[0].value) / (tx.toHex().length / 2);
-    assert.strictEqual(Math.round(actualFeerate), 15);
+    expect(Math.round(actualFeerate)).toBe(15);
 
     const tt2 = new HDSegwitBech32Transaction(tx.toHex(), null, hd);
-    assert.strictEqual(await tt2.canCancelTx(), false); // newly created cancel tx is not cancellable anymore
+    expect(await tt2.canCancelTx()).toBe(false); // newly created cancel tx is not cancellable anymore
   });
 
   it('can do RBF - bumpfees tx', async function () {
@@ -138,25 +136,25 @@ describe('HDSegwitBech32Transaction', () => {
 
     const tt = new HDSegwitBech32Transaction(null, '881c54edd95cbdd1583d6b9148eb35128a47b64a2e67a5368a649d6be960f08e', hd);
 
-    assert.strictEqual(await tt.canCancelTx(), true);
-    assert.strictEqual(await tt.canBumpTx(), true);
+    expect(await tt.canCancelTx()).toBe(true);
+    expect(await tt.canBumpTx()).toBe(true);
 
     const { tx } = await tt.createRBFbumpFee(17);
 
     const createdTx = bitcoin.Transaction.fromHex(tx.toHex());
-    assert.strictEqual(createdTx.ins.length, 2);
-    assert.strictEqual(createdTx.outs.length, 2);
+    expect(createdTx.ins.length).toBe(2);
+    expect(createdTx.outs.length).toBe(2);
     const addr0 = SegwitP2SHWallet.scriptPubKeyToAddress(createdTx.outs[0].script);
-    assert.ok(!hd.weOwnAddress(addr0));
-    assert.strictEqual(addr0, '3NLnALo49CFEF4tCRhCvz45ySSfz3UktZC'); // dest address
+    expect(!hd.weOwnAddress(addr0)).toBeTruthy();
+    expect(addr0).toBe('3NLnALo49CFEF4tCRhCvz45ySSfz3UktZC'); // dest address
     const addr1 = SegwitBech32Wallet.scriptPubKeyToAddress(createdTx.outs[1].script);
-    assert.ok(hd.weOwnAddress(addr1));
+    expect(hd.weOwnAddress(addr1)).toBeTruthy();
 
     const actualFeerate = (108150 + 200000 - (createdTx.outs[0].value + createdTx.outs[1].value)) / (tx.toHex().length / 2);
-    assert.strictEqual(Math.round(actualFeerate), 17);
+    expect(Math.round(actualFeerate)).toBe(17);
 
     const tt2 = new HDSegwitBech32Transaction(tx.toHex(), null, hd);
-    assert.strictEqual(await tt2.canCancelTx(), true); // new tx is still cancellable since we only bumped fees
+    expect(await tt2.canCancelTx()).toBe(true); // new tx is still cancellable since we only bumped fees
   });
 
   it('can do CPFP - bump fees', async function () {
@@ -168,11 +166,10 @@ describe('HDSegwitBech32Transaction', () => {
     const hd = await _getHdWallet();
 
     const tt = new HDSegwitBech32Transaction(null, '2ec8a1d0686dcccffc102ba5453a28d99c8a1e5061c27b41f5c0a23b0b27e75f', hd);
-    assert.ok(await tt.isToUsTransaction());
+    expect(await tt.isToUsTransaction()).toBeTruthy();
     const { unconfirmedUtxos, fee: oldFee } = await tt.getInfo();
 
-    assert.strictEqual(
-      JSON.stringify(unconfirmedUtxos),
+    expect(JSON.stringify(unconfirmedUtxos)).toBe(
       JSON.stringify([
         {
           vout: 0,
@@ -185,6 +182,6 @@ describe('HDSegwitBech32Transaction', () => {
 
     const { tx, fee } = await tt.createCPFPbumpFee(20);
     const avgFeeRate = (oldFee + fee) / (tt._txhex.length / 2 + tx.toHex().length / 2);
-    assert.ok(Math.round(avgFeeRate) >= 20);
+    expect(Math.round(avgFeeRate) >= 20).toBeTruthy();
   });
 });

--- a/tests/integration/hd-segwit-bech32-wallet.test.js
+++ b/tests/integration/hd-segwit-bech32-wallet.test.js
@@ -1,5 +1,4 @@
 import { HDSegwitBech32Wallet } from '../../class';
-const assert = require('assert');
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
 const BlueElectrum = require('../../blue_modules/BlueElectrum'); // so it connects ASAP
@@ -27,73 +26,72 @@ describe('Bech32 Segwit HD (BIP84)', () => {
 
     let hd = new HDSegwitBech32Wallet();
     hd.setSecret(process.env.HD_MNEMONIC);
-    assert.ok(hd.validateMnemonic());
+    expect(hd.validateMnemonic()).toBeTruthy();
 
-    assert.strictEqual(
-      'zpub6r7jhKKm7BAVx3b3nSnuadY1WnshZYkhK8gKFoRLwK9rF3Mzv28BrGcCGA3ugGtawi1WLb2vyjQAX9ZTDGU5gNk2bLdTc3iEXr6tzR1ipNP',
+    expect('zpub6r7jhKKm7BAVx3b3nSnuadY1WnshZYkhK8gKFoRLwK9rF3Mzv28BrGcCGA3ugGtawi1WLb2vyjQAX9ZTDGU5gNk2bLdTc3iEXr6tzR1ipNP').toBe(
       hd.getXpub(),
     );
 
-    assert.strictEqual(hd._getExternalAddressByIndex(0), 'bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p');
-    assert.strictEqual(hd._getExternalAddressByIndex(1), 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
-    assert.strictEqual(hd._getInternalAddressByIndex(0), 'bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy');
-    assert.strictEqual(hd._getInternalAddressByIndex(1), 'bc1qwp58x4c9e5cplsnw5096qzdkae036ug7a34x3r');
+    expect(hd._getExternalAddressByIndex(0)).toBe('bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p');
+    expect(hd._getExternalAddressByIndex(1)).toBe('bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
+    expect(hd._getInternalAddressByIndex(0)).toBe('bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy');
+    expect(hd._getInternalAddressByIndex(1)).toBe('bc1qwp58x4c9e5cplsnw5096qzdkae036ug7a34x3r');
 
-    assert.ok(hd.weOwnAddress('bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p'));
-    assert.ok(hd.weOwnAddress('BC1QVD6W54SYDC08Z3802SVKXR7297EZ7CUSD6266P'));
-    assert.ok(hd.weOwnAddress('bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh'));
-    assert.ok(!hd.weOwnAddress('1HjsSTnrwWzzEV2oi4r5MsAYENkTkrCtwL'));
-    assert.ok(!hd.weOwnAddress('garbage'));
-    assert.ok(!hd.weOwnAddress(false));
+    expect(hd.weOwnAddress('bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p')).toBeTruthy();
+    expect(hd.weOwnAddress('BC1QVD6W54SYDC08Z3802SVKXR7297EZ7CUSD6266P')).toBeTruthy();
+    expect(hd.weOwnAddress('bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh')).toBeTruthy();
+    expect(!hd.weOwnAddress('1HjsSTnrwWzzEV2oi4r5MsAYENkTkrCtwL')).toBeTruthy();
+    expect(!hd.weOwnAddress('garbage')).toBeTruthy();
+    expect(!hd.weOwnAddress(false)).toBeTruthy();
 
-    assert.strictEqual(hd.timeToRefreshBalance(), true);
-    assert.ok(hd._lastTxFetch === 0);
-    assert.ok(hd._lastBalanceFetch === 0);
+    expect(hd.timeToRefreshBalance()).toBe(true);
+    expect(hd._lastTxFetch === 0).toBeTruthy();
+    expect(hd._lastBalanceFetch === 0).toBeTruthy();
 
     await hd.fetchBalance();
-    assert.strictEqual(hd.getBalance(), 200000);
-    assert.strictEqual(await hd.getAddressAsync(), hd._getExternalAddressByIndex(2));
-    assert.strictEqual(await hd.getChangeAddressAsync(), hd._getInternalAddressByIndex(2));
-    assert.strictEqual(hd.next_free_address_index, 2);
-    assert.strictEqual(hd.getNextFreeAddressIndex(), 2);
-    assert.strictEqual(hd.next_free_change_address_index, 2);
+    expect(hd.getBalance()).toBe(200000);
+    expect(await hd.getAddressAsync()).toBe(hd._getExternalAddressByIndex(2));
+    expect(await hd.getChangeAddressAsync()).toBe(hd._getInternalAddressByIndex(2));
+    expect(hd.next_free_address_index).toBe(2);
+    expect(hd.getNextFreeAddressIndex()).toBe(2);
+    expect(hd.next_free_change_address_index).toBe(2);
 
     // now fetch txs
     await hd.fetchTransactions();
-    assert.ok(hd._lastTxFetch > 0);
-    assert.ok(hd._lastBalanceFetch > 0);
-    assert.strictEqual(hd.timeToRefreshBalance(), false);
-    assert.strictEqual(hd.getTransactions().length, 4);
+    expect(hd._lastTxFetch > 0).toBeTruthy();
+    expect(hd._lastBalanceFetch > 0).toBeTruthy();
+    expect(hd.timeToRefreshBalance()).toBe(false);
+    expect(hd.getTransactions().length).toBe(4);
 
     for (const tx of hd.getTransactions()) {
-      assert.ok(tx.hash);
-      assert.strictEqual(tx.value, 50000);
-      assert.ok(tx.received);
-      assert.ok(tx.confirmations > 1);
+      expect(tx.hash).toBeTruthy();
+      expect(tx.value).toBe(50000);
+      expect(tx.received).toBeTruthy();
+      expect(tx.confirmations > 1).toBeTruthy();
     }
 
-    assert.ok(hd.weOwnTransaction('5e2fa84148a7389537434b3ad12fcae71ed43ce5fb0f016a7f154a9b99a973df'));
-    assert.ok(hd.weOwnTransaction('ad00a92409d8982a1d7f877056dbed0c4337d2ebab70b30463e2802279fb936d'));
-    assert.ok(!hd.weOwnTransaction('825c12f277d1f84911ac15ad1f41a3de28e9d906868a930b0a7bca61b17c8881'));
+    expect(hd.weOwnTransaction('5e2fa84148a7389537434b3ad12fcae71ed43ce5fb0f016a7f154a9b99a973df')).toBeTruthy();
+    expect(hd.weOwnTransaction('ad00a92409d8982a1d7f877056dbed0c4337d2ebab70b30463e2802279fb936d')).toBeTruthy();
+    expect(!hd.weOwnTransaction('825c12f277d1f84911ac15ad1f41a3de28e9d906868a930b0a7bca61b17c8881')).toBeTruthy();
 
     // now fetch UTXO
     await hd.fetchUtxo();
     const utxo = hd.getUtxo();
-    assert.strictEqual(utxo.length, 4);
-    assert.ok(utxo[0].txId);
-    assert.ok(utxo[0].vout === 0 || utxo[0].vout === 1);
-    assert.ok(utxo[0].value);
-    assert.ok(utxo[0].address);
+    expect(utxo.length).toBe(4);
+    expect(utxo[0].txId).toBeTruthy();
+    expect(utxo[0].vout === 0 || utxo[0].vout === 1).toBeTruthy();
+    expect(utxo[0].value).toBeTruthy();
+    expect(utxo[0].address).toBeTruthy();
 
     // now, reset HD wallet, and find free addresses from scratch:
     hd = new HDSegwitBech32Wallet();
     hd.setSecret(process.env.HD_MNEMONIC);
 
-    assert.strictEqual(await hd.getAddressAsync(), hd._getExternalAddressByIndex(2));
-    assert.strictEqual(await hd.getChangeAddressAsync(), hd._getInternalAddressByIndex(2));
-    assert.strictEqual(hd.next_free_address_index, 2);
-    assert.strictEqual(hd.getNextFreeAddressIndex(), 2);
-    assert.strictEqual(hd.next_free_change_address_index, 2);
+    expect(await hd.getAddressAsync()).toBe(hd._getExternalAddressByIndex(2));
+    expect(await hd.getChangeAddressAsync()).toBe(hd._getInternalAddressByIndex(2));
+    expect(hd.next_free_address_index).toBe(2);
+    expect(hd.getNextFreeAddressIndex()).toBe(2);
+    expect(hd.next_free_change_address_index).toBe(2);
     if (disableBatching) BlueElectrum.setBatchingEnabled();
   });
 
@@ -104,7 +102,7 @@ describe('Bech32 Segwit HD (BIP84)', () => {
     }
     const hd = new HDSegwitBech32Wallet();
     hd.setSecret(process.env.HD_MNEMONIC_BIP84);
-    assert.ok(hd.validateMnemonic());
+    expect(hd.validateMnemonic()).toBeTruthy();
 
     await hd.fetchBalance();
     const oldBalance = hd.getBalance();
@@ -121,15 +119,15 @@ describe('Bech32 Segwit HD (BIP84)', () => {
     for (let c = 17; c < 100; c++) hd._balances_by_internal_index[c] = { c: 0, u: 0 };
     hd._balances_by_external_index['2'].c = 1000000;
 
-    assert.ok(hd.getBalance() !== oldBalance);
-    assert.ok(hd.getTransactions().length !== oldTransactions.length);
+    expect(hd.getBalance() !== oldBalance).toBeTruthy();
+    expect(hd.getTransactions().length !== oldTransactions.length).toBeTruthy();
 
     // now, refetch! should get back to normal
 
     await hd.fetchBalance();
-    assert.strictEqual(hd.getBalance(), oldBalance);
+    expect(hd.getBalance()).toBe(oldBalance);
     await hd.fetchTransactions();
-    assert.strictEqual(hd.getTransactions().length, oldTransactions.length);
+    expect(hd.getTransactions().length).toBe(oldTransactions.length);
   });
 
   it.skip('can work with faulty zpub', async () => {
@@ -144,7 +142,7 @@ describe('Bech32 Segwit HD (BIP84)', () => {
     await hd.fetchBalance();
     await hd.fetchTransactions();
 
-    assert.ok(hd.getTransactions().length >= 76);
+    expect(hd.getTransactions().length >= 76).toBeTruthy();
   });
 
   it('can fetchBalance, fetchTransactions, fetchUtxo and create transactions', async () => {
@@ -154,9 +152,8 @@ describe('Bech32 Segwit HD (BIP84)', () => {
     }
     const hd = new HDSegwitBech32Wallet();
     hd.setSecret(process.env.HD_MNEMONIC_BIP84);
-    assert.ok(hd.validateMnemonic());
-    assert.strictEqual(
-      hd.getXpub(),
+    expect(hd.validateMnemonic()).toBeTruthy();
+    expect(hd.getXpub()).toBe(
       'zpub6qoWjSiZRHzSYPGYJ6EzxEXJXP1b2Rj9syWwJZFNCmupMwkbSAWSBk3UvSkJyQLEhQpaBAwvhmNj3HPKpwCJiTBB9Tutt46FtEmjL2DoU3J',
     );
 
@@ -165,9 +162,9 @@ describe('Bech32 Segwit HD (BIP84)', () => {
     let end = +new Date();
     end - start > 5000 && console.warn('fetchBalance took', (end - start) / 1000, 'sec');
 
-    assert.ok(hd.next_free_change_address_index > 0);
-    assert.ok(hd.next_free_address_index > 0);
-    assert.ok(hd.getNextFreeAddressIndex() > 0);
+    expect(hd.next_free_change_address_index > 0).toBeTruthy();
+    expect(hd.next_free_address_index > 0).toBeTruthy();
+    expect(hd.getNextFreeAddressIndex() > 0).toBeTruthy();
 
     start = +new Date();
     await hd.fetchTransactions();
@@ -188,41 +185,41 @@ describe('Bech32 Segwit HD (BIP84)', () => {
     let txFound = 0;
     for (const tx of hd.getTransactions()) {
       if (tx.hash === 'e9ef58baf4cff3ad55913a360c2fa1fd124309c59dcd720cdb172ce46582097b') {
-        assert.strictEqual(tx.value, -129545);
-        assert.strictEqual(tx.inputs[0].addresses[0], 'bc1qffcl35r05wyf06meu3dalfevawx559n0ufrxcw');
-        assert.strictEqual(tx.inputs[1].addresses[0], 'bc1qtvh8mjcfdg9224nx4wu3sw7fmmtmy2k3jhdeul');
-        assert.strictEqual(tx.inputs[2].addresses[0], 'bc1qhe03zgvq4fmfw8l2qq2zu4dxyhgyukcz6k2a5w');
+        expect(tx.value).toBe(-129545);
+        expect(tx.inputs[0].addresses[0]).toBe('bc1qffcl35r05wyf06meu3dalfevawx559n0ufrxcw');
+        expect(tx.inputs[1].addresses[0]).toBe('bc1qtvh8mjcfdg9224nx4wu3sw7fmmtmy2k3jhdeul');
+        expect(tx.inputs[2].addresses[0]).toBe('bc1qhe03zgvq4fmfw8l2qq2zu4dxyhgyukcz6k2a5w');
         txFound++;
       }
       if (tx.hash === 'e112771fd43962abfe4e4623bf788d6d95ff1bd0f9b56a6a41fb9ed4dacc75f1') {
-        assert.strictEqual(tx.value, 1000000);
-        assert.strictEqual(tx.inputs[0].addresses[0], '3NLnALo49CFEF4tCRhCvz45ySSfz3UktZC');
-        assert.strictEqual(tx.inputs[1].addresses[0], '3NLnALo49CFEF4tCRhCvz45ySSfz3UktZC');
+        expect(tx.value).toBe(1000000);
+        expect(tx.inputs[0].addresses[0]).toBe('3NLnALo49CFEF4tCRhCvz45ySSfz3UktZC');
+        expect(tx.inputs[1].addresses[0]).toBe('3NLnALo49CFEF4tCRhCvz45ySSfz3UktZC');
         txFound++;
       }
       if (tx.hash === 'c94bdec21c72d3441245caa164b00315b131f6b72513369f4be1b00b9fb99cc5') {
-        assert.strictEqual(tx.inputs[0].addresses[0], '16Nf5X77RbFz9Mb6t2GFqxs3twQN1joBkD');
+        expect(tx.inputs[0].addresses[0]).toBe('16Nf5X77RbFz9Mb6t2GFqxs3twQN1joBkD');
         txFound++;
       }
       if (tx.hash === '51fc225ddf24f7e124f034637f46442645ca7ea2c442b28124d4bcdd04e30195') {
-        assert.strictEqual(tx.inputs[0].addresses[0], '3NLnALo49CFEF4tCRhCvz45ySSfz3UktZC');
+        expect(tx.inputs[0].addresses[0]).toBe('3NLnALo49CFEF4tCRhCvz45ySSfz3UktZC');
         txFound++;
       }
     }
-    assert.strictEqual(txFound, 4);
+    expect(txFound).toBe(4);
 
     await hd.fetchUtxo();
-    assert.strictEqual(hd.getUtxo().length, 2);
-    assert.strictEqual(hd.getDerivedUtxoFromOurTransaction().length, 2);
+    expect(hd.getUtxo().length).toBe(2);
+    expect(hd.getDerivedUtxoFromOurTransaction().length).toBe(2);
     const u1 = hd.getUtxo()[0];
     const u2 = hd.getDerivedUtxoFromOurTransaction()[0];
     delete u1.confirmations;
     delete u2.confirmations;
     delete u1.height;
     delete u2.height;
-    assert.deepStrictEqual(u1, u2);
+    expect(u1).toEqual(u2);
     const changeAddress = await hd.getChangeAddressAsync();
-    assert.ok(changeAddress && changeAddress.startsWith('bc1'));
+    expect(changeAddress && changeAddress.startsWith('bc1')).toBeTruthy();
 
     const { tx, inputs, outputs, fee } = hd.createTransaction(
       hd.getUtxo(),
@@ -231,21 +228,21 @@ describe('Bech32 Segwit HD (BIP84)', () => {
       changeAddress,
     );
 
-    assert.strictEqual(Math.round(fee / tx.byteLength()), 13);
+    expect(Math.round(fee / tx.byteLength())).toBe(13);
 
     let totalInput = 0;
     for (const inp of inputs) {
       totalInput += inp.value;
     }
 
-    assert.strictEqual(outputs.length, 2);
+    expect(outputs.length).toBe(2);
     let totalOutput = 0;
     for (const outp of outputs) {
       totalOutput += outp.value;
     }
 
-    assert.strictEqual(totalInput - totalOutput, fee);
-    assert.strictEqual(outputs[outputs.length - 1].address, changeAddress);
+    expect(totalInput - totalOutput).toBe(fee);
+    expect(outputs[outputs.length - 1].address).toBe(changeAddress);
   });
 
   it('wasEverUsed() works', async () => {
@@ -256,10 +253,10 @@ describe('Bech32 Segwit HD (BIP84)', () => {
 
     let hd = new HDSegwitBech32Wallet();
     hd.setSecret(process.env.HD_MNEMONIC);
-    assert.ok(await hd.wasEverUsed());
+    expect(await hd.wasEverUsed()).toBeTruthy();
 
     hd = new HDSegwitBech32Wallet();
     await hd.generate();
-    assert.ok(!(await hd.wasEverUsed()), hd.getSecret());
+    expect(!(await hd.wasEverUsed())).toBeTruthy();
   });
 });

--- a/tests/integration/hd-segwit-p2sh-wallet.test.js
+++ b/tests/integration/hd-segwit-p2sh-wallet.test.js
@@ -1,6 +1,5 @@
+import * as bitcoin from 'bitcoinjs-lib';
 import { HDSegwitP2SHWallet } from '../../class';
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
 const BlueElectrum = require('../../blue_modules/BlueElectrum'); // so it connects ASAP
@@ -35,7 +34,7 @@ it('HD (BIP49) can work with a gap', async function () {
   //   console.log('external', c, hd._getExternalAddressByIndex(c));
   // }
   await hd.fetchTransactions();
-  assert.ok(hd.getTransactions().length >= 3);
+  expect(hd.getTransactions().length >= 3).toBeTruthy();
 });
 
 it('Segwit HD (BIP49) can fetch more data if pointers to last_used_addr are lagging behind', async function () {
@@ -45,7 +44,7 @@ it('Segwit HD (BIP49) can fetch more data if pointers to last_used_addr are lagg
   hd.next_free_address_index = 50;
   await hd.fetchBalance();
   await hd.fetchTransactions();
-  assert.strictEqual(hd.getTransactions().length, 153);
+  expect(hd.getTransactions().length).toBe(153);
 });
 
 it('HD (BIP49) can create TX', async () => {
@@ -55,16 +54,16 @@ it('HD (BIP49) can create TX', async () => {
   }
   const hd = new HDSegwitP2SHWallet();
   hd.setSecret(process.env.HD_MNEMONIC_BIP49);
-  assert.ok(hd.validateMnemonic());
+  expect(hd.validateMnemonic()).toBeTruthy();
 
   await hd.fetchBalance();
   await hd.fetchUtxo();
-  assert.ok(typeof hd.utxo[0].confirmations === 'number');
-  assert.ok(hd.utxo[0].txid);
-  assert.ok(hd.utxo[0].vout !== undefined);
-  assert.ok(hd.utxo[0].amount);
-  assert.ok(hd.utxo[0].address);
-  assert.ok(hd.utxo[0].wif);
+  expect(typeof hd.utxo[0].confirmations === 'number').toBeTruthy();
+  expect(hd.utxo[0].txid).toBeTruthy();
+  expect(hd.utxo[0].vout !== undefined).toBeTruthy();
+  expect(hd.utxo[0].amount).toBeTruthy();
+  expect(hd.utxo[0].address).toBeTruthy();
+  expect(hd.utxo[0].wif).toBeTruthy();
 
   let txNew = hd.createTransaction(
     hd.getUtxo(),
@@ -73,18 +72,17 @@ it('HD (BIP49) can create TX', async () => {
     hd._getInternalAddressByIndex(hd.next_free_change_address_index),
   );
   let tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-  assert.strictEqual(
-    txNew.tx.toHex(),
+  expect(txNew.tx.toHex()).toBe(
     '0200000000010187c9acd9d5714845343b18abaa26cb83299be2487c22da9c0e270f241b4d9cfe0000000017160014a239b6a0cbc7aadc2e77643de36306a6167fad150000008002f40100000000000017a914a3a65daca3064280ae072b9d6773c027b30abace87ba6200000000000017a9140acff2c37ed45110baece4bb9d4dcc0c6309dbbd8702483045022100a14eb345f26933b29ba2a68075994ecf10f16286611c1d34ccd5850d977c25620220050e80c62ba64d99101253d94f756791f881bdb92100885fbe5ea3e29964573001210202ac3bd159e54dc31e65842ad5f9a10b4eb024e83864a319b27de65ee08b2a3900000000',
   );
-  assert.strictEqual(tx.ins.length, 1);
-  assert.strictEqual(tx.outs.length, 2);
-  assert.strictEqual(tx.outs[0].value, 500);
-  assert.strictEqual(tx.outs[1].value, 25274);
+  expect(tx.ins.length).toBe(1);
+  expect(tx.outs.length).toBe(2);
+  expect(tx.outs[0].value).toBe(500);
+  expect(tx.outs[1].value).toBe(25274);
   let toAddress = bitcoin.address.fromOutputScript(tx.outs[0].script);
   const changeAddress = bitcoin.address.fromOutputScript(tx.outs[1].script);
-  assert.strictEqual('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', toAddress);
-  assert.strictEqual(hd._getInternalAddressByIndex(hd.next_free_change_address_index), changeAddress);
+  expect('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK').toBe(toAddress);
+  expect(hd._getInternalAddressByIndex(hd.next_free_change_address_index)).toBe(changeAddress);
 
   //
 
@@ -95,10 +93,10 @@ it('HD (BIP49) can create TX', async () => {
     hd._getInternalAddressByIndex(hd.next_free_change_address_index),
   );
   tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-  assert.strictEqual(tx.ins.length, 1);
-  assert.strictEqual(tx.outs.length, 1);
+  expect(tx.ins.length).toBe(1);
+  expect(tx.outs.length).toBe(1);
   toAddress = bitcoin.address.fromOutputScript(tx.outs[0].script);
-  assert.strictEqual('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', toAddress);
+  expect('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK').toBe(toAddress);
 
   // testing sendMAX
   const utxo = [
@@ -142,8 +140,8 @@ it('HD (BIP49) can create TX', async () => {
     hd._getInternalAddressByIndex(hd.next_free_change_address_index),
   );
   tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-  assert.strictEqual(tx.outs.length, 1);
-  assert.ok(tx.outs[0].value > 77000);
+  expect(tx.outs.length).toBe(1);
+  expect(tx.outs[0].value > 77000).toBeTruthy();
 
   // MAX with regular output
   txNew = hd.createTransaction(
@@ -153,9 +151,9 @@ it('HD (BIP49) can create TX', async () => {
     hd._getInternalAddressByIndex(hd.next_free_change_address_index),
   );
   tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-  assert.strictEqual(tx.outs.length, 2);
-  assert.ok(tx.outs[0].value > 50000);
-  assert.strictEqual(tx.outs[1].value, 25000);
+  expect(tx.outs.length).toBe(2);
+  expect(tx.outs[0].value > 50000).toBeTruthy();
+  expect(tx.outs[1].value).toBe(25000);
 });
 
 it('Segwit HD (BIP49) can fetch balance with many used addresses in hierarchy', async function () {
@@ -166,20 +164,20 @@ it('Segwit HD (BIP49) can fetch balance with many used addresses in hierarchy', 
 
   const hd = new HDSegwitP2SHWallet();
   hd.setSecret(process.env.HD_MNEMONIC_BIP49_MANY_TX);
-  assert.ok(hd.validateMnemonic());
+  expect(hd.validateMnemonic()).toBeTruthy();
   const start = +new Date();
   await hd.fetchBalance();
   const end = +new Date();
   const took = (end - start) / 1000;
   took > 15 && console.warn('took', took, "sec to fetch huge HD wallet's balance");
-  assert.strictEqual(hd.getBalance(), 51432);
+  expect(hd.getBalance()).toBe(51432);
 
   await hd.fetchUtxo();
-  assert.ok(hd.utxo.length > 0);
-  assert.ok(hd.utxo[0].txid);
-  assert.ok(hd.utxo[0].vout === 0);
-  assert.ok(hd.utxo[0].amount);
+  expect(hd.utxo.length > 0).toBeTruthy();
+  expect(hd.utxo[0].txid).toBeTruthy();
+  expect(hd.utxo[0].vout === 0).toBeTruthy();
+  expect(hd.utxo[0].amount).toBeTruthy();
 
   await hd.fetchTransactions();
-  assert.strictEqual(hd.getTransactions().length, 107);
+  expect(hd.getTransactions().length).toBe(107);
 });

--- a/tests/integration/hodlhodl.test.js
+++ b/tests/integration/hodlhodl.test.js
@@ -1,8 +1,7 @@
+import * as bitcoin from 'bitcoinjs-lib';
+
 import { LegacyWallet, SegwitBech32Wallet, SegwitP2SHWallet } from '../../class';
 import { HodlHodlApi } from '../../class/hodl-hodl-api';
-
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
 
 it.skip('can verify escrow address', () => {
   const encryptedSeed =
@@ -14,8 +13,10 @@ it.skip('can verify escrow address', () => {
     '522103dc0edfea797214be15a69148bfb1dffa1c8295c05300b7632143a77d918b4a0821031fec42b60942633616aff7e245796b5caae6bf59ef5ba688b0a59f33f08b2896210351fd6e52d38a37b9834909e3f8345c471346e1f5990ec00dafcc53e238d3c7c553ae';
 
   const Hodl = new HodlHodlApi();
-  assert.ok(Hodl.verifyEscrowAddress(encryptedSeed, encryptPassword, index, address, witnessScript));
-  assert.ok(!Hodl.verifyEscrowAddress(encryptedSeed, encryptPassword, index, '3QDf45WU88t2kEBJTHcTPvtrXZx88SkmKC', witnessScript));
+  expect(Hodl.verifyEscrowAddress(encryptedSeed, encryptPassword, index, address, witnessScript)).toBeTruthy();
+  expect(
+    !Hodl.verifyEscrowAddress(encryptedSeed, encryptPassword, index, '3QDf45WU88t2kEBJTHcTPvtrXZx88SkmKC', witnessScript),
+  ).toBeTruthy();
 });
 
 it('can create escrow address', () => {
@@ -43,7 +44,7 @@ it('can create escrow address', () => {
   const address = p2shP2wshP2ms.address;
   // console.warn(p2sh_p2wsh_p2ms);
 
-  assert.strictEqual(address, '391ygT71qeF7vbYjxsUZPzH6oDc7Rv4vTs');
+  expect(address).toBe('391ygT71qeF7vbYjxsUZPzH6oDc7Rv4vTs');
 
   const signedByServerReleaseTransaction =
     '01000000000101356493a6b93bf17e66d7ec12f1a54e279da17f669f41bf11405a6f2617e1022501000000232200208ec72df31adaa132e40a5f5033589c0e18b67a64cdc65e9c75027fe1efd10f4cffffffff02227e010000000000160014b1c61a73a529c315a1f2b87df12c7948d86ba10c26020000000000001976a914d0b77eb1502c81c4093da9aa6eccfdf560cdd6b288ac040047304402205a447563db8e74177a1fbcdcfe7b7b22556c39d68c17ffe0a4a02609d78c83130220772fbf3261b6031a915eca7e441092df3fe6e4c7d4f389c4921c1f18661c20f401460000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000069522103141024b18929bfec5b567c12b1693d4ae02783873e2e3aa444f0d6950cb97dee210208137b6cb23cef02c0529948a2ed12fbeed0813cce555de073319f56e215ee1b21035ed5825258d4f1685df804f21296b9957cd319cf5949ace92fa5767eb7a946f253ae00000000';
@@ -99,12 +100,12 @@ describe.skip('HodlHodl API', function () {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 200 * 1000;
     const Hodl = new HodlHodlApi();
     const countries = await Hodl.getCountries();
-    assert.ok(countries[0]);
-    assert.ok(countries[0].code);
-    assert.ok(countries[0].name);
-    assert.ok(countries[0].native_name);
-    assert.ok(countries[0].currency_code);
-    assert.ok(countries[0].currency_name);
+    expect(countries[0]).toBeTruthy();
+    expect(countries[0].code).toBeTruthy();
+    expect(countries[0].name).toBeTruthy();
+    expect(countries[0].native_name).toBeTruthy();
+    expect(countries[0].currency_code).toBeTruthy();
+    expect(countries[0].currency_name).toBeTruthy();
   });
 
   it('can get offers', async () => {
@@ -129,15 +130,15 @@ describe.skip('HodlHodl API', function () {
       },
     );
 
-    assert.ok(offers[0]);
-    assert.ok(offers[0].asset_code === 'BTC');
-    assert.ok(offers[0].country_code);
-    assert.ok(offers[0].side === HodlHodlApi.FILTERS_SIDE_VALUE_SELL);
-    assert.ok(typeof offers[0].title !== 'undefined', JSON.stringify(offers[0], null, 2));
-    assert.ok(typeof offers[0].description !== 'undefined', JSON.stringify(offers[0], null, 2));
-    assert.ok(offers[0].price);
-    assert.ok(offers[0].payment_method_instructions);
-    assert.ok(offers[0].trader);
+    expect(offers[0]).toBeTruthy();
+    expect(offers[0].asset_code === 'BTC').toBeTruthy();
+    expect(offers[0].country_code).toBeTruthy();
+    expect(offers[0].side === HodlHodlApi.FILTERS_SIDE_VALUE_SELL).toBeTruthy();
+    expect(typeof offers[0].title !== 'undefined').toBeTruthy();
+    expect(typeof offers[0].description !== 'undefined').toBeTruthy();
+    expect(offers[0].price).toBeTruthy();
+    expect(offers[0].payment_method_instructions).toBeTruthy();
+    expect(offers[0].trader).toBeTruthy();
   });
 
   it('can get offer', async () => {
@@ -148,8 +149,8 @@ describe.skip('HodlHodl API', function () {
     if (!process.env.HODLHODL_OFFER_ID) return;
     const Hodl = new HodlHodlApi();
     const offer = await Hodl.getOffer(process.env.HODLHODL_OFFER_ID);
-    assert.ok(offer.id);
-    assert.ok(offer.version);
+    expect(offer.id).toBeTruthy();
+    expect(offer.version).toBeTruthy();
   });
 
   it('can accept offer', async () => {
@@ -161,7 +162,7 @@ describe.skip('HodlHodl API', function () {
     if (!process.env.HODLHODL_OFFER_ID) return;
     const Hodl = new HodlHodlApi();
     const offer = await Hodl.getOffer(process.env.HODLHODL_OFFER_ID);
-    assert.strictEqual(offer.side, 'sell');
+    expect(offer.side).toBe('sell');
     const paymentMethodInstructionId = offer.payment_method_instructions[0].id;
     const paymentMethodInstructionVersion = offer.payment_method_instructions[0].version;
     const fiatValue = 100;
@@ -184,9 +185,9 @@ describe.skip('HodlHodl API', function () {
     if (!process.env.HODLHODL_CONTRACT_ID) return;
     const Hodl = new HodlHodlApi();
     const contract = await Hodl.getContract(process.env.HODLHODL_CONTRACT_ID);
-    assert.ok(contract.your_role);
-    assert.ok(contract.volume);
-    assert.ok(contract.escrow);
+    expect(contract.your_role).toBeTruthy();
+    expect(contract.volume).toBeTruthy();
+    expect(contract.escrow).toBeTruthy();
   });
 
   it('can mark contract as confirmed', async () => {
@@ -208,10 +209,10 @@ describe.skip('HodlHodl API', function () {
     }
     const Hodl = new HodlHodlApi();
     const methods = await Hodl.getPaymentMethods(HodlHodlApi.FILTERS_COUNTRY_VALUE_GLOBAL);
-    assert.ok(methods[0]);
-    assert.ok(methods[0].id);
-    assert.ok(methods[0].type);
-    assert.ok(methods[0].name);
+    expect(methods[0]).toBeTruthy();
+    expect(methods[0].id).toBeTruthy();
+    expect(methods[0].type).toBeTruthy();
+    expect(methods[0].name).toBeTruthy();
   });
 
   it('cat get currencies', async () => {
@@ -221,10 +222,10 @@ describe.skip('HodlHodl API', function () {
     }
     const Hodl = new HodlHodlApi();
     const currencies = await Hodl.getCurrencies();
-    assert.ok(currencies[0]);
-    assert.ok(currencies[0].code);
-    assert.ok(currencies[0].name);
-    assert.ok(currencies[0].type);
+    expect(currencies[0]).toBeTruthy();
+    expect(currencies[0].code).toBeTruthy();
+    expect(currencies[0].name).toBeTruthy();
+    expect(currencies[0].type).toBeTruthy();
   });
 
   it('cat get myself', async () => {
@@ -234,7 +235,7 @@ describe.skip('HodlHodl API', function () {
     }
     const Hodl = new HodlHodlApi();
     const myself = await Hodl.getMyself();
-    assert.ok(myself.encrypted_seed);
+    expect(myself.encrypted_seed).toBeTruthy();
   });
 
   it('can create signature for autologin', async () => {
@@ -244,6 +245,6 @@ describe.skip('HodlHodl API', function () {
       'cce14197a08ebab7cfbb41cfce9fe91e0f31d572d3f48571ca3c30bfd516f769',
       1589980224,
     );
-    assert.strictEqual(sig, '1d2a51ca2c54ff9107a3460b22f01bc877e527a9a719d81b32038741332159fc');
+    expect(sig).toBe('1d2a51ca2c54ff9107a3460b22f01bc877e527a9a719d81b32038741332159fc');
   });
 });

--- a/tests/integration/import.test.js
+++ b/tests/integration/import.test.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   HDSegwitElectrumSeedP2WPKHWallet,
   HDLegacyBreadwalletWallet,
@@ -14,9 +15,7 @@ import {
   SLIP39SegwitBech32Wallet,
 } from '../../class';
 import WalletImport from '../../class/wallet-import';
-import React from 'react';
 import Notifications from '../../blue_modules/notifications';
-const assert = require('assert');
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
 const BlueElectrum = require('../../blue_modules/BlueElectrum'); // so it connects ASAP
@@ -68,9 +67,9 @@ describe('import procedure', function () {
     await WalletImport.processImportText(
       'always direct find escape liar turn differ shy tool gap elder galaxy lawn wild movie fog moon spread casual inner box diagram outdoor tell',
     );
-    assert.strictEqual(lastImportedWallet.type, HDSegwitBech32Wallet.type);
-    assert.strictEqual(lastImportedWallet._getExternalAddressByIndex(0), 'bc1qth9qxvwvdthqmkl6x586ukkq8zvumd38nxr08l');
-    assert.strictEqual(lastImportedWallet.getLabel(), 'Imported HD SegWit (BIP84 Bech32 Native)');
+    expect(lastImportedWallet.type).toBe(HDSegwitBech32Wallet.type);
+    expect(lastImportedWallet._getExternalAddressByIndex(0)).toBe('bc1qth9qxvwvdthqmkl6x586ukkq8zvumd38nxr08l');
+    expect(lastImportedWallet.getLabel()).toBe('Imported HD SegWit (BIP84 Bech32 Native)');
   });
 
   it('can import BIP84 with passphrase', async () => {
@@ -78,78 +77,78 @@ describe('import procedure', function () {
       'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
       'BlueWallet',
     );
-    assert.strictEqual(lastImportedWallet.type, HDSegwitBech32Wallet.type);
-    assert.strictEqual(lastImportedWallet._getExternalAddressByIndex(0), 'bc1qe8q660wfj6uvqg7zyn86jcsux36natklqnfdrc');
-    assert.strictEqual(lastImportedWallet.getLabel(), 'Imported HD SegWit (BIP84 Bech32 Native)');
+    expect(lastImportedWallet.type).toBe(HDSegwitBech32Wallet.type);
+    expect(lastImportedWallet._getExternalAddressByIndex(0)).toBe('bc1qe8q660wfj6uvqg7zyn86jcsux36natklqnfdrc');
+    expect(lastImportedWallet.getLabel()).toBe('Imported HD SegWit (BIP84 Bech32 Native)');
   });
 
   it('can import Legacy', async () => {
     await WalletImport.processImportText('KztVRmc2EJJBHi599mCdXrxMTsNsGy3NUjc3Fb3FFDSMYyMDRjnv');
-    assert.strictEqual(lastImportedWallet.type, LegacyWallet.type);
-    assert.strictEqual(lastImportedWallet.getAddress(), '1AhcdMCzby4VXgqrexuMfh7eiSprRFtN78');
-    assert.strictEqual(lastImportedWallet.getLabel(), 'Imported Legacy (P2PKH)');
+    expect(lastImportedWallet.type).toBe(LegacyWallet.type);
+    expect(lastImportedWallet.getAddress()).toBe('1AhcdMCzby4VXgqrexuMfh7eiSprRFtN78');
+    expect(lastImportedWallet.getLabel()).toBe('Imported Legacy (P2PKH)');
   });
 
   it('can import Legacy P2SH Segwit', async () => {
     await WalletImport.processImportText('L3NxFnYoBGjJ5PhxrxV6jorvjnc8cerYJx71vXU6ta8BXQxHVZya');
-    assert.strictEqual(lastImportedWallet.type, SegwitP2SHWallet.type);
-    assert.strictEqual(lastImportedWallet.getAddress(), '3KM9VfdsDf9uT7uwZagoKgVn8z35m9CtSM');
-    assert.strictEqual(lastImportedWallet.getLabel(), 'Imported SegWit (P2SH)');
+    expect(lastImportedWallet.type).toBe(SegwitP2SHWallet.type);
+    expect(lastImportedWallet.getAddress()).toBe('3KM9VfdsDf9uT7uwZagoKgVn8z35m9CtSM');
+    expect(lastImportedWallet.getLabel()).toBe('Imported SegWit (P2SH)');
   });
 
   it('can import Legacy Bech32 Segwit', async () => {
     await WalletImport.processImportText('L1T6FfKpKHi8JE6eBKrsXkenw34d5FfFzJUZ6dLs2utxkSvsDfxZ');
-    assert.strictEqual(lastImportedWallet.type, SegwitBech32Wallet.type);
-    assert.strictEqual(lastImportedWallet.getAddress(), 'bc1q763rf54hzuncmf8dtlz558uqe4f247mq39rjvr');
-    assert.strictEqual(lastImportedWallet.getLabel(), 'Imported P2 WPKH');
+    expect(lastImportedWallet.type).toBe(SegwitBech32Wallet.type);
+    expect(lastImportedWallet.getAddress()).toBe('bc1q763rf54hzuncmf8dtlz558uqe4f247mq39rjvr');
+    expect(lastImportedWallet.getLabel()).toBe('Imported P2 WPKH');
   });
 
   it('can import BIP44', async () => {
     await WalletImport.processImportText(
       'sting museum endless duty nice riot because swallow brother depth weapon merge woman wish hold finish venture gauge stomach bomb device bracket agent parent',
     );
-    assert.strictEqual(lastImportedWallet.type, HDLegacyP2PKHWallet.type);
-    assert.strictEqual(lastImportedWallet._getExternalAddressByIndex(0), '1EgDbwf5nXp9knoaWW6nV6N91EK3EFQ5vC');
-    assert.strictEqual(lastImportedWallet.getLabel(), 'Imported HD Legacy (BIP44 P2PKH)');
+    expect(lastImportedWallet.type).toBe(HDLegacyP2PKHWallet.type);
+    expect(lastImportedWallet._getExternalAddressByIndex(0)).toBe('1EgDbwf5nXp9knoaWW6nV6N91EK3EFQ5vC');
+    expect(lastImportedWallet.getLabel()).toBe('Imported HD Legacy (BIP44 P2PKH)');
   });
 
   it('can import BIP49', async () => {
     await WalletImport.processImportText(
       'believe torch sport lizard absurd retreat scale layer song pen clump combine window staff dream filter latin bicycle vapor anchor put clean gain slush',
     );
-    assert.strictEqual(lastImportedWallet.type, HDSegwitP2SHWallet.type);
-    assert.strictEqual(lastImportedWallet._getExternalAddressByIndex(0), '3EoqYYp7hQSHn5nHqRtWzkgqmK3caQ2SUu');
-    assert.strictEqual(lastImportedWallet.getLabel(), 'Imported HD SegWit (BIP49 P2SH)');
+    expect(lastImportedWallet.type).toBe(HDSegwitP2SHWallet.type);
+    expect(lastImportedWallet._getExternalAddressByIndex(0)).toBe('3EoqYYp7hQSHn5nHqRtWzkgqmK3caQ2SUu');
+    expect(lastImportedWallet.getLabel()).toBe('Imported HD SegWit (BIP49 P2SH)');
   });
 
   it('can import HD Legacy Electrum (BIP32 P2PKH)', async () => {
     await WalletImport.processImportText('eight derive blast guide smoke piece coral burden lottery flower tomato flame');
-    assert.strictEqual(lastImportedWallet.type, HDLegacyElectrumSeedP2PKHWallet.type);
-    assert.strictEqual(lastImportedWallet._getExternalAddressByIndex(0), '1FgVfJ5D3HyKWKC4xk36Cio7MUaxxnXaVd');
-    assert.strictEqual(lastImportedWallet.getLabel(), 'Imported HD Legacy Electrum (BIP32 P2PKH)');
+    expect(lastImportedWallet.type).toBe(HDLegacyElectrumSeedP2PKHWallet.type);
+    expect(lastImportedWallet._getExternalAddressByIndex(0)).toBe('1FgVfJ5D3HyKWKC4xk36Cio7MUaxxnXaVd');
+    expect(lastImportedWallet.getLabel()).toBe('Imported HD Legacy Electrum (BIP32 P2PKH)');
   });
 
   it('can import BreadWallet', async () => {
     await WalletImport.processImportText(
       'tired lesson alert attend giggle fancy nose enter ethics fashion fly dove dutch hidden toe argue save fish catch patient waste gift divorce whisper',
     );
-    assert.strictEqual(lastImportedWallet.type, HDLegacyBreadwalletWallet.type);
-    assert.strictEqual(lastImportedWallet._getExternalAddressByIndex(0), '1j7TbbTv8adcZFr4RC7Cyr7GN9VGYTecu');
-    assert.strictEqual(lastImportedWallet.getLabel(), 'Imported HD Legacy Breadwallet (P2PKH)');
+    expect(lastImportedWallet.type).toBe(HDLegacyBreadwalletWallet.type);
+    expect(lastImportedWallet._getExternalAddressByIndex(0)).toBe('1j7TbbTv8adcZFr4RC7Cyr7GN9VGYTecu');
+    expect(lastImportedWallet.getLabel()).toBe('Imported HD Legacy Breadwallet (P2PKH)');
   });
 
   it('can import HD Electrum (BIP32 P2WPKH)', async () => {
     await WalletImport.processImportText('noble mimic pipe merry knife screen enter dune crop bonus slice card');
-    assert.strictEqual(lastImportedWallet.type, HDSegwitElectrumSeedP2WPKHWallet.type);
-    assert.strictEqual(lastImportedWallet._getExternalAddressByIndex(0), 'bc1qzzanxnr3xv9a5ha264kpzpfq260qvuameslddu');
-    assert.strictEqual(lastImportedWallet.getLabel(), 'Imported HD Electrum (BIP32 P2WPKH)');
+    expect(lastImportedWallet.type).toBe(HDSegwitElectrumSeedP2WPKHWallet.type);
+    expect(lastImportedWallet._getExternalAddressByIndex(0)).toBe('bc1qzzanxnr3xv9a5ha264kpzpfq260qvuameslddu');
+    expect(lastImportedWallet.getLabel()).toBe('Imported HD Electrum (BIP32 P2WPKH)');
   });
 
   it('can import AEZEED', async () => {
     await WalletImport.processImportText(
       'abstract rhythm weird food attract treat mosquito sight royal actor surround ride strike remove guilt catch filter summer mushroom protect poverty cruel chaos pattern',
     );
-    assert.strictEqual(lastImportedWallet.type, HDAezeedWallet.type);
+    expect(lastImportedWallet.type).toBe(HDAezeedWallet.type);
   });
 
   it('can import AEZEED with password', async () => {
@@ -157,43 +156,43 @@ describe('import procedure', function () {
       'able mix price funny host express lawsuit congress antique float pig exchange vapor drip wide cup style apple tumble verb fix blush tongue market',
       'strongPassword',
     );
-    assert.strictEqual(lastImportedWallet.type, HDAezeedWallet.type);
+    expect(lastImportedWallet.type).toBe(HDAezeedWallet.type);
   });
 
   it('importing empty BIP39 should yield BIP84', async () => {
     const tempWallet = new HDSegwitBech32Wallet();
     await tempWallet.generate();
     await WalletImport.processImportText(tempWallet.getSecret());
-    assert.strictEqual(lastImportedWallet.type, HDSegwitBech32Wallet.type);
+    expect(lastImportedWallet.type).toBe(HDSegwitBech32Wallet.type);
   });
 
   it('can import Legacy with uncompressed pubkey', async () => {
     await WalletImport.processImportText('5KE6tf9vhYkzYSbgEL6M7xvkY69GMFHF3WxzYaCFMvwMxn3QgRS');
-    assert.strictEqual(lastImportedWallet.getSecret(), '5KE6tf9vhYkzYSbgEL6M7xvkY69GMFHF3WxzYaCFMvwMxn3QgRS');
-    assert.strictEqual(lastImportedWallet.type, LegacyWallet.type);
-    assert.strictEqual(lastImportedWallet.getAddress(), '1GsJDeD6fqS912egpjhdjrUTiCh1hhwBgQ');
-    assert.strictEqual(lastImportedWallet.getLabel(), 'Imported Legacy (P2PKH)');
+    expect(lastImportedWallet.getSecret()).toBe('5KE6tf9vhYkzYSbgEL6M7xvkY69GMFHF3WxzYaCFMvwMxn3QgRS');
+    expect(lastImportedWallet.type).toBe(LegacyWallet.type);
+    expect(lastImportedWallet.getAddress()).toBe('1GsJDeD6fqS912egpjhdjrUTiCh1hhwBgQ');
+    expect(lastImportedWallet.getLabel()).toBe('Imported Legacy (P2PKH)');
   });
 
   it('can import BIP38 encrypted backup', async () => {
     await WalletImport.processImportText('6PnU5voARjBBykwSddwCdcn6Eu9EcsK24Gs5zWxbJbPZYW7eiYQP8XgKbN', 'qwerty');
-    assert.strictEqual(lastImportedWallet.getSecret(), 'KxqRtpd9vFju297ACPKHrGkgXuberTveZPXbRDiQ3MXZycSQYtjc');
-    assert.strictEqual(lastImportedWallet.type, LegacyWallet.type);
-    assert.strictEqual(lastImportedWallet.getAddress(), '1639W2kM6UY9PdavMQeLqG4SuUEae9NZfq');
-    assert.strictEqual(lastImportedWallet.getLabel(), 'Imported Legacy (P2PKH)');
+    expect(lastImportedWallet.getSecret()).toBe('KxqRtpd9vFju297ACPKHrGkgXuberTveZPXbRDiQ3MXZycSQYtjc');
+    expect(lastImportedWallet.type).toBe(LegacyWallet.type);
+    expect(lastImportedWallet.getAddress()).toBe('1639W2kM6UY9PdavMQeLqG4SuUEae9NZfq');
+    expect(lastImportedWallet.getLabel()).toBe('Imported Legacy (P2PKH)');
   });
 
   it('can import watch-only address', async () => {
     await WalletImport.processImportText('1AhcdMCzby4VXgqrexuMfh7eiSprRFtN78');
-    assert.strictEqual(lastImportedWallet.type, WatchOnlyWallet.type);
+    expect(lastImportedWallet.type).toBe(WatchOnlyWallet.type);
     await WalletImport.processImportText('3EoqYYp7hQSHn5nHqRtWzkgqmK3caQ2SUu');
-    assert.strictEqual(lastImportedWallet.type, WatchOnlyWallet.type);
+    expect(lastImportedWallet.type).toBe(WatchOnlyWallet.type);
     await WalletImport.processImportText('bc1q8j4lk4qlhun0n7h5ahfslfldc8zhlxgynfpdj2');
-    assert.strictEqual(lastImportedWallet.type, WatchOnlyWallet.type);
+    expect(lastImportedWallet.type).toBe(WatchOnlyWallet.type);
     await WalletImport.processImportText(
       'zpub6r7jhKKm7BAVx3b3nSnuadY1WnshZYkhK8gKFoRLwK9rF3Mzv28BrGcCGA3ugGtawi1WLb2vyjQAX9ZTDGU5gNk2bLdTc3iEXr6tzR1ipNP',
     );
-    assert.strictEqual(lastImportedWallet.type, WatchOnlyWallet.type);
+    expect(lastImportedWallet.type).toBe(WatchOnlyWallet.type);
   });
 
   it('can import slip39 wallet', async () => {
@@ -205,7 +204,7 @@ describe('import procedure', function () {
       'crystal lungs academic acid corner infant satisfy spider alcohol laser golden equation fiscal epidemic infant scholar space findings tadpole belong\n' +
         'crystal lungs academic agency class payment actress avoid rebound ordinary exchange petition tendency mild mobile spine robin fancy shelter increase',
     );
-    assert.strictEqual(lastImportedWallet.type, SLIP39SegwitP2SHWallet.type);
+    expect(lastImportedWallet.type).toBe(SLIP39SegwitP2SHWallet.type);
   });
 
   it('can import slip39 wallet with password', async () => {
@@ -218,14 +217,14 @@ describe('import procedure', function () {
         'crystal lungs academic agency class payment actress avoid rebound ordinary exchange petition tendency mild mobile spine robin fancy shelter increase',
       'BlueWallet',
     );
-    assert.strictEqual(lastImportedWallet.type, SLIP39SegwitBech32Wallet.type);
-    assert.strictEqual(lastImportedWallet._getExternalAddressByIndex(0), 'bc1q5k23fle53w8a3982m82e9f6hqlnrh3mv5s9s6z');
+    expect(lastImportedWallet.type).toBe(SLIP39SegwitBech32Wallet.type);
+    expect(lastImportedWallet._getExternalAddressByIndex(0)).toBe('bc1q5k23fle53w8a3982m82e9f6hqlnrh3mv5s9s6z');
   });
 
   it('can import watch-only Cobo vault export', async () => {
     await WalletImport.processImportText(
       '{"ExtPubKey":"zpub6riZchHnrWzhhZ3Z4dhCJmesGyafMmZBRC9txhnidR313XJbcv4KiDubderKHhL7rMsqacYd82FQ38e4whgs8Dg7CpsxX3dSGWayXsEerF4","MasterFingerprint":"7D2F0272","AccountKeyPath":"84\'\\/0\'\\/0\'","CoboVaultFirmwareVersion":"2.6.1(BTC-Only)"}',
     );
-    assert.strictEqual(lastImportedWallet.type, WatchOnlyWallet.type);
+    expect(lastImportedWallet.type).toBe(WatchOnlyWallet.type);
   });
 });

--- a/tests/integration/legacy-wallet.test.js
+++ b/tests/integration/legacy-wallet.test.js
@@ -1,5 +1,4 @@
 import { LegacyWallet, SegwitP2SHWallet, SegwitBech32Wallet } from '../../class';
-const assert = require('assert');
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
 const BlueElectrum = require('../../blue_modules/BlueElectrum'); // so it connects ASAP
@@ -24,61 +23,61 @@ describe('LegacyWallet', function () {
     const key = JSON.stringify(a);
 
     const b = LegacyWallet.fromJson(key);
-    assert.strictEqual(b.type, LegacyWallet.type);
-    assert.strictEqual(key, JSON.stringify(b));
+    expect(b.type).toBe(LegacyWallet.type);
+    expect(key).toBe(JSON.stringify(b));
   });
 
   it('can validate addresses', () => {
     const w = new LegacyWallet();
-    assert.ok(w.isAddressValid('12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG'));
-    assert.ok(!w.isAddressValid('12eQ9m4sgAwTSQoNXkRABKhCXCsjm2j'));
-    assert.ok(w.isAddressValid('3BDsBDxDimYgNZzsqszNZobqQq3yeUoJf2'));
-    assert.ok(!w.isAddressValid('3BDsBDxDimYgNZzsqszNZobqQq3yeUo'));
-    assert.ok(!w.isAddressValid('12345'));
-    assert.ok(w.isAddressValid('bc1quuafy8htjjj263cvpj7md84magzmc8svmh8lrm'));
-    assert.ok(w.isAddressValid('BC1QH6TF004TY7Z7UN2V5NTU4MKF630545GVHS45U7'));
+    expect(w.isAddressValid('12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG')).toBeTruthy();
+    expect(!w.isAddressValid('12eQ9m4sgAwTSQoNXkRABKhCXCsjm2j')).toBeTruthy();
+    expect(w.isAddressValid('3BDsBDxDimYgNZzsqszNZobqQq3yeUoJf2')).toBeTruthy();
+    expect(!w.isAddressValid('3BDsBDxDimYgNZzsqszNZobqQq3yeUo')).toBeTruthy();
+    expect(!w.isAddressValid('12345')).toBeTruthy();
+    expect(w.isAddressValid('bc1quuafy8htjjj263cvpj7md84magzmc8svmh8lrm')).toBeTruthy();
+    expect(w.isAddressValid('BC1QH6TF004TY7Z7UN2V5NTU4MKF630545GVHS45U7')).toBeTruthy();
   });
 
   it('can fetch balance', async () => {
     const w = new LegacyWallet();
     w._address = '115fUy41sZkAG14CmdP1VbEKcNRZJWkUWG'; // hack internals
-    assert.ok(w.weOwnAddress('115fUy41sZkAG14CmdP1VbEKcNRZJWkUWG'));
-    assert.ok(!w.weOwnAddress('aaa'));
-    assert.ok(!w.weOwnAddress(false));
-    assert.ok(w.getBalance() === 0);
-    assert.ok(w.getUnconfirmedBalance() === 0);
-    assert.ok(w._lastBalanceFetch === 0);
+    expect(w.weOwnAddress('115fUy41sZkAG14CmdP1VbEKcNRZJWkUWG')).toBeTruthy();
+    expect(!w.weOwnAddress('aaa')).toBeTruthy();
+    expect(!w.weOwnAddress(false)).toBeTruthy();
+    expect(w.getBalance() === 0).toBeTruthy();
+    expect(w.getUnconfirmedBalance() === 0).toBeTruthy();
+    expect(w._lastBalanceFetch === 0).toBeTruthy();
     await w.fetchBalance();
-    assert.ok(w.getBalance() === 18262000);
-    assert.ok(w.getUnconfirmedBalance() === 0);
-    assert.ok(w._lastBalanceFetch > 0);
+    expect(w.getBalance() === 18262000).toBeTruthy();
+    expect(w.getUnconfirmedBalance() === 0).toBeTruthy();
+    expect(w._lastBalanceFetch > 0).toBeTruthy();
   });
 
   it('can fetch TXs and derive UTXO from them', async () => {
     const w = new LegacyWallet();
     w._address = '3GCvDBAktgQQtsbN6x5DYiQCMmgZ9Yk8BK';
     await w.fetchTransactions();
-    assert.strictEqual(w.getTransactions().length, 1);
+    expect(w.getTransactions().length).toBe(1);
 
     for (const tx of w.getTransactions()) {
-      assert.ok(tx.hash);
-      assert.ok(tx.value);
-      assert.ok(tx.received);
-      assert.ok(tx.confirmations > 1);
+      expect(tx.hash).toBeTruthy();
+      expect(tx.value).toBeTruthy();
+      expect(tx.received).toBeTruthy();
+      expect(tx.confirmations > 1).toBeTruthy();
     }
 
-    assert.ok(w.weOwnTransaction('b2ac59bc282083498d1e87805d89bef9d3f3bc216c1d2c4dfaa2e2911b547100'));
-    assert.ok(!w.weOwnTransaction('825c12f277d1f84911ac15ad1f41a3de28e9d906868a930b0a7bca61b17c8881'));
+    expect(w.weOwnTransaction('b2ac59bc282083498d1e87805d89bef9d3f3bc216c1d2c4dfaa2e2911b547100')).toBeTruthy();
+    expect(!w.weOwnTransaction('825c12f277d1f84911ac15ad1f41a3de28e9d906868a930b0a7bca61b17c8881')).toBeTruthy();
 
-    assert.strictEqual(w.getUtxo().length, 1);
+    expect(w.getUtxo().length).toBe(1);
 
     for (const tx of w.getUtxo()) {
-      assert.strictEqual(tx.txid, 'b2ac59bc282083498d1e87805d89bef9d3f3bc216c1d2c4dfaa2e2911b547100');
-      assert.strictEqual(tx.vout, 0);
-      assert.strictEqual(tx.address, '3GCvDBAktgQQtsbN6x5DYiQCMmgZ9Yk8BK');
-      assert.strictEqual(tx.value, 51432);
-      assert.strictEqual(tx.value, tx.amount);
-      assert.ok(tx.confirmations > 0);
+      expect(tx.txid).toBe('b2ac59bc282083498d1e87805d89bef9d3f3bc216c1d2c4dfaa2e2911b547100');
+      expect(tx.vout).toBe(0);
+      expect(tx.address).toBe('3GCvDBAktgQQtsbN6x5DYiQCMmgZ9Yk8BK');
+      expect(tx.value).toBe(51432);
+      expect(tx.value).toBe(tx.amount);
+      expect(tx.confirmations > 0).toBeTruthy();
     }
   });
 
@@ -95,12 +94,12 @@ describe('LegacyWallet', function () {
       w._address = address;
       await w.fetchTransactions();
 
-      assert.ok(w.getTransactions().length > 0);
+      expect(w.getTransactions().length > 0).toBeTruthy();
       for (const tx of w.getTransactions()) {
-        assert.ok(tx.hash);
-        assert.ok(tx.value);
-        assert.ok(tx.received);
-        assert.ok(tx.confirmations > 1);
+        expect(tx.hash).toBeTruthy();
+        expect(tx.value).toBeTruthy();
+        expect(tx.received).toBeTruthy();
+        expect(tx.confirmations > 1).toBeTruthy();
       }
     },
     240000,
@@ -110,13 +109,13 @@ describe('LegacyWallet', function () {
     const w = new LegacyWallet();
     w._address = '12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX';
     await w.fetchUtxo();
-    assert.ok(w.utxo.length > 0, 'unexpected empty UTXO');
-    assert.ok(w.getUtxo().length > 0, 'unexpected empty UTXO');
+    expect(w.utxo.length > 0).toBeTruthy();
+    expect(w.getUtxo().length > 0).toBeTruthy();
 
-    assert.ok(w.getUtxo()[0].value);
-    assert.ok(w.getUtxo()[0].vout === 1, JSON.stringify(w.getUtxo()[0]));
-    assert.ok(w.getUtxo()[0].txid);
-    assert.ok(w.getUtxo()[0].confirmations);
+    expect(w.getUtxo()[0].value).toBeTruthy();
+    expect(w.getUtxo()[0].vout === 1).toBeTruthy();
+    expect(w.getUtxo()[0].txid).toBeTruthy();
+    expect(w.getUtxo()[0].confirmations).toBeTruthy();
   });
 });
 
@@ -124,11 +123,11 @@ describe('SegwitP2SHWallet', function () {
   it('can generate segwit P2SH address from WIF', async () => {
     const l = new SegwitP2SHWallet();
     l.setSecret('Kxr9tQED9H44gCmp6HAdmemAzU3n84H3dGkuWTKvE23JgHMW8gct');
-    assert.ok(l.getAddress() === '34AgLJhwXrvmkZS1o5TrcdeevMt22Nar53', 'expected ' + l.getAddress());
-    assert.ok(l.getAddress() === (await l.getAddressAsync()));
-    assert.ok(l.weOwnAddress('34AgLJhwXrvmkZS1o5TrcdeevMt22Nar53'));
-    assert.ok(!l.weOwnAddress('garbage'));
-    assert.ok(!l.weOwnAddress(false));
+    expect(l.getAddress() === '34AgLJhwXrvmkZS1o5TrcdeevMt22Nar53').toBeTruthy();
+    expect(l.getAddress() === (await l.getAddressAsync())).toBeTruthy();
+    expect(l.weOwnAddress('34AgLJhwXrvmkZS1o5TrcdeevMt22Nar53')).toBeTruthy();
+    expect(!l.weOwnAddress('garbage')).toBeTruthy();
+    expect(!l.weOwnAddress(false)).toBeTruthy();
   });
 });
 
@@ -136,12 +135,12 @@ describe('SegwitBech32Wallet', function () {
   it('can fetch balance', async () => {
     const w = new SegwitBech32Wallet();
     w._address = 'bc1qn887fmetaytw4vj68vsh529ft408q8j9x3dndc';
-    assert.ok(w.weOwnAddress('bc1qn887fmetaytw4vj68vsh529ft408q8j9x3dndc'));
-    assert.ok(w.weOwnAddress('BC1QN887FMETAYTW4VJ68VSH529FT408Q8J9X3DNDC'));
-    assert.ok(!w.weOwnAddress('garbage'));
-    assert.ok(!w.weOwnAddress(false));
+    expect(w.weOwnAddress('bc1qn887fmetaytw4vj68vsh529ft408q8j9x3dndc')).toBeTruthy();
+    expect(w.weOwnAddress('BC1QN887FMETAYTW4VJ68VSH529FT408Q8J9X3DNDC')).toBeTruthy();
+    expect(!w.weOwnAddress('garbage')).toBeTruthy();
+    expect(!w.weOwnAddress(false)).toBeTruthy();
     await w.fetchBalance();
-    assert.strictEqual(w.getBalance(), 100000);
+    expect(w.getBalance()).toBe(100000);
   });
 
   it('can fetch UTXO', async () => {
@@ -149,59 +148,59 @@ describe('SegwitBech32Wallet', function () {
     w._address = 'bc1qn887fmetaytw4vj68vsh529ft408q8j9x3dndc';
     await w.fetchUtxo();
     const l1 = w.getUtxo().length;
-    assert.ok(w.getUtxo().length > 0, 'unexpected empty UTXO');
+    expect(w.getUtxo().length > 0).toBeTruthy();
 
-    assert.ok(w.getUtxo()[0].value);
-    assert.ok(w.getUtxo()[0].vout === 0);
-    assert.ok(w.getUtxo()[0].txid);
-    assert.ok(w.getUtxo()[0].confirmations, JSON.stringify(w.getUtxo()[0], null, 2));
+    expect(w.getUtxo()[0].value).toBeTruthy();
+    expect(w.getUtxo()[0].vout === 0).toBeTruthy();
+    expect(w.getUtxo()[0].txid).toBeTruthy();
+    expect(w.getUtxo()[0].confirmations).toBeTruthy();
     // double fetch shouldnt duplicate UTXOs:
     await w.fetchUtxo();
     const l2 = w.getUtxo().length;
-    assert.strictEqual(l1, l2);
+    expect(l1).toBe(l2);
   });
 
   it('can fetch TXs', async () => {
     const w = new LegacyWallet();
     w._address = 'bc1quhnve8q4tk3unhmjts7ymxv8cd6w9xv8wy29uv';
     await w.fetchTransactions();
-    assert.strictEqual(w.getTransactions().length, 2);
+    expect(w.getTransactions().length).toBe(2);
 
     for (const tx of w.getTransactions()) {
-      assert.ok(tx.hash);
-      assert.ok(tx.value);
-      assert.ok(tx.received);
-      assert.ok(tx.confirmations > 1);
+      expect(tx.hash).toBeTruthy();
+      expect(tx.value).toBeTruthy();
+      expect(tx.received).toBeTruthy();
+      expect(tx.confirmations > 1).toBeTruthy();
     }
 
-    assert.strictEqual(w.getTransactions()[0].value, -892111);
-    assert.strictEqual(w.getTransactions()[1].value, 892111);
+    expect(w.getTransactions()[0].value).toBe(-892111);
+    expect(w.getTransactions()[1].value).toBe(892111);
   });
 
   it('can fetch TXs', async () => {
     const w = new SegwitBech32Wallet();
     w._address = 'bc1qn887fmetaytw4vj68vsh529ft408q8j9x3dndc';
-    assert.ok(w.weOwnAddress('bc1qn887fmetaytw4vj68vsh529ft408q8j9x3dndc'));
-    assert.ok(w.weOwnAddress('BC1QN887FMETAYTW4VJ68VSH529FT408Q8J9X3DNDC'));
-    assert.ok(!w.weOwnAddress('garbage'));
-    assert.ok(!w.weOwnAddress(false));
+    expect(w.weOwnAddress('bc1qn887fmetaytw4vj68vsh529ft408q8j9x3dndc')).toBeTruthy();
+    expect(w.weOwnAddress('BC1QN887FMETAYTW4VJ68VSH529FT408Q8J9X3DNDC')).toBeTruthy();
+    expect(!w.weOwnAddress('garbage')).toBeTruthy();
+    expect(!w.weOwnAddress(false)).toBeTruthy();
     await w.fetchTransactions();
-    assert.strictEqual(w.getTransactions().length, 1);
+    expect(w.getTransactions().length).toBe(1);
 
     for (const tx of w.getTransactions()) {
-      assert.ok(tx.hash);
-      assert.strictEqual(tx.value, 100000);
-      assert.ok(tx.received);
-      assert.ok(tx.confirmations > 1);
+      expect(tx.hash).toBeTruthy();
+      expect(tx.value).toBe(100000);
+      expect(tx.received).toBeTruthy();
+      expect(tx.confirmations > 1).toBeTruthy();
     }
 
     const tx0 = w.getTransactions()[0];
-    assert.ok(tx0.inputs);
-    assert.ok(tx0.inputs.length === 1);
-    assert.ok(tx0.outputs);
-    assert.ok(tx0.outputs.length === 3);
+    expect(tx0.inputs).toBeTruthy();
+    expect(tx0.inputs.length === 1).toBeTruthy();
+    expect(tx0.outputs).toBeTruthy();
+    expect(tx0.outputs.length === 3).toBeTruthy();
 
-    assert.ok(w.weOwnTransaction('49944e90fe917952e36b1967cdbc1139e60c89b4800b91258bf2345a77a8b888'));
-    assert.ok(!w.weOwnTransaction('825c12f277d1f84911ac15ad1f41a3de28e9d906868a930b0a7bca61b17c8881'));
+    expect(w.weOwnTransaction('49944e90fe917952e36b1967cdbc1139e60c89b4800b91258bf2345a77a8b888')).toBeTruthy();
+    expect(!w.weOwnTransaction('825c12f277d1f84911ac15ad1f41a3de28e9d906868a930b0a7bca61b17c8881')).toBeTruthy();
   });
 });

--- a/tests/integration/lightning-custodian-wallet.test.js
+++ b/tests/integration/lightning-custodian-wallet.test.js
@@ -1,32 +1,31 @@
 import Frisbee from 'frisbee';
 import { LightningCustodianWallet } from '../../class';
-const assert = require('assert');
 
 describe.skip('LightningCustodianWallet', () => {
   const l1 = new LightningCustodianWallet();
 
   it.skip('issue credentials', async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 200 * 1000;
-    assert.ok(l1.refill_addressess.length === 0);
-    assert.ok(l1._refresh_token_created_ts === 0);
-    assert.ok(l1._access_token_created_ts === 0);
+    expect(l1.refill_addressess.length === 0).toBeTruthy();
+    expect(l1._refresh_token_created_ts === 0).toBeTruthy();
+    expect(l1._access_token_created_ts === 0).toBeTruthy();
     l1.balance = 'FAKE';
 
     await l1.createAccount(false);
     await l1.authorize();
 
-    assert.ok(l1.access_token);
-    assert.ok(l1.refresh_token);
-    assert.ok(l1._refresh_token_created_ts > 0);
-    assert.ok(l1._access_token_created_ts > 0);
+    expect(l1.access_token).toBeTruthy();
+    expect(l1.refresh_token).toBeTruthy();
+    expect(l1._refresh_token_created_ts > 0).toBeTruthy();
+    expect(l1._access_token_created_ts > 0).toBeTruthy();
     console.log(l1.getSecret());
   });
 
   it('can create, auth and getbtc', async () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 200 * 1000;
-    assert.ok(l1.refill_addressess.length === 0);
-    assert.ok(l1._refresh_token_created_ts === 0);
-    assert.ok(l1._access_token_created_ts === 0);
+    expect(l1.refill_addressess.length === 0).toBeTruthy();
+    expect(l1._refresh_token_created_ts === 0).toBeTruthy();
+    expect(l1._access_token_created_ts === 0).toBeTruthy();
     l1.balance = 'FAKE';
 
     await l1.createAccount(true);
@@ -37,16 +36,16 @@ describe.skip('LightningCustodianWallet', () => {
     await l1.fetchTransactions();
     await l1.fetchPendingTransactions();
 
-    assert.ok(l1.access_token);
-    assert.ok(l1.refresh_token);
-    assert.ok(l1._refresh_token_created_ts > 0);
-    assert.ok(l1._access_token_created_ts > 0);
-    assert.ok(l1.refill_addressess.length > 0);
-    assert.ok(l1.balance === 0);
-    assert.ok(l1.info_raw);
-    assert.ok(l1.pending_transactions_raw.length === 0);
-    assert.ok(l1.transactions_raw.length === 0);
-    assert.ok(l1.transactions_raw.length === l1.getTransactions().length);
+    expect(l1.access_token).toBeTruthy();
+    expect(l1.refresh_token).toBeTruthy();
+    expect(l1._refresh_token_created_ts > 0).toBeTruthy();
+    expect(l1._access_token_created_ts > 0).toBeTruthy();
+    expect(l1.refill_addressess.length > 0).toBeTruthy();
+    expect(l1.balance === 0).toBeTruthy();
+    expect(l1.info_raw).toBeTruthy();
+    expect(l1.pending_transactions_raw.length === 0).toBeTruthy();
+    expect(l1.transactions_raw.length === 0).toBeTruthy();
+    expect(l1.transactions_raw.length === l1.getTransactions().length).toBeTruthy();
   });
 
   it('can refresh token', async () => {
@@ -54,10 +53,10 @@ describe.skip('LightningCustodianWallet', () => {
     const oldRefreshToken = l1.refresh_token;
     const oldAccessToken = l1.access_token;
     await l1.refreshAcessToken();
-    assert.ok(oldRefreshToken !== l1.refresh_token);
-    assert.ok(oldAccessToken !== l1.access_token);
-    assert.ok(l1.access_token);
-    assert.ok(l1.refresh_token);
+    expect(oldRefreshToken !== l1.refresh_token).toBeTruthy();
+    expect(oldAccessToken !== l1.access_token).toBeTruthy();
+    expect(l1.access_token).toBeTruthy();
+    expect(l1.refresh_token).toBeTruthy();
   });
 
   it('can use existing login/pass', async () => {
@@ -72,19 +71,19 @@ describe.skip('LightningCustodianWallet', () => {
     await l2.fetchPendingTransactions();
     await l2.fetchTransactions();
 
-    assert.ok(l2.pending_transactions_raw.length === 0);
-    assert.ok(l2.transactions_raw.length > 0);
-    assert.ok(l2.transactions_raw.length === l2.getTransactions().length);
+    expect(l2.pending_transactions_raw.length === 0).toBeTruthy();
+    expect(l2.transactions_raw.length > 0).toBeTruthy();
+    expect(l2.transactions_raw.length === l2.getTransactions().length).toBeTruthy();
     for (const tx of l2.getTransactions()) {
-      assert.ok(typeof tx.fee !== 'undefined');
-      assert.ok(tx.value);
-      assert.ok(tx.timestamp);
-      assert.ok(tx.description || tx.memo, JSON.stringify(tx));
-      assert.ok(!isNaN(tx.value));
-      assert.ok(tx.type === 'bitcoind_tx' || tx.type === 'paid_invoice', 'unexpected tx type ' + tx.type);
+      expect(typeof tx.fee !== 'undefined').toBeTruthy();
+      expect(tx.value).toBeTruthy();
+      expect(tx.timestamp).toBeTruthy();
+      expect(tx.description || tx.memo).toBeTruthy();
+      expect(!isNaN(tx.value)).toBeTruthy();
+      expect(tx.type === 'bitcoind_tx' || tx.type === 'paid_invoice').toBeTruthy();
     }
     await l2.fetchBalance();
-    assert.ok(l2.getBalance() > 0);
+    expect(l2.getBalance() > 0).toBeTruthy();
   });
 
   it('can decode & check invoice', async () => {
@@ -101,10 +100,10 @@ describe.skip('LightningCustodianWallet', () => {
       'lnbc1u1pdcqpt3pp5ltuevvq2g69kdrzcegrs9gfqjer45rwjc0w736qjl92yvwtxhn6qdp8dp6kuerjv4j9xct5daeks6tnyp3xc6t50f582cscqp2zrkghzl535xjav52ns0rpskcn20takzdr2e02wn4xqretlgdemg596acq5qtfqhjk4jpr7jk8qfuuka2k0lfwjsk9mchwhxcgxzj3tsp09gfpy';
     const decoded = l2.decodeInvoice(invoice);
 
-    assert.ok(decoded.payment_hash);
-    assert.ok(decoded.description);
-    assert.ok(decoded.num_satoshis);
-    assert.strictEqual(parseInt(decoded.num_satoshis) * 1000, parseInt(decoded.num_millisatoshis));
+    expect(decoded.payment_hash).toBeTruthy();
+    expect(decoded.description).toBeTruthy();
+    expect(decoded.num_satoshis).toBeTruthy();
+    expect(parseInt(decoded.num_satoshis) * 1000).toBe(parseInt(decoded.num_millisatoshis));
 
     // checking that bad invoice cant be decoded
     invoice = 'gsom';
@@ -114,7 +113,7 @@ describe.skip('LightningCustodianWallet', () => {
     } catch (Err) {
       error = true;
     }
-    assert.ok(error);
+    expect(error).toBeTruthy();
   });
 
   it('decode can handle zero sats but present msats', async () => {
@@ -122,7 +121,7 @@ describe.skip('LightningCustodianWallet', () => {
     const decoded = l.decodeInvoice(
       'lnbc89n1p0zptvhpp5j3h5e80vdlzn32df8y80nl2t7hssn74lzdr96ve0u4kpaupflx2sdphgfkx7cmtwd68yetpd5s9xct5v4kxc6t5v5s9gunpdeek66tnwd5k7mscqp2sp57m89zv0lrgc9zzaxy5p3d5rr2cap2pm6zm4n0ew9vyp2d5zf2mfqrzjqfxj8p6qjf5l8du7yuytkwdcjhylfd4gxgs48t65awjg04ye80mq7z990yqq9jsqqqqqqqqqqqqq05qqrc9qy9qsq9mynpa9ucxg53hwnvw323r55xdd3l6lcadzs584zvm4wdw5pv3eksdlcek425pxaqrn9u5gpw0dtpyl9jw2pynjtqexxgh50akwszjgq4ht4dh',
     );
-    assert.strictEqual(decoded.num_satoshis, '8.9');
+    expect(decoded.num_satoshis).toBe('8.9');
   });
 
   it('can decode invoice locally & remotely', async () => {
@@ -137,13 +136,13 @@ describe.skip('LightningCustodianWallet', () => {
       'lnbc1u1pdcqpt3pp5ltuevvq2g69kdrzcegrs9gfqjer45rwjc0w736qjl92yvwtxhn6qdp8dp6kuerjv4j9xct5daeks6tnyp3xc6t50f582cscqp2zrkghzl535xjav52ns0rpskcn20takzdr2e02wn4xqretlgdemg596acq5qtfqhjk4jpr7jk8qfuuka2k0lfwjsk9mchwhxcgxzj3tsp09gfpy';
     const decodedLocally = l2.decodeInvoice(invoice);
     const decodedRemotely = await l2.decodeInvoiceRemote(invoice);
-    assert.strictEqual(decodedLocally.destination, decodedRemotely.destination);
-    assert.strictEqual(decodedLocally.num_satoshis, decodedRemotely.num_satoshis);
-    assert.strictEqual(decodedLocally.timestamp, decodedRemotely.timestamp);
-    assert.strictEqual(decodedLocally.expiry, decodedRemotely.expiry);
-    assert.strictEqual(decodedLocally.payment_hash, decodedRemotely.payment_hash);
-    assert.strictEqual(decodedLocally.description, decodedRemotely.description);
-    assert.strictEqual(decodedLocally.cltv_expiry, decodedRemotely.cltv_expiry);
+    expect(decodedLocally.destination).toBe(decodedRemotely.destination);
+    expect(decodedLocally.num_satoshis).toBe(decodedRemotely.num_satoshis);
+    expect(decodedLocally.timestamp).toBe(decodedRemotely.timestamp);
+    expect(decodedLocally.expiry).toBe(decodedRemotely.expiry);
+    expect(decodedLocally.payment_hash).toBe(decodedRemotely.payment_hash);
+    expect(decodedLocally.description).toBe(decodedRemotely.description);
+    expect(decodedLocally.cltv_expiry).toBe(decodedRemotely.cltv_expiry);
   });
 
   it('can pay invoice from opennode', async () => {
@@ -187,10 +186,10 @@ describe.skip('LightningCustodianWallet', () => {
     }
 
     await l2.fetchTransactions();
-    assert.strictEqual(l2.transactions_raw.length, txLen + 1);
+    expect(l2.transactions_raw.length).toBe(txLen + 1);
     const lastTx = l2.transactions_raw[l2.transactions_raw.length - 1];
-    assert.strictEqual(typeof lastTx.payment_preimage, 'string', 'preimage is present and is a string');
-    assert.strictEqual(lastTx.payment_preimage.length, 64, 'preimage is present and is a string of 32 hex-encoded bytes');
+    expect(typeof lastTx.payment_preimage).toBe('string');
+    expect(lastTx.payment_preimage.length).toBe(64);
     // transactions became more after paying an invoice
   });
 
@@ -233,8 +232,8 @@ describe.skip('LightningCustodianWallet', () => {
     const txLen = l2.transactions_raw.length;
 
     const decoded = l2.decodeInvoice(invoice);
-    assert.ok(decoded.payment_hash);
-    assert.ok(decoded.description);
+    expect(decoded.payment_hash).toBeTruthy();
+    expect(decoded.description).toBeTruthy();
 
     let start = +new Date();
     await l2.payInvoice(invoice);
@@ -244,10 +243,10 @@ describe.skip('LightningCustodianWallet', () => {
     }
 
     await l2.fetchTransactions();
-    assert.strictEqual(l2.transactions_raw.length, txLen + 1);
+    expect(l2.transactions_raw.length).toBe(txLen + 1);
     const lastTx = l2.transactions_raw[l2.transactions_raw.length - 1];
-    assert.strictEqual(typeof lastTx.payment_preimage, 'string', 'preimage is present and is a string');
-    assert.strictEqual(lastTx.payment_preimage.length, 64, 'preimage is present and is a string of 32 hex-encoded bytes');
+    expect(typeof lastTx.payment_preimage).toBe('string');
+    expect(lastTx.payment_preimage.length).toBe(64);
     // transactions became more after paying an invoice
 
     // now, trying to pay duplicate invoice
@@ -258,9 +257,9 @@ describe.skip('LightningCustodianWallet', () => {
     } catch (Err) {
       caughtError = true;
     }
-    assert.ok(caughtError);
+    expect(caughtError).toBeTruthy();
     await l2.fetchTransactions();
-    assert.strictEqual(l2.transactions_raw.length, txLen + 1);
+    expect(l2.transactions_raw.length).toBe(txLen + 1);
     // havent changed since last time
     end = +new Date();
     if ((end - start) / 1000 > 9) {
@@ -299,7 +298,7 @@ describe.skip('LightningCustodianWallet', () => {
     const txLen = l2.transactions_raw.length;
 
     const decoded = l2.decodeInvoice(invoice);
-    assert.ok(decoded.payment_hash);
+    expect(decoded.payment_hash).toBeTruthy();
 
     let start = +new Date();
     await l2.payInvoice(invoice);
@@ -309,10 +308,10 @@ describe.skip('LightningCustodianWallet', () => {
     }
 
     await l2.fetchTransactions();
-    assert.strictEqual(l2.transactions_raw.length, txLen + 1);
+    expect(l2.transactions_raw.length).toBe(txLen + 1);
     const lastTx = l2.transactions_raw[l2.transactions_raw.length - 1];
-    assert.strictEqual(typeof lastTx.payment_preimage, 'string', 'preimage is present and is a string');
-    assert.strictEqual(lastTx.payment_preimage.length, 64, 'preimage is present and is a string of 32 hex-encoded bytes');
+    expect(typeof lastTx.payment_preimage).toBe('string');
+    expect(lastTx.payment_preimage.length).toBe(64);
     // transactions became more after paying an invoice
 
     // now, trying to pay duplicate invoice
@@ -323,9 +322,9 @@ describe.skip('LightningCustodianWallet', () => {
     } catch (Err) {
       caughtError = true;
     }
-    assert.ok(caughtError);
+    expect(caughtError).toBeTruthy();
     await l2.fetchTransactions();
-    assert.strictEqual(l2.transactions_raw.length, txLen + 1);
+    expect(l2.transactions_raw.length).toBe(txLen + 1);
     // havent changed since last time
     end = +new Date();
     if ((end - start) / 1000 > 9) {
@@ -351,22 +350,22 @@ describe.skip('LightningCustodianWallet', () => {
     await lNew.createAccount(true);
     await lNew.authorize();
     await lNew.fetchBalance();
-    assert.strictEqual(lNew.balance, 0);
+    expect(lNew.balance).toBe(0);
 
     let invoices = await lNew.getUserInvoices();
     let invoice = await lNew.addInvoice(1, 'test memo');
     const decoded = lNew.decodeInvoice(invoice);
     let invoices2 = await lNew.getUserInvoices();
-    assert.strictEqual(invoices2.length, invoices.length + 1);
-    assert.ok(invoices2[0].ispaid === false);
-    assert.ok(invoices2[0].description);
-    assert.strictEqual(invoices2[0].description, 'test memo');
-    assert.ok(invoices2[0].payment_request);
-    assert.ok(invoices2[0].timestamp);
-    assert.ok(invoices2[0].expire_time);
-    assert.strictEqual(invoices2[0].amt, 1);
+    expect(invoices2.length).toBe(invoices.length + 1);
+    expect(invoices2[0].ispaid === false).toBeTruthy();
+    expect(invoices2[0].description).toBeTruthy();
+    expect(invoices2[0].description).toBe('test memo');
+    expect(invoices2[0].payment_request).toBeTruthy();
+    expect(invoices2[0].timestamp).toBeTruthy();
+    expect(invoices2[0].expire_time).toBeTruthy();
+    expect(invoices2[0].amt).toBe(1);
     for (const inv of invoices2) {
-      assert.strictEqual(inv.type, 'user_invoice');
+      expect(inv.type).toBe('user_invoice');
     }
 
     await lOld.fetchBalance();
@@ -380,25 +379,25 @@ describe.skip('LightningCustodianWallet', () => {
     }
 
     invoices2 = await lNew.getUserInvoices();
-    assert.ok(invoices2[0].ispaid);
+    expect(invoices2[0].ispaid).toBeTruthy();
 
-    assert.ok(lNew.weOwnTransaction(decoded.payment_hash));
-    assert.ok(!lNew.weOwnTransaction('d45818ae11a584357f7b74da26012d2becf4ef064db015a45bdfcd9cb438929d'));
+    expect(lNew.weOwnTransaction(decoded.payment_hash)).toBeTruthy();
+    expect(!lNew.weOwnTransaction('d45818ae11a584357f7b74da26012d2becf4ef064db015a45bdfcd9cb438929d')).toBeTruthy();
 
     await lOld.fetchBalance();
     await lNew.fetchBalance();
-    assert.strictEqual(oldBalance - lOld.balance, 1);
-    assert.strictEqual(lNew.balance, 1);
+    expect(oldBalance - lOld.balance).toBe(1);
+    expect(lNew.balance).toBe(1);
 
     await lOld.fetchTransactions();
-    assert.strictEqual(lOld.transactions_raw.length, txLen + 1, 'internal invoice should also produce record in payer`s tx list');
+    expect(lOld.transactions_raw.length).toBe(txLen + 1);
     const newTx = lOld.transactions_raw.slice().pop();
-    assert.ok(typeof newTx.fee !== 'undefined');
-    assert.ok(newTx.value);
-    assert.ok(newTx.description || newTx.memo, JSON.stringify(newTx));
-    assert.ok(newTx.timestamp);
-    assert.ok(!isNaN(newTx.value));
-    assert.ok(newTx.type === 'paid_invoice', 'unexpected tx type ' + newTx.type);
+    expect(typeof newTx.fee !== 'undefined').toBeTruthy();
+    expect(newTx.value).toBeTruthy();
+    expect(newTx.description || newTx.memo).toBeTruthy();
+    expect(newTx.timestamp).toBeTruthy();
+    expect(!isNaN(newTx.value)).toBeTruthy();
+    expect(newTx.type === 'paid_invoice').toBeTruthy();
 
     // now, paying back that amount
     oldBalance = lOld.balance;
@@ -406,8 +405,8 @@ describe.skip('LightningCustodianWallet', () => {
     await lNew.payInvoice(invoice);
     await lOld.fetchBalance();
     await lNew.fetchBalance();
-    assert.strictEqual(lOld.balance - oldBalance, 1);
-    assert.strictEqual(lNew.balance, 0);
+    expect(lOld.balance - oldBalance).toBe(1);
+    expect(lNew.balance).toBe(0);
 
     // now, paying same internal invoice. should fail:
 
@@ -420,19 +419,19 @@ describe.skip('LightningCustodianWallet', () => {
     } catch (Err) {
       coughtError = true;
     }
-    assert.ok(coughtError);
+    expect(coughtError).toBeTruthy();
 
     await lOld.fetchTransactions();
-    assert.strictEqual(txLen, lOld.transactions_raw.length, 'tx count should not be changed');
-    assert.strictEqual(invLen, (await lNew.getUserInvoices()).length, 'invoices count should not be changed');
+    expect(txLen).toBe(lOld.transactions_raw.length);
+    expect(invLen).toBe((await lNew.getUserInvoices()).length);
 
     // testing how limiting works:
-    assert.strictEqual(lNew.user_invoices_raw.length, 1);
+    expect(lNew.user_invoices_raw.length).toBe(1);
     await lNew.addInvoice(666, 'test memo 2');
     invoices = await lNew.getUserInvoices(1);
-    assert.strictEqual(invoices.length, 2);
-    assert.strictEqual(invoices[0].amt, 1);
-    assert.strictEqual(invoices[1].amt, 666);
+    expect(invoices.length).toBe(2);
+    expect(invoices[0].amt).toBe(1);
+    expect(invoices[1].amt).toBe(666);
   });
 
   it('can pay invoice with free amount (tippin.me)', async function () {
@@ -479,9 +478,9 @@ describe.skip('LightningCustodianWallet', () => {
     const txLen = l2.transactions_raw.length;
 
     const decoded = l2.decodeInvoice(invoice);
-    assert.ok(decoded.payment_hash);
-    assert.ok(decoded.description);
-    assert.strictEqual(+decoded.num_satoshis, 0);
+    expect(decoded.payment_hash).toBeTruthy();
+    expect(decoded.description).toBeTruthy();
+    expect(+decoded.num_satoshis).toBe(0);
 
     // first, tip invoice without amount should not work:
     let gotError = false;
@@ -490,7 +489,7 @@ describe.skip('LightningCustodianWallet', () => {
     } catch (_) {
       gotError = true;
     }
-    assert.ok(gotError);
+    expect(gotError).toBeTruthy();
 
     // then, pay:
 
@@ -502,31 +501,31 @@ describe.skip('LightningCustodianWallet', () => {
     }
 
     await l2.fetchTransactions();
-    assert.strictEqual(l2.transactions_raw.length, txLen + 1);
+    expect(l2.transactions_raw.length).toBe(txLen + 1);
     // transactions became more after paying an invoice
 
     await l2.fetchBalance();
-    assert.ok(oldBalance - l2.balance >= 3);
-    assert.ok(oldBalance - l2.balance < 10); // sanity check
+    expect(oldBalance - l2.balance >= 3).toBeTruthy();
+    expect(oldBalance - l2.balance < 10).toBeTruthy(); // sanity check
   });
 
   it('cant create zemo amt invoices yet', async () => {
     const l1 = new LightningCustodianWallet();
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 200 * 1000;
-    assert.ok(l1.refill_addressess.length === 0);
-    assert.ok(l1._refresh_token_created_ts === 0);
-    assert.ok(l1._access_token_created_ts === 0);
+    expect(l1.refill_addressess.length === 0).toBeTruthy();
+    expect(l1._refresh_token_created_ts === 0).toBeTruthy();
+    expect(l1._access_token_created_ts === 0).toBeTruthy();
     l1.balance = 'FAKE';
 
     await l1.createAccount(true);
     await l1.authorize();
     await l1.fetchBalance();
 
-    assert.ok(l1.access_token);
-    assert.ok(l1.refresh_token);
-    assert.ok(l1._refresh_token_created_ts > 0);
-    assert.ok(l1._access_token_created_ts > 0);
-    assert.ok(l1.balance === 0);
+    expect(l1.access_token).toBeTruthy();
+    expect(l1.refresh_token).toBeTruthy();
+    expect(l1._refresh_token_created_ts > 0).toBeTruthy();
+    expect(l1._access_token_created_ts > 0).toBeTruthy();
+    expect(l1.balance === 0).toBeTruthy();
 
     let err = false;
     try {
@@ -534,7 +533,7 @@ describe.skip('LightningCustodianWallet', () => {
     } catch (_) {
       err = true;
     }
-    assert.ok(err);
+    expect(err).toBeTruthy();
 
     err = false;
     try {
@@ -542,7 +541,7 @@ describe.skip('LightningCustodianWallet', () => {
     } catch (_) {
       err = true;
     }
-    assert.ok(err);
+    expect(err).toBeTruthy();
   });
 
   it('cant pay negative free amount', async () => {
@@ -585,9 +584,9 @@ describe.skip('LightningCustodianWallet', () => {
     const txLen = l2.transactions_raw.length;
 
     const decoded = l2.decodeInvoice(invoice);
-    assert.ok(decoded.payment_hash);
-    assert.ok(decoded.description);
-    assert.strictEqual(+decoded.num_satoshis, 0);
+    expect(decoded.payment_hash).toBeTruthy();
+    expect(decoded.description).toBeTruthy();
+    expect(+decoded.num_satoshis).toBe(0);
 
     let error = false;
     try {
@@ -595,10 +594,10 @@ describe.skip('LightningCustodianWallet', () => {
     } catch (Err) {
       error = true;
     }
-    assert.ok(error);
+    expect(error).toBeTruthy();
     await l2.fetchBalance();
-    assert.strictEqual(l2.balance, oldBalance);
+    expect(l2.balance).toBe(oldBalance);
     await l2.fetchTransactions();
-    assert.strictEqual(l2.transactions_raw.length, txLen);
+    expect(l2.transactions_raw.length).toBe(txLen);
   });
 });

--- a/tests/integration/multisig-hd-wallet.test.js
+++ b/tests/integration/multisig-hd-wallet.test.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { MultisigHDWallet } from '../../class/';
 const BlueElectrum = require('../../blue_modules/BlueElectrum'); // so it connects ASAP
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
@@ -35,16 +34,16 @@ describe('multisig-hd-wallet', () => {
     w.setDerivationPath(path);
     w.setM(2);
 
-    assert.strictEqual(w.getM(), 2);
-    assert.strictEqual(w.getN(), 2);
-    assert.strictEqual(w.getDerivationPath(), path);
-    assert.strictEqual(w.getCosigner(1), Zpub1);
-    assert.strictEqual(w.getCosigner(2), Zpub2);
-    assert.strictEqual(w.getCosignerForFingerprint(fp1), Zpub1);
-    assert.strictEqual(w.getCosignerForFingerprint(fp2), Zpub2);
+    expect(w.getM()).toBe(2);
+    expect(w.getN()).toBe(2);
+    expect(w.getDerivationPath()).toBe(path);
+    expect(w.getCosigner(1)).toBe(Zpub1);
+    expect(w.getCosigner(2)).toBe(Zpub2);
+    expect(w.getCosignerForFingerprint(fp1)).toBe(Zpub1);
+    expect(w.getCosignerForFingerprint(fp2)).toBe(Zpub2);
 
     await w.fetchBalance();
     await w.fetchTransactions();
-    assert.ok(w.getTransactions().length >= 6);
+    expect(w.getTransactions().length >= 6).toBeTruthy();
   });
 });

--- a/tests/integration/notifications.test.js
+++ b/tests/integration/notifications.test.js
@@ -1,15 +1,16 @@
 import Notifications from '../../blue_modules/notifications';
-const assert = require('assert');
+
 Notifications.default = new Notifications();
+
 describe('notifications', () => {
   it('can check groundcontrol server uri validity', async () => {
-    assert.ok(await Notifications.isGroundControlUriValid('https://groundcontrol-bluewallet.herokuapp.com'));
-    assert.ok(!(await Notifications.isGroundControlUriValid('https://www.google.com')));
+    expect(await Notifications.isGroundControlUriValid('https://groundcontrol-bluewallet.herokuapp.com')).toBeTruthy();
+    expect(!(await Notifications.isGroundControlUriValid('https://www.google.com'))).toBeTruthy();
     await new Promise(resolve => setTimeout(resolve, 2000));
   });
 
   // muted because it causes jest to hang waiting indefinitely
   it.skip('can check non-responding url', async () => {
-    assert.ok(!(await Notifications.isGroundControlUriValid('https://localhost.com')));
+    expect(!(await Notifications.isGroundControlUriValid('https://localhost.com'))).toBeTruthy();
   });
 });

--- a/tests/integration/watch-only-wallet.test.js
+++ b/tests/integration/watch-only-wallet.test.js
@@ -1,5 +1,4 @@
 import { WatchOnlyWallet } from '../../class';
-const assert = require('assert');
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
 const BlueElectrum = require('../../blue_modules/BlueElectrum'); // so it connects ASAP
@@ -22,31 +21,31 @@ describe('Watch only wallet', () => {
     const w = new WatchOnlyWallet();
     w.setSecret('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa');
     await w.fetchBalance();
-    assert.ok(w.getBalance() > 16);
+    expect(w.getBalance() > 16).toBeTruthy();
   });
 
   it('can fetch tx', async () => {
     let w = new WatchOnlyWallet();
     w.setSecret('167zK5iZrs1U6piDqubD3FjRqUTM2CZnb8');
     await w.fetchTransactions();
-    assert.ok(w.getTransactions().length >= 215, w.getTransactions().length);
+    expect(w.getTransactions().length >= 215).toBeTruthy();
     // should be 233 but electrum server cant return huge transactions >.<
 
     w = new WatchOnlyWallet();
     w.setSecret('1BiJW1jyUaxcJp2JWwbPLPzB1toPNWTFJV');
     await w.fetchTransactions();
-    assert.strictEqual(w.getTransactions().length, 2);
+    expect(w.getTransactions().length).toBe(2);
 
     // fetch again and make sure no duplicates
     await w.fetchTransactions();
-    assert.strictEqual(w.getTransactions().length, 2);
+    expect(w.getTransactions().length).toBe(2);
   });
 
   it.skip('can fetch tx from huge wallet', async () => {
     const w = new WatchOnlyWallet();
     w.setSecret('1NDyJtNTjmwk5xPNhjgAMu4HDHigtobu1s'); // binance wallet
     await w.fetchTransactions();
-    assert.ok(w.getTransactions().length === 0, w.getTransactions().length); // not yet kek but at least we dont crash
+    expect(w.getTransactions().length === 0).toBeTruthy(); // not yet kek but at least we dont crash
   });
 
   it('can fetch TXs with values', async () => {
@@ -60,23 +59,23 @@ describe('Watch only wallet', () => {
       'BITCOIN:bc1quhnve8q4tk3unhmjts7ymxv8cd6w9xv8wy29uv',
     ]) {
       w.setSecret(sec);
-      assert.strictEqual(w.getAddress(), 'bc1quhnve8q4tk3unhmjts7ymxv8cd6w9xv8wy29uv');
-      assert.strictEqual(await w.getAddressAsync(), 'bc1quhnve8q4tk3unhmjts7ymxv8cd6w9xv8wy29uv');
-      assert.ok(w.weOwnAddress('bc1quhnve8q4tk3unhmjts7ymxv8cd6w9xv8wy29uv'));
-      assert.ok(w.weOwnAddress('BC1QUHNVE8Q4TK3UNHMJTS7YMXV8CD6W9XV8WY29UV'));
-      assert.ok(!w.weOwnAddress('garbage'));
-      assert.ok(!w.weOwnAddress(false));
+      expect(w.getAddress()).toBe('bc1quhnve8q4tk3unhmjts7ymxv8cd6w9xv8wy29uv');
+      expect(await w.getAddressAsync()).toBe('bc1quhnve8q4tk3unhmjts7ymxv8cd6w9xv8wy29uv');
+      expect(w.weOwnAddress('bc1quhnve8q4tk3unhmjts7ymxv8cd6w9xv8wy29uv')).toBeTruthy();
+      expect(w.weOwnAddress('BC1QUHNVE8Q4TK3UNHMJTS7YMXV8CD6W9XV8WY29UV')).toBeTruthy();
+      expect(!w.weOwnAddress('garbage')).toBeTruthy();
+      expect(!w.weOwnAddress(false)).toBeTruthy();
       await w.fetchTransactions();
 
       for (const tx of w.getTransactions()) {
-        assert.ok(tx.hash);
-        assert.ok(tx.value);
-        assert.ok(tx.received);
-        assert.ok(tx.confirmations > 1);
+        expect(tx.hash).toBeTruthy();
+        expect(tx.value).toBeTruthy();
+        expect(tx.received).toBeTruthy();
+        expect(tx.confirmations > 1).toBeTruthy();
       }
 
-      assert.strictEqual(w.getTransactions()[0].value, -892111);
-      assert.strictEqual(w.getTransactions()[1].value, 892111);
+      expect(w.getTransactions()[0].value).toBe(-892111);
+      expect(w.getTransactions()[1].value).toBe(892111);
     }
   });
 
@@ -85,7 +84,7 @@ describe('Watch only wallet', () => {
     w.setSecret('3NLnALo49CFEF4tCRhCvz45ySSfz3UktZC');
     await w.fetchTransactions();
     for (const tx of w.getTransactions()) {
-      assert.ok(tx.value, 'incorrect tx.value');
+      expect(tx.value).toBeTruthy();
     }
   });
 
@@ -93,9 +92,9 @@ describe('Watch only wallet', () => {
     const w = new WatchOnlyWallet();
     w.setSecret('zpub6r7jhKKm7BAVx3b3nSnuadY1WnshZYkhK8gKFoRLwK9rF3Mzv28BrGcCGA3ugGtawi1WLb2vyjQAX9ZTDGU5gNk2bLdTc3iEXr6tzR1ipNP');
     await w.fetchBalance();
-    assert.strictEqual(w.getBalance(), 200000);
+    expect(w.getBalance()).toBe(200000);
     await w.fetchTransactions();
-    assert.strictEqual(w.getTransactions().length, 4);
-    assert.ok((await w.getAddressAsync()).startsWith('bc1'));
+    expect(w.getTransactions().length).toBe(4);
+    expect((await w.getAddressAsync()).startsWith('bc1')).toBeTruthy();
   });
 });

--- a/tests/unit/addresses.test.js
+++ b/tests/unit/addresses.test.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { getAddress, sortByAddressIndex, totalBalance, filterByAddressType } from '../../screen/wallets/addresses';
 import { TABS } from '../../components/addresses/AddressTypeTabs';
 
@@ -14,9 +13,9 @@ describe('Addresses', () => {
   it('Sort by index', () => {
     const sortedList = mockAddressesList.sort(sortByAddressIndex);
 
-    assert.strictEqual(sortedList[0].index, 0);
-    assert.strictEqual(sortedList[2].index, 1);
-    assert.strictEqual(sortedList[4].index, 2);
+    expect(sortedList[0].index).toBe(0);
+    expect(sortedList[2].index).toBe(1);
+    expect(sortedList[4].index).toBe(2);
   });
 
   it('Have tabs defined', () => {
@@ -25,7 +24,7 @@ describe('Addresses', () => {
       INTERNAL: 'change',
     };
 
-    assert.deepStrictEqual(TABS, tabsEnum);
+    expect(TABS).toEqual(tabsEnum);
   });
 
   it('Filter by type', () => {
@@ -38,11 +37,11 @@ describe('Addresses', () => {
     const internalAddresses = mockAddressesList.filter(address => filterByAddressType(TABS.INTERNAL, address.isInternal, currentTab));
 
     externalAddresses.forEach(address => {
-      assert.strictEqual(address.isInternal, false);
+      expect(address.isInternal).toBe(false);
     });
 
     internalAddresses.forEach(address => {
-      assert.strictEqual(address.isInternal, true);
+      expect(address.isInternal).toBe(true);
     });
   });
 
@@ -51,9 +50,9 @@ describe('Addresses', () => {
     const wallet2Balance = { c: 7, u: 3 };
     const wallet3Balance = { c: 3, u: 7 };
 
-    assert.strictEqual(totalBalance(wallet1Balance), 0);
-    assert.strictEqual(totalBalance(wallet2Balance), 10);
-    assert.strictEqual(totalBalance(wallet3Balance), 10);
+    expect(totalBalance(wallet1Balance)).toBe(0);
+    expect(totalBalance(wallet2Balance)).toBe(10);
+    expect(totalBalance(wallet3Balance)).toBe(10);
   });
 
   it('Returns AddressItem object', () => {
@@ -69,7 +68,7 @@ describe('Addresses', () => {
     const firstExternalAddress = getAddress(fakeWallet, 0, false);
     const firstInternalAddress = getAddress(fakeWallet, 0, true);
 
-    assert.deepStrictEqual(firstExternalAddress, {
+    expect(firstExternalAddress).toEqual({
       address: 'external_address_0',
       balance: 0,
       index: 0,
@@ -78,7 +77,7 @@ describe('Addresses', () => {
       transactions: 1,
     });
 
-    assert.deepStrictEqual(firstInternalAddress, {
+    expect(firstInternalAddress).toEqual({
       address: 'internal_address_0',
       balance: 0,
       index: 0,

--- a/tests/unit/bip38.test.js
+++ b/tests/unit/bip38.test.js
@@ -1,5 +1,3 @@
-const assert = require('assert');
-
 it('bip38 decodes', async () => {
   const bip38 = require('../../blue_modules/bip38');
   const wif = require('wif');
@@ -12,10 +10,7 @@ it('bip38 decodes', async () => {
     { N: 1, r: 8, p: 8 }, // using non-default parameters to speed it up (not-bip38 compliant)
   );
 
-  assert.strictEqual(
-    wif.encode(0x80, decryptedKey.privateKey, decryptedKey.compressed),
-    '5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR',
-  );
+  expect(wif.encode(0x80, decryptedKey.privateKey, decryptedKey.compressed)).toBe('5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR');
 });
 
 it('bip38 decodes slow', async () => {
@@ -34,12 +29,9 @@ it('bip38 decodes slow', async () => {
     // on RN scrypt is handled by native module and takes ~4 secs
     callbackWasCalled = true;
   });
-  assert.ok(callbackWasCalled);
+  expect(callbackWasCalled).toBeTruthy();
 
-  assert.strictEqual(
-    wif.encode(0x80, decryptedKey.privateKey, decryptedKey.compressed),
-    'KxqRtpd9vFju297ACPKHrGkgXuberTveZPXbRDiQ3MXZycSQYtjc',
-  );
+  expect(wif.encode(0x80, decryptedKey.privateKey, decryptedKey.compressed)).toBe('KxqRtpd9vFju297ACPKHrGkgXuberTveZPXbRDiQ3MXZycSQYtjc');
 
   let wasError = false;
   try {
@@ -48,5 +40,5 @@ it('bip38 decodes slow', async () => {
     wasError = true;
   }
 
-  assert.ok(wasError);
+  expect(wasError).toBeTruthy();
 });

--- a/tests/unit/cosign.test.js
+++ b/tests/unit/cosign.test.js
@@ -1,5 +1,3 @@
-/* global it, describe */
-import assert from 'assert';
 import * as bitcoin from 'bitcoinjs-lib';
 import { HDLegacyP2PKHWallet, HDSegwitBech32Wallet, HDSegwitP2SHWallet } from '../../class';
 
@@ -12,7 +10,7 @@ describe('AbstractHDElectrumWallet.cosign', () => {
 
     const w1 = new HDLegacyP2PKHWallet();
     w1.setSecret(process.env.HD_MNEMONIC);
-    assert.ok(w1.validateMnemonic());
+    expect(w1.validateMnemonic()).toBeTruthy();
     const w1Utxo = [
       {
         height: 554830,
@@ -29,7 +27,7 @@ describe('AbstractHDElectrumWallet.cosign', () => {
 
     const w2 = new HDSegwitBech32Wallet();
     w2.setSecret(process.env.HD_MNEMONIC);
-    assert.ok(w2.validateMnemonic());
+    expect(w2.validateMnemonic()).toBeTruthy();
     const w2Utxo = [
       {
         height: 563077,
@@ -44,7 +42,7 @@ describe('AbstractHDElectrumWallet.cosign', () => {
 
     const w3 = new HDSegwitP2SHWallet();
     w3.setSecret(process.env.HD_MNEMONIC_BIP49);
-    assert.ok(w3.validateMnemonic());
+    expect(w3.validateMnemonic()).toBeTruthy();
     const w3Utxo = [
       {
         height: 591862,
@@ -150,8 +148,7 @@ describe('AbstractHDElectrumWallet.cosign', () => {
       value: 10000,
     });
 
-    assert.strictEqual(
-      psbt.toBase64(),
+    expect(psbt.toBase64()).toBe(
       'cHNidP8BAKcCAAAAA1+8dBEMLW/PTRFhpZkT+80rarPFqetNDcCFlRXLyGVPAAAAAAAAAACAbZP7eSKA4mMEs3Cr69I3Qwzt21Zwh38dKpjYCSSpAK0BAAAAAAAAAICHyazZ1XFIRTQ7GKuqJsuDKZviSHwi2pwOJw8kG02c/gAAAAAAAAAAgAEQJwAAAAAAABl2qRRNxsv2TfmrEGzugSx1AZYLk+khd4isAAAAAAABAP1gAQEAAAAAAQHo2Y7/u0+6TwqJvPIX61p+L478rkTzLsrLxdjMPOaDwwEAAAAXFgAUi6bQLnTApuAA6LF06y7UTl6iEab/////BRAnAAAAAAAAGXapFE3Gy/ZN+asQbO6BLHUBlguT6SF3iKwgTgAAAAAAABl2qRS8Lba3TI25sYhxHc7dUR5qMFYD9YisMHUAAAAAAAAZdqkUTcbL9k35qxBs7oEsdQGWC5PpIXeIrECcAAAAAAAAGXapFLwttrdMjbmxiHEdzt1RHmowVgP1iKwgRxYAAAAAABepFOKG1Y5T+SR6RxDlEjLM4GhvFoc8hwJIMEUCIQCvOADNgXHxVHhc8T9GwJL2HBZo+X20MrtOfte8gSqMbQIgUb3coerxrYtfO9DM3nRH5W/TyHCeWQbwLsYybppbL/MBIQOaQh1et8neZZCuKkcctVa2DejGsFa+uQfb3B9eYJL1iAAAAAAiBgMW6EolVvMKGZVBYz9d2meHcQzKsmdxtwhPTJ4RBPR2ZxgAAAAALAAAgAAAAIAAAACAAAAAAAAAAAAAAQEfUMMAAAAAAAAWABRdVlN9SNyYZGw0RlmtnzqBcHoXxSIGAnqv8b0nSBLQEkZL4l3AZYcoektXhnjljJSaEzufuTx/GAAAAABUAACAAAAAgAAAAIAAAAAAAQAAAAABASCQZQAAAAAAABepFHH8oGeDfo3SSYkgJqW15AVPiyXhhwEEFgAUojm2oMvHqtwud2Q942MGphZ/rRUiBgICrDvRWeVNwx5lhCrV+aELTrAk6DhkoxmyfeZe4IsqORgAAAAAMQAAgAAAAIAAAACAAAAAAAAAAAAAAA==',
     );
 
@@ -160,21 +157,20 @@ describe('AbstractHDElectrumWallet.cosign', () => {
 
     let tx;
 
-    assert.strictEqual(w1.calculateHowManySignaturesWeHaveFromPsbt(psbt), 0);
+    expect(w1.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(0);
     tx = w1.cosignPsbt(psbt).tx;
-    assert.strictEqual(w1.calculateHowManySignaturesWeHaveFromPsbt(psbt), 1);
-    assert.strictEqual(tx, false); // not yet fully-signed
+    expect(w1.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(1);
+    expect(tx).toBe(false); // not yet fully-signed
 
     tx = w2.cosignPsbt(psbt).tx;
-    assert.strictEqual(w2.calculateHowManySignaturesWeHaveFromPsbt(psbt), 2);
-    assert.strictEqual(tx, false); // not yet fully-signed
+    expect(w2.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(2);
+    expect(tx).toBe(false); // not yet fully-signed
 
     tx = w3.cosignPsbt(psbt).tx; // GREAT SUCCESS!
-    assert.strictEqual(w3.calculateHowManySignaturesWeHaveFromPsbt(psbt), 3);
-    assert.ok(tx);
+    expect(w3.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(3);
+    expect(tx).toBeTruthy();
 
-    assert.strictEqual(
-      tx.toHex(),
+    expect(tx.toHex()).toBe(
       '020000000001035fbc74110c2d6fcf4d1161a59913fbcd2b6ab3c5a9eb4d0dc0859515cbc8654f000000006a473044022041df555e5f6a3769fafdbe23bfe29de84a1341b8fd85ffd279e238309c5df07702207cf1628b35ccacdb7d34e20fd46a3bc8adc0b1bd3b63249a3a4442b5a993d73501210316e84a2556f30a199541633f5dda6787710ccab26771b7084f4c9e1104f47667000000806d93fb792280e26304b370abebd237430ceddb5670877f1d2a98d80924a900ad01000000000000008087c9acd9d5714845343b18abaa26cb83299be2487c22da9c0e270f241b4d9cfe0000000017160014a239b6a0cbc7aadc2e77643de36306a6167fad15000000800110270000000000001976a9144dc6cbf64df9ab106cee812c7501960b93e9217788ac0002483045022100efe66403aba1441041dfdeff1f24b5e89ab5728ae7ceb9edb264eee004d5883c02207bf03cb611c9322086ac75fa97c374e9540c911359ede4f62de3c94c429ea2320121027aaff1bd274812d012464be25dc06587287a4b578678e58c949a133b9fb93c7f0247304402207a99c115f0b372d151caf991bb5af9f880e7d87625eeb4233fefa671489ed8e702200e5675b92e4e22b2fe37f563b2a0e75fb81def5a6efb431c7ca3b654ef63fe5801210202ac3bd159e54dc31e65842ad5f9a10b4eb024e83864a319b27de65ee08b2a3900000000',
     );
   });
@@ -187,16 +183,16 @@ describe('AbstractHDElectrumWallet.cosign', () => {
 
     const w = new HDSegwitBech32Wallet();
     w.setSecret(process.env.MNEMONICS_COBO);
-    assert.ok(w.validateMnemonic());
+    expect(w.validateMnemonic()).toBeTruthy();
 
     const psbtWithCorrectFpBase64 =
       'cHNidP8BAFUCAAAAAfsmeQ1mJJqC9cD0DxDRFQoG2hvU6S4koB0jl+8TEDKjAAAAAAD/////AQpfAAAAAAAAGXapFBkSnVPmMZuvGdugWb6tFm35Crj1iKwAAAAAAAEBH8p3AAAAAAAAFgAUf8fcrCg92McSzWkmw+UAluC4IjsiBgLfsmddhS3oxlnlGrUPDBVoVHSMa8RcXlGsyhfc8CcGpRjTfq2IVAAAgAAAAIAAAACAAAAAAAQAAAAAAA==';
     const psbtWithCorrectFp = bitcoin.Psbt.fromBase64(psbtWithCorrectFpBase64);
 
-    assert.strictEqual(w.calculateHowManySignaturesWeHaveFromPsbt(psbtWithCorrectFp), 0);
+    expect(w.calculateHowManySignaturesWeHaveFromPsbt(psbtWithCorrectFp)).toBe(0);
 
     const { tx } = w.cosignPsbt(psbtWithCorrectFp);
-    assert.ok(tx && tx.toHex());
-    assert.strictEqual(w.calculateHowManySignaturesWeHaveFromPsbt(psbtWithCorrectFp), 1);
+    expect(tx && tx.toHex()).toBeTruthy();
+    expect(w.calculateHowManySignaturesWeHaveFromPsbt(psbtWithCorrectFp)).toBe(1);
   });
 });

--- a/tests/unit/currency.test.js
+++ b/tests/unit/currency.test.js
@@ -1,36 +1,32 @@
 import { FiatUnit } from '../../models/fiatUnit';
-const assert = require('assert');
 
 describe('currency', () => {
   it('formats everything correctly', async () => {
     const currency = require('../../blue_modules/currency');
     currency._setExchangeRate('BTC_USD', 10000);
 
-    assert.strictEqual(currency.satoshiToLocalCurrency(1), '$0.0001');
-    assert.strictEqual(currency.satoshiToLocalCurrency(-1), '-$0.0001');
-    assert.strictEqual(currency.satoshiToLocalCurrency(123), '$0.01');
-    assert.strictEqual(currency.satoshiToLocalCurrency(156), '$0.02');
-    assert.strictEqual(currency.satoshiToLocalCurrency(51), '$0.01');
-    assert.strictEqual(currency.satoshiToLocalCurrency(45), '$0.0045');
-    assert.strictEqual(currency.satoshiToLocalCurrency(123456789), '$12,345.68');
+    expect(currency.satoshiToLocalCurrency(1)).toBe('$0.0001');
+    expect(currency.satoshiToLocalCurrency(-1)).toBe('-$0.0001');
+    expect(currency.satoshiToLocalCurrency(123)).toBe('$0.01');
+    expect(currency.satoshiToLocalCurrency(156)).toBe('$0.02');
+    expect(currency.satoshiToLocalCurrency(51)).toBe('$0.01');
+    expect(currency.satoshiToLocalCurrency(45)).toBe('$0.0045');
+    expect(currency.satoshiToLocalCurrency(123456789)).toBe('$12,345.68');
 
-    assert.strictEqual(currency.BTCToLocalCurrency(1), '$10,000.00');
-    assert.strictEqual(currency.BTCToLocalCurrency(-1), '-$10,000.00');
-    assert.strictEqual(currency.BTCToLocalCurrency(1.00000001), '$10,000.00');
-    assert.strictEqual(currency.BTCToLocalCurrency(1.0000123), '$10,000.12');
-    assert.strictEqual(currency.BTCToLocalCurrency(1.0000146), '$10,000.15');
+    expect(currency.BTCToLocalCurrency(1)).toBe('$10,000.00');
+    expect(currency.BTCToLocalCurrency(-1)).toBe('-$10,000.00');
+    expect(currency.BTCToLocalCurrency(1.00000001)).toBe('$10,000.00');
+    expect(currency.BTCToLocalCurrency(1.0000123)).toBe('$10,000.12');
+    expect(currency.BTCToLocalCurrency(1.0000146)).toBe('$10,000.15');
 
-    assert.strictEqual(currency.satoshiToBTC(1), '0.00000001');
-    assert.strictEqual(currency.satoshiToBTC(-1), '-0.00000001');
-    assert.strictEqual(currency.satoshiToBTC(100000000), '1');
-    assert.strictEqual(currency.satoshiToBTC(123456789123456789), '1234567891.2345678'); // eslint-disable-line no-loss-of-precision
+    expect(currency.satoshiToBTC(1)).toBe('0.00000001');
+    expect(currency.satoshiToBTC(-1)).toBe('-0.00000001');
+    expect(currency.satoshiToBTC(100000000)).toBe('1');
+    expect(currency.satoshiToBTC(123456789123456789)).toBe('1234567891.2345678'); // eslint-disable-line no-loss-of-precision
 
     currency._setPreferredFiatCurrency(FiatUnit.JPY);
     currency._setExchangeRate('BTC_JPY', 1043740.8614);
 
-    assert.ok(
-      currency.satoshiToLocalCurrency(1) === '¥0.01' || currency.satoshiToLocalCurrency(1) === '￥0.01',
-      'Unexpected: ' + currency.satoshiToLocalCurrency(1),
-    );
+    expect(currency.satoshiToLocalCurrency(1) === '¥0.01' || currency.satoshiToLocalCurrency(1) === '￥0.01').toBeTruthy();
   });
 });

--- a/tests/unit/deeplink-schema-match.test.js
+++ b/tests/unit/deeplink-schema-match.test.js
@@ -1,74 +1,73 @@
 import DeeplinkSchemaMatch from '../../class/deeplink-schema-match';
-const assert = require('assert');
 jest.useFakeTimers();
 
 describe('unit - DeepLinkSchemaMatch', function () {
   it('hasSchema', () => {
-    assert.ok(DeeplinkSchemaMatch.hasSchema('bitcoin:12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG'));
-    assert.ok(DeeplinkSchemaMatch.hasSchema('bitcoin:bc1qh6tf004ty7z7un2v5ntu4mkf630545gvhs45u7?amount=666&label=Yo'));
-    assert.ok(DeeplinkSchemaMatch.hasSchema('bitcoin:BC1QH6TF004TY7Z7UN2V5NTU4MKF630545GVHS45U7?amount=666&label=Yo'));
-    assert.ok(DeeplinkSchemaMatch.hasSchema('BITCOIN:BC1Q3RL0MKYK0ZRTXFMQN9WPCD3GNAZ00YV9YP0HXE'));
-    assert.ok(DeeplinkSchemaMatch.hasSchema('BITCOIN:BC1Q3RL0MKYK0ZRTXFMQN9WPCD3GNAZ00YV9YP0HXE?amount=666&label=Yo'));
-    assert.ok(
+    expect(DeeplinkSchemaMatch.hasSchema('bitcoin:12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG')).toBeTruthy();
+    expect(DeeplinkSchemaMatch.hasSchema('bitcoin:bc1qh6tf004ty7z7un2v5ntu4mkf630545gvhs45u7?amount=666&label=Yo')).toBeTruthy();
+    expect(DeeplinkSchemaMatch.hasSchema('bitcoin:BC1QH6TF004TY7Z7UN2V5NTU4MKF630545GVHS45U7?amount=666&label=Yo')).toBeTruthy();
+    expect(DeeplinkSchemaMatch.hasSchema('BITCOIN:BC1Q3RL0MKYK0ZRTXFMQN9WPCD3GNAZ00YV9YP0HXE')).toBeTruthy();
+    expect(DeeplinkSchemaMatch.hasSchema('BITCOIN:BC1Q3RL0MKYK0ZRTXFMQN9WPCD3GNAZ00YV9YP0HXE?amount=666&label=Yo')).toBeTruthy();
+    expect(
       DeeplinkSchemaMatch.hasSchema(
         'lightning:lnbc10u1pwjqwkkpp5vlc3tttdzhpk9fwzkkue0sf2pumtza7qyw9vucxyyeh0yaqq66yqdq5f38z6mmwd3ujqar9wd6qcqzpgxq97zvuqrzjqvgptfurj3528snx6e3dtwepafxw5fpzdymw9pj20jj09sunnqmwqz9hx5qqtmgqqqqqqqlgqqqqqqgqjq5duu3fs9xq9vn89qk3ezwpygecu4p3n69wm3tnl28rpgn2gmk5hjaznemw0gy32wrslpn3g24khcgnpua9q04fttm2y8pnhmhhc2gncplz0zde',
       ),
-    );
+    ).toBeTruthy();
 
-    assert.ok(DeeplinkSchemaMatch.hasSchema('bluewallet:bitcoin:12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG'));
-    assert.ok(DeeplinkSchemaMatch.hasSchema('bluewallet:bitcoin:bc1qh6tf004ty7z7un2v5ntu4mkf630545gvhs45u7?amount=666&label=Yo'));
-    assert.ok(DeeplinkSchemaMatch.hasSchema('bluewallet:bitcoin:BC1QH6TF004TY7Z7UN2V5NTU4MKF630545GVHS45U7?amount=666&label=Yo'));
-    assert.ok(DeeplinkSchemaMatch.hasSchema('bluewallet:BITCOIN:BC1Q3RL0MKYK0ZRTXFMQN9WPCD3GNAZ00YV9YP0HXE'));
-    assert.ok(DeeplinkSchemaMatch.hasSchema('bluewallet:BITCOIN:BC1Q3RL0MKYK0ZRTXFMQN9WPCD3GNAZ00YV9YP0HXE?amount=666&label=Yo'));
-    assert.ok(
+    expect(DeeplinkSchemaMatch.hasSchema('bluewallet:bitcoin:12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG')).toBeTruthy();
+    expect(DeeplinkSchemaMatch.hasSchema('bluewallet:bitcoin:bc1qh6tf004ty7z7un2v5ntu4mkf630545gvhs45u7?amount=666&label=Yo')).toBeTruthy();
+    expect(DeeplinkSchemaMatch.hasSchema('bluewallet:bitcoin:BC1QH6TF004TY7Z7UN2V5NTU4MKF630545GVHS45U7?amount=666&label=Yo')).toBeTruthy();
+    expect(DeeplinkSchemaMatch.hasSchema('bluewallet:BITCOIN:BC1Q3RL0MKYK0ZRTXFMQN9WPCD3GNAZ00YV9YP0HXE')).toBeTruthy();
+    expect(DeeplinkSchemaMatch.hasSchema('bluewallet:BITCOIN:BC1Q3RL0MKYK0ZRTXFMQN9WPCD3GNAZ00YV9YP0HXE?amount=666&label=Yo')).toBeTruthy();
+    expect(
       DeeplinkSchemaMatch.hasSchema(
         'bluewallet:lightning:lnbc10u1pwjqwkkpp5vlc3tttdzhpk9fwzkkue0sf2pumtza7qyw9vucxyyeh0yaqq66yqdq5f38z6mmwd3ujqar9wd6qcqzpgxq97zvuqrzjqvgptfurj3528snx6e3dtwepafxw5fpzdymw9pj20jj09sunnqmwqz9hx5qqtmgqqqqqqqlgqqqqqqgqjq5duu3fs9xq9vn89qk3ezwpygecu4p3n69wm3tnl28rpgn2gmk5hjaznemw0gy32wrslpn3g24khcgnpua9q04fttm2y8pnhmhhc2gncplz0zde',
       ),
-    );
+    ).toBeTruthy();
   });
 
   it('isBitcoin Address', () => {
-    assert.ok(DeeplinkSchemaMatch.isBitcoinAddress('12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG'));
-    assert.ok(DeeplinkSchemaMatch.isBitcoinAddress('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK'));
-    assert.ok(DeeplinkSchemaMatch.isBitcoinAddress('bc1qykcp2x3djgdtdwelxn9z4j2y956npte0a4sref'));
-    assert.ok(DeeplinkSchemaMatch.isBitcoinAddress('BC1QYKCP2X3DJGDTDWELXN9Z4J2Y956NPTE0A4SREF'));
-    assert.ok(DeeplinkSchemaMatch.isBitcoinAddress('bitcoin:BC1QH6TF004TY7Z7UN2V5NTU4MKF630545GVHS45U7'));
-    assert.ok(DeeplinkSchemaMatch.isBitcoinAddress('BITCOIN:BC1Q3RL0MKYK0ZRTXFMQN9WPCD3GNAZ00YV9YP0HXE'));
-    assert.ok(DeeplinkSchemaMatch.isBitcoinAddress('BITCOIN:BC1Q3RL0MKYK0ZRTXFMQN9WPCD3GNAZ00YV9YP0HXE?amount=666&label=Yo'));
+    expect(DeeplinkSchemaMatch.isBitcoinAddress('12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG')).toBeTruthy();
+    expect(DeeplinkSchemaMatch.isBitcoinAddress('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK')).toBeTruthy();
+    expect(DeeplinkSchemaMatch.isBitcoinAddress('bc1qykcp2x3djgdtdwelxn9z4j2y956npte0a4sref')).toBeTruthy();
+    expect(DeeplinkSchemaMatch.isBitcoinAddress('BC1QYKCP2X3DJGDTDWELXN9Z4J2Y956NPTE0A4SREF')).toBeTruthy();
+    expect(DeeplinkSchemaMatch.isBitcoinAddress('bitcoin:BC1QH6TF004TY7Z7UN2V5NTU4MKF630545GVHS45U7')).toBeTruthy();
+    expect(DeeplinkSchemaMatch.isBitcoinAddress('BITCOIN:BC1Q3RL0MKYK0ZRTXFMQN9WPCD3GNAZ00YV9YP0HXE')).toBeTruthy();
+    expect(DeeplinkSchemaMatch.isBitcoinAddress('BITCOIN:BC1Q3RL0MKYK0ZRTXFMQN9WPCD3GNAZ00YV9YP0HXE?amount=666&label=Yo')).toBeTruthy();
   });
 
   it('isLighting Invoice', () => {
-    assert.ok(
+    expect(
       DeeplinkSchemaMatch.isLightningInvoice(
         'lightning:lnbc10u1pwjqwkkpp5vlc3tttdzhpk9fwzkkue0sf2pumtza7qyw9vucxyyeh0yaqq66yqdq5f38z6mmwd3ujqar9wd6qcqzpgxq97zvuqrzjqvgptfurj3528snx6e3dtwepafxw5fpzdymw9pj20jj09sunnqmwqz9hx5qqtmgqqqqqqqlgqqqqqqgqjq5duu3fs9xq9vn89qk3ezwpygecu4p3n69wm3tnl28rpgn2gmk5hjaznemw0gy32wrslpn3g24khcgnpua9q04fttm2y8pnhmhhc2gncplz0zde',
       ),
-    );
+    ).toBeTruthy();
   });
 
   it('isBoth Bitcoin & Invoice', () => {
-    assert.ok(
+    expect(
       DeeplinkSchemaMatch.isBothBitcoinAndLightning(
         'bitcoin:BC1Q3RL0MKYK0ZRTXFMQN9WPCD3GNAZ00YV9YP0HXE?amount=0.000001&lightning=lnbc1u1pwry044pp53xlmkghmzjzm3cljl6729cwwqz5hhnhevwfajpkln850n7clft4sdqlgfy4qv33ypmj7sj0f32rzvfqw3jhxaqcqzysxq97zvuq5zy8ge6q70prnvgwtade0g2k5h2r76ws7j2926xdjj2pjaq6q3r4awsxtm6k5prqcul73p3atveljkn6wxdkrcy69t6k5edhtc6q7lgpe4m5k4',
       ),
-    );
-    assert.ok(
+    ).toBeTruthy();
+    expect(
       DeeplinkSchemaMatch.isBothBitcoinAndLightning(
         'BITCOIN:12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG?amount=0.000001&lightning=lnbc1u1pwry044pp53xlmkghmzjzm3cljl6729cwwqz5hhnhevwfajpkln850n7clft4sdqlgfy4qv33ypmj7sj0f32rzvfqw3jhxaqcqzysxq97zvuq5zy8ge6q70prnvgwtade0g2k5h2r76ws7j2926xdjj2pjaq6q3r4awsxtm6k5prqcul73p3atveljkn6wxdkrcy69t6k5edhtc6q7lgpe4m5k4',
       ),
-    );
+    ).toBeTruthy();
   });
 
   it('isLnurl', () => {
-    assert.ok(
+    expect(
       DeeplinkSchemaMatch.isLnUrl(
         'LNURL1DP68GURN8GHJ7UM9WFMXJCM99E3K7MF0V9CXJ0M385EKVCENXC6R2C35XVUKXEFCV5MKVV34X5EKZD3EV56NYD3HXQURZEPEXEJXXEPNXSCRVWFNV9NXZCN9XQ6XYEFHVGCXXCMYXYMNSERXFQ5FNS',
       ),
-    );
+    ).toBeTruthy();
   });
 
   it('isSafelloRedirect', () => {
-    assert.ok(DeeplinkSchemaMatch.isSafelloRedirect({ url: 'bluewallet:?safello-state-token=TEST' }));
-    assert.ok(!DeeplinkSchemaMatch.isSafelloRedirect({ url: 'bluewallet:' }));
+    expect(DeeplinkSchemaMatch.isSafelloRedirect({ url: 'bluewallet:?safello-state-token=TEST' })).toBeTruthy();
+    expect(!DeeplinkSchemaMatch.isSafelloRedirect({ url: 'bluewallet:' })).toBeTruthy();
   });
 
   it('navigationForRoute', async () => {
@@ -303,24 +302,23 @@ describe('unit - DeepLinkSchemaMatch', function () {
 
     for (const event of events) {
       const navValue = await asyncNavigationRouteFor(event.argument);
-      assert.deepStrictEqual(navValue, event.expected);
+      expect(navValue).toEqual(event.expected);
     }
 
     // BIP21 w/BOLT11 support
-    assert.equal(
+    expect(
       (
         await asyncNavigationRouteFor({
           url:
             'bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001&lightning=lnbc1u1pwry044pp53xlmkghmzjzm3cljl6729cwwqz5hhnhevwfajpkln850n7clft4sdqlgfy4qv33ypmj7sj0f32rzvfqw3jhxaqcqzysxq97zvuq5zy8ge6q70prnvgwtade0g2k5h2r76ws7j2926xdjj2pjaq6q3r4awsxtm6k5prqcul73p3atveljkn6wxdkrcy69t6k5edhtc6q7lgpe4m5k4',
         })
       )[0],
-      'SelectWallet',
-    );
+    ).toBe('SelectWallet');
   });
 
   it('decodes bip21', () => {
     let decoded = DeeplinkSchemaMatch.bip21decode('bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=20.3&label=Foobar');
-    assert.deepStrictEqual(decoded, {
+    expect(decoded).toEqual({
       address: '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH',
       options: {
         amount: 20.3,
@@ -331,10 +329,10 @@ describe('unit - DeepLinkSchemaMatch', function () {
     decoded = DeeplinkSchemaMatch.bip21decode(
       'bitcoin:bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7?amount=0.0001&pj=https://btc.donate.kukks.org/BTC/pj',
     );
-    assert.strictEqual(decoded.options.pj, 'https://btc.donate.kukks.org/BTC/pj');
+    expect(decoded.options.pj).toBe('https://btc.donate.kukks.org/BTC/pj');
 
     decoded = DeeplinkSchemaMatch.bip21decode('BITCOIN:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=20.3&label=Foobar');
-    assert.deepStrictEqual(decoded, {
+    expect(decoded).toEqual({
       address: '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH',
       options: {
         amount: 20.3,
@@ -345,28 +343,27 @@ describe('unit - DeepLinkSchemaMatch', function () {
 
   it('encodes bip21', () => {
     let encoded = DeeplinkSchemaMatch.bip21encode('1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH');
-    assert.strictEqual(encoded, 'bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH');
+    expect(encoded).toBe('bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH');
     encoded = DeeplinkSchemaMatch.bip21encode('1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH', {
       amount: 20.3,
       label: 'Foobar',
     });
-    assert.strictEqual(encoded, 'bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=20.3&label=Foobar');
+    expect(encoded).toBe('bitcoin:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=20.3&label=Foobar');
   });
 
   it('can decodeBitcoinUri', () => {
-    assert.deepStrictEqual(
+    expect(
       DeeplinkSchemaMatch.decodeBitcoinUri(
         'bitcoin:bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7?amount=0.0001&pj=https://btc.donate.kukks.org/BTC/pj',
       ),
-      {
-        address: 'bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7',
-        amount: 0.0001,
-        memo: '',
-        payjoinUrl: 'https://btc.donate.kukks.org/BTC/pj',
-      },
-    );
+    ).toEqual({
+      address: 'bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7',
+      amount: 0.0001,
+      memo: '',
+      payjoinUrl: 'https://btc.donate.kukks.org/BTC/pj',
+    });
 
-    assert.deepStrictEqual(DeeplinkSchemaMatch.decodeBitcoinUri('BITCOIN:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=20.3&label=Foobar'), {
+    expect(DeeplinkSchemaMatch.decodeBitcoinUri('BITCOIN:1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH?amount=20.3&label=Foobar')).toEqual({
       address: '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH',
       amount: 20.3,
       memo: 'Foobar',
@@ -376,64 +373,65 @@ describe('unit - DeepLinkSchemaMatch', function () {
 
   it('recognizes files', () => {
     // txn files:
-    assert.ok(DeeplinkSchemaMatch.isTXNFile('file://com.android.externalstorage.documents/document/081D-1403%3Atxhex.txn'));
-    assert.ok(!DeeplinkSchemaMatch.isPossiblySignedPSBTFile('file://com.android.externalstorage.documents/document/081D-1403%3Atxhex.txn'));
+    expect(DeeplinkSchemaMatch.isTXNFile('file://com.android.externalstorage.documents/document/081D-1403%3Atxhex.txn')).toBeTruthy();
+    expect(
+      !DeeplinkSchemaMatch.isPossiblySignedPSBTFile('file://com.android.externalstorage.documents/document/081D-1403%3Atxhex.txn'),
+    ).toBeTruthy();
 
-    assert.ok(DeeplinkSchemaMatch.isTXNFile('content://com.android.externalstorage.documents/document/081D-1403%3Atxhex.txn'));
-    assert.ok(
+    expect(DeeplinkSchemaMatch.isTXNFile('content://com.android.externalstorage.documents/document/081D-1403%3Atxhex.txn')).toBeTruthy();
+    expect(
       !DeeplinkSchemaMatch.isPossiblySignedPSBTFile('content://com.android.externalstorage.documents/document/081D-1403%3Atxhex.txn'),
-    );
+    ).toBeTruthy();
 
     // psbt files (signed):
-    assert.ok(
+    expect(
       DeeplinkSchemaMatch.isPossiblySignedPSBTFile(
         'content://com.android.externalstorage.documents/document/081D-1403%3Atxhex-signed.psbt',
       ),
-    );
-    assert.ok(
+    ).toBeTruthy();
+    expect(
       DeeplinkSchemaMatch.isPossiblySignedPSBTFile('file://com.android.externalstorage.documents/document/081D-1403%3Atxhex-signed.psbt'),
-    );
+    ).toBeTruthy();
 
-    assert.ok(!DeeplinkSchemaMatch.isTXNFile('content://com.android.externalstorage.documents/document/081D-1403%3Atxhex-signed.psbt'));
-    assert.ok(!DeeplinkSchemaMatch.isTXNFile('file://com.android.externalstorage.documents/document/081D-1403%3Atxhex-signed.psbt'));
+    expect(
+      !DeeplinkSchemaMatch.isTXNFile('content://com.android.externalstorage.documents/document/081D-1403%3Atxhex-signed.psbt'),
+    ).toBeTruthy();
+    expect(
+      !DeeplinkSchemaMatch.isTXNFile('file://com.android.externalstorage.documents/document/081D-1403%3Atxhex-signed.psbt'),
+    ).toBeTruthy();
 
     // psbt files (unsigned):
-    assert.ok(DeeplinkSchemaMatch.isPossiblyPSBTFile('content://com.android.externalstorage.documents/document/081D-1403%3Atxhex.psbt'));
-    assert.ok(DeeplinkSchemaMatch.isPossiblyPSBTFile('file://com.android.externalstorage.documents/document/081D-1403%3Atxhex.psbt'));
+    expect(
+      DeeplinkSchemaMatch.isPossiblyPSBTFile('content://com.android.externalstorage.documents/document/081D-1403%3Atxhex.psbt'),
+    ).toBeTruthy();
+    expect(
+      DeeplinkSchemaMatch.isPossiblyPSBTFile('file://com.android.externalstorage.documents/document/081D-1403%3Atxhex.psbt'),
+    ).toBeTruthy();
   });
 
   it('can work with some deeplink actions', () => {
-    assert.strictEqual(DeeplinkSchemaMatch.getServerFromSetElectrumServerAction('sgasdgasdgasd'), false);
-    assert.strictEqual(
+    expect(DeeplinkSchemaMatch.getServerFromSetElectrumServerAction('sgasdgasdgasd')).toBe(false);
+    expect(
       DeeplinkSchemaMatch.getServerFromSetElectrumServerAction('bluewallet:setelectrumserver?server=electrum1.bluewallet.io%3A443%3As'),
+    ).toBe('electrum1.bluewallet.io:443:s');
+    expect(DeeplinkSchemaMatch.getServerFromSetElectrumServerAction('setelectrumserver?server=electrum1.bluewallet.io%3A443%3As')).toBe(
       'electrum1.bluewallet.io:443:s',
     );
-    assert.strictEqual(
-      DeeplinkSchemaMatch.getServerFromSetElectrumServerAction('setelectrumserver?server=electrum1.bluewallet.io%3A443%3As'),
-      'electrum1.bluewallet.io:443:s',
-    );
-    assert.strictEqual(
+    expect(
       DeeplinkSchemaMatch.getServerFromSetElectrumServerAction('ololo:setelectrumserver?server=electrum1.bluewallet.io%3A443%3As'),
-      false,
-    );
-    assert.strictEqual(
-      DeeplinkSchemaMatch.getServerFromSetElectrumServerAction('setTrololo?server=electrum1.bluewallet.io%3A443%3As'),
-      false,
-    );
+    ).toBe(false);
+    expect(DeeplinkSchemaMatch.getServerFromSetElectrumServerAction('setTrololo?server=electrum1.bluewallet.io%3A443%3As')).toBe(false);
 
-    assert.strictEqual(
-      DeeplinkSchemaMatch.getUrlFromSetLndhubUrlAction('bluewallet:setlndhuburl?url=https%3A%2F%2Flndhub.herokuapp.com'),
+    expect(DeeplinkSchemaMatch.getUrlFromSetLndhubUrlAction('bluewallet:setlndhuburl?url=https%3A%2F%2Flndhub.herokuapp.com')).toBe(
       'https://lndhub.herokuapp.com',
     );
-    assert.strictEqual(
-      DeeplinkSchemaMatch.getUrlFromSetLndhubUrlAction('bluewallet:setlndhuburl?url=https%3A%2F%2Flndhub.herokuapp.com%3A443'),
+    expect(DeeplinkSchemaMatch.getUrlFromSetLndhubUrlAction('bluewallet:setlndhuburl?url=https%3A%2F%2Flndhub.herokuapp.com%3A443')).toBe(
       'https://lndhub.herokuapp.com:443',
     );
-    assert.strictEqual(
-      DeeplinkSchemaMatch.getUrlFromSetLndhubUrlAction('setlndhuburl?url=https%3A%2F%2Flndhub.herokuapp.com%3A443'),
+    expect(DeeplinkSchemaMatch.getUrlFromSetLndhubUrlAction('setlndhuburl?url=https%3A%2F%2Flndhub.herokuapp.com%3A443')).toBe(
       'https://lndhub.herokuapp.com:443',
     );
-    assert.strictEqual(DeeplinkSchemaMatch.getUrlFromSetLndhubUrlAction('gsom?url=https%3A%2F%2Flndhub.herokuapp.com%3A443'), false);
-    assert.strictEqual(DeeplinkSchemaMatch.getUrlFromSetLndhubUrlAction('sdfhserhsthsd'), false);
+    expect(DeeplinkSchemaMatch.getUrlFromSetLndhubUrlAction('gsom?url=https%3A%2F%2Flndhub.herokuapp.com%3A443')).toBe(false);
+    expect(DeeplinkSchemaMatch.getUrlFromSetLndhubUrlAction('sdfhserhsthsd')).toBe(false);
   });
 });

--- a/tests/unit/encryption.test.js
+++ b/tests/unit/encryption.test.js
@@ -1,4 +1,3 @@
-const assert = require('assert');
 const c = require('../../blue_modules/encryption');
 
 describe('unit - encryption', function () {
@@ -7,16 +6,16 @@ describe('unit - encryption', function () {
     const crypted = c.encrypt(data2encrypt, 'password');
     const decrypted = c.decrypt(crypted, 'password');
 
-    assert.ok(crypted);
-    assert.ok(decrypted);
-    assert.strictEqual(decrypted, data2encrypt);
-    assert.ok(crypted !== data2encrypt);
+    expect(crypted).toBeTruthy();
+    expect(decrypted).toBeTruthy();
+    expect(decrypted).toBe(data2encrypt);
+    expect(crypted !== data2encrypt).toBeTruthy();
 
     let decryptedWithBadPassword;
     try {
       decryptedWithBadPassword = c.decrypt(crypted, 'passwordBad');
     } catch (e) {}
-    assert.ok(!decryptedWithBadPassword);
+    expect(!decryptedWithBadPassword).toBeTruthy();
 
     let exceptionRaised = false;
     try {
@@ -24,7 +23,7 @@ describe('unit - encryption', function () {
     } catch (_) {
       exceptionRaised = true;
     }
-    assert.ok(exceptionRaised);
+    expect(exceptionRaised).toBeTruthy();
   });
 
   it('handles ok malformed data', function () {
@@ -32,7 +31,7 @@ describe('unit - encryption', function () {
       'U2FsdGVkX1/OSNdi0JrLANn9qdNEiXgP20MJgT13CMKC7xKe+sb7x0An6r8lzrYeL2vjoPm2Xi5I3UdBcsgjgh0TR4PypNdDaW1tW8LhFH1wVCh1hacrFsJjoKMBmdCn4IVMwtIffGPptqBrGZl+6kjOc3BBbgq4uaAavFIwTS86WdaRt9qAboBcoPJZxsj37othbZfZfl2GBTCWnR1tOYAbElKWv4lBwNQpX7HqX3wTQkAbamBslsH5FfZRY1c38lOHrZMwNSyxhgspydksTxKkhPqWQu3XWT4GpRoRuVvYlBNvJOCUu2JbiVSp4NiOMSfnA8ahvpCGRNy+qPWsXqmJtz9BwyzedzDkgg6QOqxXz4oOeEJa/XLKiuv3ItsLrZb+sSA6wjB1Cx6/Oh2vW7eiHjCITeC7KUK1fAxVwufLcprNkvG8qFzkOcHxDyzG+sNL0cMipAxhpMX7qIcYcZFoLYkQRQHpOZKZCIAdNTfPGJ7M4cxGM0V+Uuirjyn+KAPJwNElwmPpX8sTQyEqlIlEwVjFXBpz28N5RAGN2zzCzEjD8NVYQJ2QyHj0gfWe',
       'fakePassword',
     );
-    assert.ok(!decrypted);
+    expect(!decrypted).toBeTruthy();
   });
 
   it('can decrypt cipher created by CryptoJS@3.1.9-1', () => {
@@ -40,6 +39,6 @@ describe('unit - encryption', function () {
     const crypted =
       'U2FsdGVkX19fJ4PcLum+tmBpEVNgGGsGKOhRS21cEcYAox+Df8VqmnnG9t2PvpM05eWImCRArorVUUegtcfSq314WMFzxKmiPIl9eqV1aOY+VFGuIBx0VIVsCWix2Q7sRZZwnOVpG5bdveZI0+Azyw==';
     const decrypted = c.decrypt(crypted, 'password');
-    assert.deepEqual(data2decrypt, decrypted);
+    expect(data2decrypt).toEqual(decrypted);
   });
 });

--- a/tests/unit/hd-aezeed.test.js
+++ b/tests/unit/hd-aezeed.test.js
@@ -1,98 +1,88 @@
 import { HDAezeedWallet, WatchOnlyWallet } from '../../class';
-const assert = require('assert');
 
 describe('HDAezeedWallet', () => {
   it('can import mnemonics and generate addresses and WIFs', async function () {
     const aezeed = new HDAezeedWallet();
 
     aezeed.setSecret('bs');
-    assert.ok(!(await aezeed.validateMnemonicAsync()));
-    assert.ok(!(await aezeed.mnemonicInvalidPassword()));
+    expect(!(await aezeed.validateMnemonicAsync())).toBeTruthy();
+    expect(!(await aezeed.mnemonicInvalidPassword())).toBeTruthy();
 
     // correct pass:
     aezeed.setSecret(
       'able mix price funny host express lawsuit congress antique float pig exchange vapor drip wide cup style apple tumble verb fix blush tongue market',
     );
     aezeed.setPassphrase('strongPassword');
-    assert.ok(await aezeed.validateMnemonicAsync());
-    assert.ok(!(await aezeed.mnemonicInvalidPassword()));
+    expect(await aezeed.validateMnemonicAsync()).toBeTruthy();
+    expect(!(await aezeed.mnemonicInvalidPassword())).toBeTruthy();
 
     // no pass but its required:
     aezeed.setSecret(
       'able mix price funny host express lawsuit congress antique float pig exchange vapor drip wide cup style apple tumble verb fix blush tongue market',
     );
     aezeed.setPassphrase();
-    assert.ok(!(await aezeed.validateMnemonicAsync()));
-    assert.ok(await aezeed.mnemonicInvalidPassword());
+    expect(!(await aezeed.validateMnemonicAsync())).toBeTruthy();
+    expect(await aezeed.mnemonicInvalidPassword()).toBeTruthy();
 
     // wrong pass:
     aezeed.setSecret(
       'able mix price funny host express lawsuit congress antique float pig exchange vapor drip wide cup style apple tumble verb fix blush tongue market',
     );
     aezeed.setPassphrase('badpassword');
-    assert.ok(!(await aezeed.validateMnemonicAsync()));
-    assert.ok(await aezeed.mnemonicInvalidPassword());
+    expect(!(await aezeed.validateMnemonicAsync())).toBeTruthy();
+    expect(await aezeed.mnemonicInvalidPassword()).toBeTruthy();
 
     aezeed.setSecret(
       'able concert slush lend olive cost wagon dawn board robot park snap dignity churn fiction quote shrimp hammer wing jump immune skill sunset west',
     );
     aezeed.setPassphrase();
-    assert.ok(await aezeed.validateMnemonicAsync());
-    assert.ok(!(await aezeed.mnemonicInvalidPassword()));
+    expect(await aezeed.validateMnemonicAsync()).toBeTruthy();
+    expect(!(await aezeed.mnemonicInvalidPassword())).toBeTruthy();
 
     aezeed.setSecret(
       'able concert slush lend olive cost wagon dawn board robot park snap dignity churn fiction quote shrimp hammer wing jump immune skill sunset west',
     );
     aezeed.setPassphrase('aezeed');
-    assert.ok(await aezeed.validateMnemonicAsync());
-    assert.ok(!(await aezeed.mnemonicInvalidPassword()));
+    expect(await aezeed.validateMnemonicAsync()).toBeTruthy();
+    expect(!(await aezeed.mnemonicInvalidPassword())).toBeTruthy();
 
     aezeed.setSecret(
       'abstract rhythm weird food attract treat mosquito sight royal actor surround ride strike remove guilt catch filter summer mushroom protect poverty cruel chaos pattern',
     );
     aezeed.setPassphrase();
-    assert.ok(await aezeed.validateMnemonicAsync());
-    assert.ok(!(await aezeed.mnemonicInvalidPassword()));
+    expect(await aezeed.validateMnemonicAsync()).toBeTruthy();
+    expect(!(await aezeed.mnemonicInvalidPassword())).toBeTruthy();
 
-    assert.strictEqual(
-      aezeed.getXpub(),
+    expect(aezeed.getXpub()).toBe(
       'zpub6rkAmx9z6PmK7tBpGQatqpRweZvRw7uqiEMRS9KuZA9VFKUSoz3GQeJFtRQsQwduWugh5mGHro1tGnt78ci9AiB8qEH4hCRBWxdMaxadGVy',
     );
 
     let address = aezeed._getExternalAddressByIndex(0);
-    assert.strictEqual(address, 'bc1qdjj7lhj9lnjye7xq3dzv3r4z0cta294xy78txn');
-    assert.ok(aezeed.getAllExternalAddresses().includes('bc1qdjj7lhj9lnjye7xq3dzv3r4z0cta294xy78txn'));
+    expect(address).toBe('bc1qdjj7lhj9lnjye7xq3dzv3r4z0cta294xy78txn');
+    expect(aezeed.getAllExternalAddresses().includes('bc1qdjj7lhj9lnjye7xq3dzv3r4z0cta294xy78txn')).toBeTruthy();
 
     address = aezeed._getExternalAddressByIndex(1);
-    assert.strictEqual(address, 'bc1qswr3s4fylskqn9vemef8l28qukshuagsjz3wpe');
-    assert.ok(aezeed.getAllExternalAddresses().includes('bc1qswr3s4fylskqn9vemef8l28qukshuagsjz3wpe'));
+    expect(address).toBe('bc1qswr3s4fylskqn9vemef8l28qukshuagsjz3wpe');
+    expect(aezeed.getAllExternalAddresses().includes('bc1qswr3s4fylskqn9vemef8l28qukshuagsjz3wpe')).toBeTruthy();
 
     address = aezeed._getInternalAddressByIndex(0);
-    assert.strictEqual(address, 'bc1qzyjq8sjj56n8v9fgw5klsc8sq8yuy0jx03hzzp');
+    expect(address).toBe('bc1qzyjq8sjj56n8v9fgw5klsc8sq8yuy0jx03hzzp');
 
     let wif = aezeed._getExternalWIFByIndex(0);
-    assert.strictEqual(wif, 'KxtkgprHVXCcgzRetDt3JnNuRApgzQyRrvAuwiE1yFPjmYnWh6rH');
+    expect(wif).toBe('KxtkgprHVXCcgzRetDt3JnNuRApgzQyRrvAuwiE1yFPjmYnWh6rH');
 
     wif = aezeed._getInternalWIFByIndex(0);
-    assert.strictEqual(wif, 'L1dewhNXkVMB3JdoXYRikbz6g4CbaMGfSqSXSrmTkk5PvzmEgpdT');
+    expect(wif).toBe('L1dewhNXkVMB3JdoXYRikbz6g4CbaMGfSqSXSrmTkk5PvzmEgpdT');
 
-    assert.strictEqual(aezeed.getIdentityPubkey(), '0384b9a7158320e828280075224af324931ca9d6de4334f724dbb553ffee447164');
+    expect(aezeed.getIdentityPubkey()).toBe('0384b9a7158320e828280075224af324931ca9d6de4334f724dbb553ffee447164');
 
     // we should not really test private methods, but oh well
-    assert.strictEqual(
-      aezeed._getNodePubkeyByIndex(0, 0).toString('hex'),
-      '03ed28668d446c6e2ac11e4848f7afd894761ad26569baa8a16adff723699f2c07',
-    );
-    assert.strictEqual(
-      aezeed._getNodePubkeyByIndex(1, 0).toString('hex'),
-      '0210791263114fe72ab5a2131ca1986b84c62a93e30ee9d509266f1eadf4febaf2',
-    );
-    assert.strictEqual(
-      aezeed._getPubkeyByAddress(aezeed._getExternalAddressByIndex(1)).toString('hex'),
+    expect(aezeed._getNodePubkeyByIndex(0, 0).toString('hex')).toBe('03ed28668d446c6e2ac11e4848f7afd894761ad26569baa8a16adff723699f2c07');
+    expect(aezeed._getNodePubkeyByIndex(1, 0).toString('hex')).toBe('0210791263114fe72ab5a2131ca1986b84c62a93e30ee9d509266f1eadf4febaf2');
+    expect(aezeed._getPubkeyByAddress(aezeed._getExternalAddressByIndex(1)).toString('hex')).toBe(
       aezeed._getNodePubkeyByIndex(0, 1).toString('hex'),
     );
-    assert.strictEqual(
-      aezeed._getPubkeyByAddress(aezeed._getInternalAddressByIndex(1)).toString('hex'),
+    expect(aezeed._getPubkeyByAddress(aezeed._getInternalAddressByIndex(1)).toString('hex')).toBe(
       aezeed._getNodePubkeyByIndex(1, 1).toString('hex'),
     );
   });
@@ -102,25 +92,24 @@ describe('HDAezeedWallet', () => {
     aezeed.setSecret(
       'abstract rhythm weird food attract treat mosquito sight royal actor surround ride strike remove guilt catch filter summer mushroom protect poverty cruel chaos pattern',
     );
-    assert.ok(await aezeed.validateMnemonicAsync());
-    assert.ok(!(await aezeed.mnemonicInvalidPassword()));
+    expect(await aezeed.validateMnemonicAsync()).toBeTruthy();
+    expect(!(await aezeed.mnemonicInvalidPassword())).toBeTruthy();
 
-    assert.strictEqual(
-      aezeed.getXpub(),
+    expect(aezeed.getXpub()).toBe(
       'zpub6rkAmx9z6PmK7tBpGQatqpRweZvRw7uqiEMRS9KuZA9VFKUSoz3GQeJFtRQsQwduWugh5mGHro1tGnt78ci9AiB8qEH4hCRBWxdMaxadGVy',
     );
 
     const address = aezeed._getExternalAddressByIndex(0);
-    assert.strictEqual(address, 'bc1qdjj7lhj9lnjye7xq3dzv3r4z0cta294xy78txn');
-    assert.ok(aezeed.getAllExternalAddresses().includes('bc1qdjj7lhj9lnjye7xq3dzv3r4z0cta294xy78txn'));
+    expect(address).toBe('bc1qdjj7lhj9lnjye7xq3dzv3r4z0cta294xy78txn');
+    expect(aezeed.getAllExternalAddresses().includes('bc1qdjj7lhj9lnjye7xq3dzv3r4z0cta294xy78txn')).toBeTruthy();
 
     const watchOnly = new WatchOnlyWallet();
     watchOnly.setSecret(aezeed.getXpub());
     watchOnly.init();
-    assert.strictEqual(watchOnly._getExternalAddressByIndex(0), aezeed._getExternalAddressByIndex(0));
-    assert.ok(watchOnly.weOwnAddress('bc1qdjj7lhj9lnjye7xq3dzv3r4z0cta294xy78txn'));
-    assert.ok(!watchOnly.weOwnAddress('garbage'));
-    assert.ok(!watchOnly.weOwnAddress(false));
+    expect(watchOnly._getExternalAddressByIndex(0)).toBe(aezeed._getExternalAddressByIndex(0));
+    expect(watchOnly.weOwnAddress('bc1qdjj7lhj9lnjye7xq3dzv3r4z0cta294xy78txn')).toBeTruthy();
+    expect(!watchOnly.weOwnAddress('garbage')).toBeTruthy();
+    expect(!watchOnly.weOwnAddress(false)).toBeTruthy();
   });
 
   it('can sign and verify messages', async () => {
@@ -128,18 +117,18 @@ describe('HDAezeedWallet', () => {
     aezeed.setSecret(
       'abstract rhythm weird food attract treat mosquito sight royal actor surround ride strike remove guilt catch filter summer mushroom protect poverty cruel chaos pattern',
     );
-    assert.ok(await aezeed.validateMnemonicAsync());
-    assert.ok(!(await aezeed.mnemonicInvalidPassword()));
+    expect(await aezeed.validateMnemonicAsync()).toBeTruthy();
+    expect(!(await aezeed.mnemonicInvalidPassword())).toBeTruthy();
     let signature;
 
     // external address
     signature = aezeed.signMessage('vires is numeris', aezeed._getExternalAddressByIndex(0));
-    assert.strictEqual(signature, 'J9zF7mdGGdc/9HMlvor6Zl7ap1qseQpiBDJ4oaSpkzbQGGhdfkM6LHo6m9BV8o/BlqiQI1vuODaNlBFyeyIWgfE=');
-    assert.strictEqual(aezeed.verifyMessage('vires is numeris', aezeed._getExternalAddressByIndex(0), signature), true);
+    expect(signature).toBe('J9zF7mdGGdc/9HMlvor6Zl7ap1qseQpiBDJ4oaSpkzbQGGhdfkM6LHo6m9BV8o/BlqiQI1vuODaNlBFyeyIWgfE=');
+    expect(aezeed.verifyMessage('vires is numeris', aezeed._getExternalAddressByIndex(0), signature)).toBe(true);
 
     // internal address
     signature = aezeed.signMessage('vires is numeris', aezeed._getInternalAddressByIndex(0));
-    assert.strictEqual(signature, 'KIda06aSswmo9NiAYNUBRADA9q1v39raSmHHVg56+thtah5xL7hVw/x+cZgydFNyel2bXfyGluJRaP1uRQfJtzo=');
-    assert.strictEqual(aezeed.verifyMessage('vires is numeris', aezeed._getInternalAddressByIndex(0), signature), true);
+    expect(signature).toBe('KIda06aSswmo9NiAYNUBRADA9q1v39raSmHHVg56+thtah5xL7hVw/x+cZgydFNyel2bXfyGluJRaP1uRQfJtzo=');
+    expect(aezeed.verifyMessage('vires is numeris', aezeed._getInternalAddressByIndex(0), signature)).toBe(true);
   });
 });

--- a/tests/unit/hd-legacy-breadwallet.test.js
+++ b/tests/unit/hd-legacy-breadwallet.test.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { HDLegacyBreadwalletWallet } from '../../class';
 
 it('Legacy HD Breadwallet works', async () => {
@@ -9,33 +8,30 @@ it('Legacy HD Breadwallet works', async () => {
   const hdBread = new HDLegacyBreadwalletWallet();
   hdBread.setSecret(process.env.HD_MNEMONIC_BREAD);
 
-  assert.strictEqual(hdBread.validateMnemonic(), true);
-  assert.strictEqual(hdBread._getExternalAddressByIndex(0), '1M1UphJDb1mpXV3FVEg6b2qqaBieNuaNrt');
-  assert.strictEqual(hdBread._getInternalAddressByIndex(0), '1A9Sc4opR6c7Ui6NazECiGmsmnUPh2WeHJ');
+  expect(hdBread.validateMnemonic()).toBe(true);
+  expect(hdBread._getExternalAddressByIndex(0)).toBe('1M1UphJDb1mpXV3FVEg6b2qqaBieNuaNrt');
+  expect(hdBread._getInternalAddressByIndex(0)).toBe('1A9Sc4opR6c7Ui6NazECiGmsmnUPh2WeHJ');
   hdBread._internal_segwit_index = 2;
   hdBread._external_segwit_index = 2;
-  assert.ok(hdBread._getExternalAddressByIndex(0).startsWith('1'));
-  assert.ok(hdBread._getInternalAddressByIndex(0).startsWith('1'));
-  assert.strictEqual(hdBread._getExternalAddressByIndex(2), 'bc1qh0vtrnjn7zs99j4n6xaadde95ctnnvegh9l2jn');
-  assert.strictEqual(hdBread._getInternalAddressByIndex(2), 'bc1qk9hvkxqsqmps6ex3qawr79rvtg8es4ecjfu5v0');
+  expect(hdBread._getExternalAddressByIndex(0).startsWith('1')).toBeTruthy();
+  expect(hdBread._getInternalAddressByIndex(0).startsWith('1')).toBeTruthy();
+  expect(hdBread._getExternalAddressByIndex(2)).toBe('bc1qh0vtrnjn7zs99j4n6xaadde95ctnnvegh9l2jn');
+  expect(hdBread._getInternalAddressByIndex(2)).toBe('bc1qk9hvkxqsqmps6ex3qawr79rvtg8es4ecjfu5v0');
 
-  assert.strictEqual(hdBread._getDerivationPathByAddress('1M1UphJDb1mpXV3FVEg6b2qqaBieNuaNrt'), "m/0'/0/0");
-  assert.strictEqual(hdBread._getDerivationPathByAddress('bc1qk9hvkxqsqmps6ex3qawr79rvtg8es4ecjfu5v0'), "m/0'/1/2");
+  expect(hdBread._getDerivationPathByAddress('1M1UphJDb1mpXV3FVEg6b2qqaBieNuaNrt')).toBe("m/0'/0/0");
+  expect(hdBread._getDerivationPathByAddress('bc1qk9hvkxqsqmps6ex3qawr79rvtg8es4ecjfu5v0')).toBe("m/0'/1/2");
 
-  assert.strictEqual(
-    hdBread._getPubkeyByAddress(hdBread._getExternalAddressByIndex(0)).toString('hex'),
+  expect(hdBread._getPubkeyByAddress(hdBread._getExternalAddressByIndex(0)).toString('hex')).toBe(
     '029ba027f3f0a9fa69ce680a246198d56a3b047108f26791d1e4aa2d10e7e7a29a',
   );
-  assert.strictEqual(
-    hdBread._getPubkeyByAddress(hdBread._getInternalAddressByIndex(0)).toString('hex'),
+  expect(hdBread._getPubkeyByAddress(hdBread._getInternalAddressByIndex(0)).toString('hex')).toBe(
     '03074225b31a95af63de31267104e07863d892d291a33ef5b2b32d59c772d5c784',
   );
 
-  assert.strictEqual(
-    hdBread.getXpub(),
+  expect(hdBread.getXpub()).toBe(
     'xpub68hPk9CrHimZMBQEja43qWRC2TuXmCDdgZcR5YMebr38XatUEPu2Q2oaBViSMshDcyuMDGkGbTS2aqNHFKdcN1sFWaZgK6SLg84dtN7Ym64',
   );
 
-  assert.ok(hdBread.getAllExternalAddresses().includes('1M1UphJDb1mpXV3FVEg6b2qqaBieNuaNrt'));
-  assert.ok(hdBread.getAllExternalAddresses().includes('bc1qh0vtrnjn7zs99j4n6xaadde95ctnnvegh9l2jn'));
+  expect(hdBread.getAllExternalAddresses().includes('1M1UphJDb1mpXV3FVEg6b2qqaBieNuaNrt')).toBeTruthy();
+  expect(hdBread.getAllExternalAddresses().includes('bc1qh0vtrnjn7zs99j4n6xaadde95ctnnvegh9l2jn')).toBeTruthy();
 });

--- a/tests/unit/hd-legacy-electrum-seed-p2pkh-wallet.test.js
+++ b/tests/unit/hd-legacy-electrum-seed-p2pkh-wallet.test.js
@@ -1,5 +1,4 @@
 import { HDLegacyElectrumSeedP2PKHWallet } from '../../class';
-const assert = require('assert');
 
 describe('HDLegacyElectrumSeedP2PKHWallet', () => {
   it('wont accept BIP39 seed', () => {
@@ -7,48 +6,45 @@ describe('HDLegacyElectrumSeedP2PKHWallet', () => {
     hd.setSecret(
       'honey risk juice trip orient galaxy win situate shoot anchor bounce remind horse traffic exotic since escape mimic ramp skin judge owner topple erode',
     );
-    assert.ok(!hd.validateMnemonic());
+    expect(!hd.validateMnemonic()).toBeTruthy();
   });
 
   it('wont accept electrum seed, but SEGWIT seed', () => {
     const hd = new HDLegacyElectrumSeedP2PKHWallet();
     hd.setSecret('method goddess  humble  crumble output snake essay carpet monster barely trip betray ');
-    assert.ok(!hd.validateMnemonic());
+    expect(!hd.validateMnemonic()).toBeTruthy();
   });
 
   it('can import mnemonics and generate addresses and WIFs', async function () {
     const hd = new HDLegacyElectrumSeedP2PKHWallet();
     hd.setSecret('receive happy  wash prosper update    pet neck acid try profit proud hungry  ');
-    assert.ok(hd.validateMnemonic());
-    assert.strictEqual(
-      hd.getXpub(),
+    expect(hd.validateMnemonic()).toBeTruthy();
+    expect(hd.getXpub()).toBe(
       'xpub661MyMwAqRbcG6vx5SspHUzrhRtPKyeGp41JJLBi3kgeMCFkR6mzGkhEttBHTZg6FYYij52pqD2cW7XsutiZrRukXNLqeo87mZAV5k5bC22',
     );
 
     let address = hd._getExternalAddressByIndex(0);
-    assert.strictEqual(address, '1Ca9ZVshGdKiiMEMNTG1bYqbifYMZMwV8');
-    assert.ok(hd.getAllExternalAddresses().includes('1Ca9ZVshGdKiiMEMNTG1bYqbifYMZMwV8'));
+    expect(address).toBe('1Ca9ZVshGdKiiMEMNTG1bYqbifYMZMwV8');
+    expect(hd.getAllExternalAddresses().includes('1Ca9ZVshGdKiiMEMNTG1bYqbifYMZMwV8')).toBeTruthy();
 
     address = hd._getInternalAddressByIndex(0);
-    assert.strictEqual(address, '1JygAvTQS9haAYgRfPSdHgmXd3syjB8Fnp');
+    expect(address).toBe('1JygAvTQS9haAYgRfPSdHgmXd3syjB8Fnp');
 
     let wif = hd._getExternalWIFByIndex(0);
-    assert.strictEqual(wif, 'KxGPz9dyib26p6bL2vQPvBPHBMA8iHVqEetg3x5XA4Rk1trZ11Kz');
+    expect(wif).toBe('KxGPz9dyib26p6bL2vQPvBPHBMA8iHVqEetg3x5XA4Rk1trZ11Kz');
 
     wif = hd._getInternalWIFByIndex(0);
-    assert.strictEqual(wif, 'L52d26QmYGW8ctHo1omM5fZeJMgaonSkEWCGpnEekNvkVUoqTsNF');
+    expect(wif).toBe('L52d26QmYGW8ctHo1omM5fZeJMgaonSkEWCGpnEekNvkVUoqTsNF');
 
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex'),
+    expect(hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex')).toBe(
       '02a6e6b674f82796cb4776673d824bf0673364fab24e62dcbfff4c1a5b69e3519b',
     );
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex'),
+    expect(hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex')).toBe(
       '0344708260d2a832fd430285a0b915859d73e6ed4c6c6a9cb73e9069a9de56fb23',
     );
 
     hd.setSecret('bs');
-    assert.ok(!hd.validateMnemonic());
+    expect(!hd.validateMnemonic()).toBeTruthy();
   });
 
   it('can use mnemonic with passphrase', () => {
@@ -58,13 +54,12 @@ describe('HDLegacyElectrumSeedP2PKHWallet', () => {
     hd.setSecret(mnemonic);
     hd.setPassphrase(passphrase);
 
-    assert.strictEqual(
-      hd.getXpub(),
+    expect(hd.getXpub()).toBe(
       'xpub661MyMwAqRbcGSUBZaVtq8qEoRkJM1TZNNvUJEgQvtiZE73gS1wKWQoTj6R2E46UDYS2SBpmGGrSHGsJUNxtr1krixFuq8JA772pG43Mo6R',
     );
 
-    assert.strictEqual(hd._getExternalAddressByIndex(0), '13sPvsrgRN8XibZNHtZXNqVDJPnNZLjTap');
-    assert.strictEqual(hd._getInternalAddressByIndex(0), '16oEuy5H7ejmapqc2AtKAYerdfkDkoyrDX');
-    assert.strictEqual(hd._getExternalWIFByIndex(0), 'Ky9WTDUTTZUKKYSPEE6uah2y5sJa89z6177kD23xh5cq1znX2HDj');
+    expect(hd._getExternalAddressByIndex(0)).toBe('13sPvsrgRN8XibZNHtZXNqVDJPnNZLjTap');
+    expect(hd._getInternalAddressByIndex(0)).toBe('16oEuy5H7ejmapqc2AtKAYerdfkDkoyrDX');
+    expect(hd._getExternalWIFByIndex(0)).toBe('Ky9WTDUTTZUKKYSPEE6uah2y5sJa89z6177kD23xh5cq1znX2HDj');
   });
 });

--- a/tests/unit/hd-legacy-wallet.test.js
+++ b/tests/unit/hd-legacy-wallet.test.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import * as bitcoin from 'bitcoinjs-lib';
 
 import { HDLegacyP2PKHWallet } from '../../class';
@@ -11,33 +10,30 @@ describe('Legacy HD (BIP44)', () => {
     }
     const hd = new HDLegacyP2PKHWallet();
     hd.setSecret(process.env.HD_MNEMONIC);
-    assert.ok(hd.validateMnemonic());
+    expect(hd.validateMnemonic()).toBeTruthy();
 
-    assert.strictEqual(
-      hd.getXpub(),
+    expect(hd.getXpub()).toBe(
       'xpub6ByZUAv558PPheJgcPYHpxPLwz8M7TtueYMAik84NADeQcvbzS8W3WxxJ3C9NzfYkMoChiMAumWbeEvMWhTVpH75NqGv5c9wF3wKDbfQShb',
     );
 
-    assert.strictEqual(hd._getExternalAddressByIndex(0), '186FBQmCV5W1xY7ywaWtTZPAQNciVN8Por');
-    assert.strictEqual(hd._getInternalAddressByIndex(0), '1J9zoJz5LsAJ361SQHYnLTWg46Tc2AXUCj');
+    expect(hd._getExternalAddressByIndex(0)).toBe('186FBQmCV5W1xY7ywaWtTZPAQNciVN8Por');
+    expect(hd._getInternalAddressByIndex(0)).toBe('1J9zoJz5LsAJ361SQHYnLTWg46Tc2AXUCj');
 
-    assert.strictEqual(hd._getInternalWIFByIndex(0), 'L4ojevRtK81A8Kof3qyLS2M7HvsVDbUDENNhJqU4vf79w9yGnQLb');
-    assert.strictEqual(hd._getExternalWIFByIndex(0), 'Kz6kLhdyDfSbKuVH25XVqBRztjmFe8X22Xe1hnFzEv79gJNMkTAH');
+    expect(hd._getInternalWIFByIndex(0)).toBe('L4ojevRtK81A8Kof3qyLS2M7HvsVDbUDENNhJqU4vf79w9yGnQLb');
+    expect(hd._getExternalWIFByIndex(0)).toBe('Kz6kLhdyDfSbKuVH25XVqBRztjmFe8X22Xe1hnFzEv79gJNMkTAH');
 
-    assert.ok(hd.getAllExternalAddresses().includes('186FBQmCV5W1xY7ywaWtTZPAQNciVN8Por'));
-    assert.ok(!hd.getAllExternalAddresses().includes('1J9zoJz5LsAJ361SQHYnLTWg46Tc2AXUCj')); // not internal
+    expect(hd.getAllExternalAddresses().includes('186FBQmCV5W1xY7ywaWtTZPAQNciVN8Por')).toBeTruthy();
+    expect(!hd.getAllExternalAddresses().includes('1J9zoJz5LsAJ361SQHYnLTWg46Tc2AXUCj')).toBeTruthy(); // not internal
 
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex'),
+    expect(hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex')).toBe(
       '0316e84a2556f30a199541633f5dda6787710ccab26771b7084f4c9e1104f47667',
     );
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex'),
+    expect(hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex')).toBe(
       '02ad7b2216f3a2b38d56db8a7ee5c540fd12c4bbb7013106eff78cc2ace65aa002',
     );
 
-    assert.strictEqual(hd._getDerivationPathByAddress(hd._getExternalAddressByIndex(0)), "m/44'/0'/0'/0/0");
-    assert.strictEqual(hd._getDerivationPathByAddress(hd._getInternalAddressByIndex(0)), "m/44'/0'/0'/1/0");
+    expect(hd._getDerivationPathByAddress(hd._getExternalAddressByIndex(0))).toBe("m/44'/0'/0'/0/0");
+    expect(hd._getDerivationPathByAddress(hd._getInternalAddressByIndex(0))).toBe("m/44'/0'/0'/1/0");
   });
 
   it('can create TX', async () => {
@@ -47,7 +43,7 @@ describe('Legacy HD (BIP44)', () => {
     }
     const hd = new HDLegacyP2PKHWallet();
     hd.setSecret(process.env.HD_MNEMONIC);
-    assert.ok(hd.validateMnemonic());
+    expect(hd.validateMnemonic()).toBeTruthy();
 
     const utxo = [
       {
@@ -111,14 +107,14 @@ describe('Legacy HD (BIP44)', () => {
       hd._getInternalAddressByIndex(hd.next_free_change_address_index),
     );
     let tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-    assert.strictEqual(tx.ins.length, 3);
-    assert.strictEqual(tx.outs.length, 2);
-    assert.strictEqual(tx.outs[0].value, 80000); // payee
-    assert.strictEqual(tx.outs[1].value, 9478); // change
+    expect(tx.ins.length).toBe(3);
+    expect(tx.outs.length).toBe(2);
+    expect(tx.outs[0].value).toBe(80000); // payee
+    expect(tx.outs[1].value).toBe(9478); // change
     let toAddress = bitcoin.address.fromOutputScript(tx.outs[0].script);
     const changeAddress = bitcoin.address.fromOutputScript(tx.outs[1].script);
-    assert.strictEqual('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', toAddress);
-    assert.strictEqual(hd._getInternalAddressByIndex(hd.next_free_change_address_index), changeAddress);
+    expect('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK').toBe(toAddress);
+    expect(hd._getInternalAddressByIndex(hd.next_free_change_address_index)).toBe(changeAddress);
 
     // testing sendMax
     txNew = hd.createTransaction(
@@ -128,10 +124,10 @@ describe('Legacy HD (BIP44)', () => {
       hd._getInternalAddressByIndex(hd.next_free_change_address_index),
     );
     tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-    assert.strictEqual(tx.ins.length, 4);
-    assert.strictEqual(tx.outs.length, 1);
+    expect(tx.ins.length).toBe(4);
+    expect(tx.outs.length).toBe(1);
     toAddress = bitcoin.address.fromOutputScript(tx.outs[0].script);
-    assert.strictEqual('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', toAddress);
+    expect('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK').toBe(toAddress);
   });
 
   it('can sign and verify messages', async () => {
@@ -142,20 +138,20 @@ describe('Legacy HD (BIP44)', () => {
 
     // external address
     signature = hd.signMessage('vires is numeris', hd._getExternalAddressByIndex(0));
-    assert.strictEqual(signature, 'H5J8DbqvuBy8lqRW7+LTVrrtrsaqLSwRDyj+5XtCrZpdCgPlxKM4EKRD6qvdKeyEh1fiSfIVB/edPAum3gKcJZo=');
-    assert.strictEqual(hd.verifyMessage('vires is numeris', hd._getExternalAddressByIndex(0), signature), true);
+    expect(signature).toBe('H5J8DbqvuBy8lqRW7+LTVrrtrsaqLSwRDyj+5XtCrZpdCgPlxKM4EKRD6qvdKeyEh1fiSfIVB/edPAum3gKcJZo=');
+    expect(hd.verifyMessage('vires is numeris', hd._getExternalAddressByIndex(0), signature)).toBe(true);
 
     // internal address
     signature = hd.signMessage('vires is numeris', hd._getInternalAddressByIndex(0));
-    assert.strictEqual(signature, 'H98hmvtyPFUbR6E5Tcsqmc+eSjlYhP2vy41Y6IyHS9DVKEI5n8VEMpIEDtvlMARVce96nOqbRHXo9nD05WXH/Eo=');
-    assert.strictEqual(hd.verifyMessage('vires is numeris', hd._getInternalAddressByIndex(0), signature), true);
+    expect(signature).toBe('H98hmvtyPFUbR6E5Tcsqmc+eSjlYhP2vy41Y6IyHS9DVKEI5n8VEMpIEDtvlMARVce96nOqbRHXo9nD05WXH/Eo=');
+    expect(hd.verifyMessage('vires is numeris', hd._getInternalAddressByIndex(0), signature)).toBe(true);
   });
 
   it('can show fingerprint', async () => {
     const mnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
     const hd = new HDLegacyP2PKHWallet();
     hd.setSecret(mnemonic);
-    assert.strictEqual(hd.getMasterFingerprintHex(), '73C5DA0A');
+    expect(hd.getMasterFingerprintHex()).toBe('73C5DA0A');
   });
 
   // from electrum tests https://github.com/spesmilo/electrum/blob/9c1a51547a301e765b9b0f9935c6d940bb9d658e/electrum/tests/test_wallet_vertical.py#L292
@@ -166,13 +162,12 @@ describe('Legacy HD (BIP44)', () => {
     hd.setSecret(mnemonic);
     hd.setPassphrase(UNICODE_HORROR);
 
-    assert.strictEqual(
-      hd.getXpub(),
+    expect(hd.getXpub()).toBe(
       'xpub6D85QDBajeLe2JXJrZeGyQCaw47PWKi3J9DPuHakjTkVBWCxVQQkmMVMSSfnw39tj9FntbozpRtb1AJ8ubjeVSBhyK4M5mzdvsXZzKPwodT',
     );
 
-    assert.strictEqual(hd._getExternalAddressByIndex(0), '1F88g2naBMhDB7pYFttPWGQgryba3hPevM');
-    assert.strictEqual(hd._getInternalAddressByIndex(0), '1H4QD1rg2zQJ4UjuAVJr5eW1fEM8WMqyxh');
-    assert.strictEqual(hd._getExternalWIFByIndex(0), 'L3HLzdVcwo4711gFiZG4fiLzLVNJpR6nejfo6J85wuYn9YF2G5zk');
+    expect(hd._getExternalAddressByIndex(0)).toBe('1F88g2naBMhDB7pYFttPWGQgryba3hPevM');
+    expect(hd._getInternalAddressByIndex(0)).toBe('1H4QD1rg2zQJ4UjuAVJr5eW1fEM8WMqyxh');
+    expect(hd._getExternalWIFByIndex(0)).toBe('L3HLzdVcwo4711gFiZG4fiLzLVNJpR6nejfo6J85wuYn9YF2G5zk');
   });
 });

--- a/tests/unit/hd-segwit-bech32-wallet.test.js
+++ b/tests/unit/hd-segwit-bech32-wallet.test.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { HDSegwitBech32Wallet } from '../../class';
 
 describe('Bech32 Segwit HD (BIP84)', () => {
@@ -7,58 +6,55 @@ describe('Bech32 Segwit HD (BIP84)', () => {
     const hd = new HDSegwitBech32Wallet();
     hd.setSecret(mnemonic);
 
-    assert.strictEqual(true, hd.validateMnemonic());
-    assert.strictEqual(
-      'zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs',
+    expect(true).toBe(hd.validateMnemonic());
+    expect('zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs').toBe(
       hd.getXpub(),
     );
 
-    assert.strictEqual(hd._getExternalWIFByIndex(0), 'KyZpNDKnfs94vbrwhJneDi77V6jF64PWPF8x5cdJb8ifgg2DUc9d');
-    assert.strictEqual(hd._getExternalWIFByIndex(1), 'Kxpf5b8p3qX56DKEe5NqWbNUP9MnqoRFzZwHRtsFqhzuvUJsYZCy');
-    assert.strictEqual(hd._getInternalWIFByIndex(0), 'KxuoxufJL5csa1Wieb2kp29VNdn92Us8CoaUG3aGtPtcF3AzeXvF');
-    assert.ok(hd._getInternalWIFByIndex(0) !== hd._getInternalWIFByIndex(1));
+    expect(hd._getExternalWIFByIndex(0)).toBe('KyZpNDKnfs94vbrwhJneDi77V6jF64PWPF8x5cdJb8ifgg2DUc9d');
+    expect(hd._getExternalWIFByIndex(1)).toBe('Kxpf5b8p3qX56DKEe5NqWbNUP9MnqoRFzZwHRtsFqhzuvUJsYZCy');
+    expect(hd._getInternalWIFByIndex(0)).toBe('KxuoxufJL5csa1Wieb2kp29VNdn92Us8CoaUG3aGtPtcF3AzeXvF');
+    expect(hd._getInternalWIFByIndex(0) !== hd._getInternalWIFByIndex(1)).toBeTruthy();
 
-    assert.strictEqual(hd._getExternalAddressByIndex(0), 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu');
-    assert.strictEqual(hd._getExternalAddressByIndex(1), 'bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g');
-    assert.strictEqual(hd._getInternalAddressByIndex(0), 'bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el');
-    assert.ok(hd._getInternalAddressByIndex(0) !== hd._getInternalAddressByIndex(1));
+    expect(hd._getExternalAddressByIndex(0)).toBe('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu');
+    expect(hd._getExternalAddressByIndex(1)).toBe('bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g');
+    expect(hd._getInternalAddressByIndex(0)).toBe('bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el');
+    expect(hd._getInternalAddressByIndex(0) !== hd._getInternalAddressByIndex(1)).toBeTruthy();
 
-    assert.ok(hd.getAllExternalAddresses().includes('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu'));
-    assert.ok(hd.getAllExternalAddresses().includes('bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g'));
-    assert.ok(!hd.getAllExternalAddresses().includes('bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el')); // not internal
+    expect(hd.getAllExternalAddresses().includes('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu')).toBeTruthy();
+    expect(hd.getAllExternalAddresses().includes('bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g')).toBeTruthy();
+    expect(!hd.getAllExternalAddresses().includes('bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el')).toBeTruthy(); // not internal
 
-    assert.ok(hd.addressIsChange('bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el'));
-    assert.ok(!hd.addressIsChange('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu'));
+    expect(hd.addressIsChange('bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el')).toBeTruthy();
+    expect(!hd.addressIsChange('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu')).toBeTruthy();
 
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex'),
+    expect(hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex')).toBe(
       '0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c',
     );
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex'),
+    expect(hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex')).toBe(
       '03025324888e429ab8e3dbaf1f7802648b9cd01e9b418485c5fa4c1b9b5700e1a6',
     );
 
-    assert.strictEqual(hd._getDerivationPathByAddress(hd._getExternalAddressByIndex(0)), "m/84'/0'/0'/0/0");
-    assert.strictEqual(hd._getDerivationPathByAddress(hd._getExternalAddressByIndex(1)), "m/84'/0'/0'/0/1");
-    assert.strictEqual(hd._getDerivationPathByAddress(hd._getInternalAddressByIndex(0)), "m/84'/0'/0'/1/0");
-    assert.strictEqual(hd._getDerivationPathByAddress(hd._getInternalAddressByIndex(1)), "m/84'/0'/0'/1/1");
+    expect(hd._getDerivationPathByAddress(hd._getExternalAddressByIndex(0))).toBe("m/84'/0'/0'/0/0");
+    expect(hd._getDerivationPathByAddress(hd._getExternalAddressByIndex(1))).toBe("m/84'/0'/0'/0/1");
+    expect(hd._getDerivationPathByAddress(hd._getInternalAddressByIndex(0))).toBe("m/84'/0'/0'/1/0");
+    expect(hd._getDerivationPathByAddress(hd._getInternalAddressByIndex(1))).toBe("m/84'/0'/0'/1/1");
 
-    assert.strictEqual(hd.getMasterFingerprintHex(), '73C5DA0A');
+    expect(hd.getMasterFingerprintHex()).toBe('73C5DA0A');
   });
 
   it('can generate addresses only via zpub', function () {
     const zpub = 'zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs';
     const hd = new HDSegwitBech32Wallet();
     hd._xpub = zpub;
-    assert.strictEqual(hd._getExternalAddressByIndex(0), 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu');
-    assert.strictEqual(hd._getExternalAddressByIndex(1), 'bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g');
-    assert.strictEqual(hd._getInternalAddressByIndex(0), 'bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el');
-    assert.ok(hd._getInternalAddressByIndex(0) !== hd._getInternalAddressByIndex(1));
+    expect(hd._getExternalAddressByIndex(0)).toBe('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu');
+    expect(hd._getExternalAddressByIndex(1)).toBe('bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g');
+    expect(hd._getInternalAddressByIndex(0)).toBe('bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el');
+    expect(hd._getInternalAddressByIndex(0) !== hd._getInternalAddressByIndex(1)).toBeTruthy();
 
-    assert.ok(hd.getAllExternalAddresses().includes('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu'));
-    assert.ok(hd.getAllExternalAddresses().includes('bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g'));
-    assert.ok(!hd.getAllExternalAddresses().includes('bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el')); // not internal
+    expect(hd.getAllExternalAddresses().includes('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu')).toBeTruthy();
+    expect(hd.getAllExternalAddresses().includes('bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g')).toBeTruthy();
+    expect(!hd.getAllExternalAddresses().includes('bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el')).toBeTruthy(); // not internal
   });
 
   it('can generate', async () => {
@@ -67,17 +63,17 @@ describe('Bech32 Segwit HD (BIP84)', () => {
     for (let c = 0; c < 1000; c++) {
       await hd.generate();
       const secret = hd.getSecret();
-      assert.strictEqual(secret.split(' ').length, 12);
+      expect(secret.split(' ').length).toBe(12);
       if (hashmap[secret]) {
         throw new Error('Duplicate secret generated!');
       }
       hashmap[secret] = 1;
-      assert.ok(secret.split(' ').length === 12 || secret.split(' ').length === 24);
+      expect(secret.split(' ').length === 12 || secret.split(' ').length === 24).toBeTruthy();
     }
 
     const hd2 = new HDSegwitBech32Wallet();
     hd2.setSecret(hd.getSecret());
-    assert.ok(hd2.validateMnemonic());
+    expect(hd2.validateMnemonic()).toBeTruthy();
   });
 
   it('can coin control', async () => {
@@ -89,22 +85,22 @@ describe('Bech32 Segwit HD (BIP84)', () => {
       { txid: '22222', vout: 0, value: 22222 },
     ];
 
-    assert.ok(hd.getUtxo().length === 2);
+    expect(hd.getUtxo().length === 2).toBeTruthy();
 
     // freeze one UTXO and set a memo on it
     hd.setUTXOMetadata('11111', 0, { memo: 'somememo', frozen: true });
-    assert.strictEqual(hd.getUTXOMetadata('11111', 0).memo, 'somememo');
-    assert.strictEqual(hd.getUTXOMetadata('11111', 0).frozen, true);
+    expect(hd.getUTXOMetadata('11111', 0).memo).toBe('somememo');
+    expect(hd.getUTXOMetadata('11111', 0).frozen).toBe(true);
 
     // now .getUtxo() should return a limited UTXO set
-    assert.ok(hd.getUtxo().length === 1);
-    assert.strictEqual(hd.getUtxo()[0].txid, '22222');
+    expect(hd.getUtxo().length === 1).toBeTruthy();
+    expect(hd.getUtxo()[0].txid).toBe('22222');
 
     // now .getUtxo(true) should return a full UTXO set
-    assert.ok(hd.getUtxo(true).length === 2);
+    expect(hd.getUtxo(true).length === 2).toBeTruthy();
 
     // for UTXO with no metadata .getUTXOMetadata() should return an empty object
-    assert.ok(Object.keys(hd.getUTXOMetadata('22222', 0)).length === 0);
+    expect(Object.keys(hd.getUTXOMetadata('22222', 0)).length === 0).toBeTruthy();
   });
 
   it('can sign and verify messages', async () => {
@@ -115,53 +111,50 @@ describe('Bech32 Segwit HD (BIP84)', () => {
 
     // external address
     signature = hd.signMessage('vires is numeris', hd._getExternalAddressByIndex(0));
-    assert.strictEqual(signature, 'KGW4FfrptS9zV3UptUWxbEf65GhC2mCUz86G0GpN/H4MUC29Y5TsRhWGIqG2lettEpZXZETuc2yL+O7/UvDhxhM=');
-    assert.strictEqual(hd.verifyMessage('vires is numeris', hd._getExternalAddressByIndex(0), signature), true);
+    expect(signature).toBe('KGW4FfrptS9zV3UptUWxbEf65GhC2mCUz86G0GpN/H4MUC29Y5TsRhWGIqG2lettEpZXZETuc2yL+O7/UvDhxhM=');
+    expect(hd.verifyMessage('vires is numeris', hd._getExternalAddressByIndex(0), signature)).toBe(true);
 
     // internal address
     signature = hd.signMessage('vires is numeris', hd._getInternalAddressByIndex(0));
-    assert.strictEqual(signature, 'KJ5B9JkZ042FhtGeObU/MxLCzQWHbrpXNQxhfJj9wMboa/icLIIaAlsKaSkS27fZLvX3WH0qyj3aAaXscnWsfSw=');
-    assert.strictEqual(hd.verifyMessage('vires is numeris', hd._getInternalAddressByIndex(0), signature), true);
+    expect(signature).toBe('KJ5B9JkZ042FhtGeObU/MxLCzQWHbrpXNQxhfJj9wMboa/icLIIaAlsKaSkS27fZLvX3WH0qyj3aAaXscnWsfSw=');
+    expect(hd.verifyMessage('vires is numeris', hd._getInternalAddressByIndex(0), signature)).toBe(true);
 
     // multiline message
     signature = hd.signMessage('vires\nis\nnumeris', hd._getExternalAddressByIndex(0));
-    assert.strictEqual(signature, 'KFI22tlJVGq2HGQM5rcBtYu+Jq8oc7QyjSBP1ZQup3a/GEw1Khu2qFbL/iLzqw95wN22a/Tll1oMLdWxg9cWMYM=');
-    assert.strictEqual(hd.verifyMessage('vires\nis\nnumeris', hd._getExternalAddressByIndex(0), signature), true);
+    expect(signature).toBe('KFI22tlJVGq2HGQM5rcBtYu+Jq8oc7QyjSBP1ZQup3a/GEw1Khu2qFbL/iLzqw95wN22a/Tll1oMLdWxg9cWMYM=');
+    expect(hd.verifyMessage('vires\nis\nnumeris', hd._getExternalAddressByIndex(0), signature)).toBe(true);
 
     // can't sign if address doesn't belong to wallet
-    assert.throws(() => hd.signMessage('vires is numeris', '186FBQmCV5W1xY7ywaWtTZPAQNciVN8Por'));
+    expect(() => hd.signMessage('vires is numeris', '186FBQmCV5W1xY7ywaWtTZPAQNciVN8Por')).toThrow();
 
     // can't verify wrong signature
-    assert.throws(() => hd.verifyMessage('vires is numeris', hd._getInternalAddressByIndex(0), 'wrong signature'));
+    expect(() => hd.verifyMessage('vires is numeris', hd._getInternalAddressByIndex(0), 'wrong signature')).toThrow();
 
     // can verify electrum message signature
     // bech32 segwit (p2wpkh)
-    assert.strictEqual(
+    expect(
       hd.verifyMessage(
         'vires is numeris',
         'bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el',
         'Hya6IaZGbKF83eOmC5i1CX5V42Wqkf+eSMi8S+hvJuJrDmp5F56ivrHgAzcxNIShIpY2lJv76M2LB6zLV70KxWQ=',
       ),
-      true,
-    );
+    ).toBe(true);
     // p2sh-segwit (p2wpkh-p2sh)
-    assert.strictEqual(
+    expect(
       hd.verifyMessage(
         'vires is numeris',
         '37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf',
         'IBm8XAd/NdWjjUBXr3pkXdVk1XQBHKPkBy4DCmSG0Ox4IKOLb1O+V7cTXPQ2vm3rcYquF+6iKSPJDiE1TPrAswY=',
       ),
-      true,
-    );
+    ).toBe(true);
     // legacy
-    assert.strictEqual(
+    expect(
       hd.verifyMessage(
         'vires is numeris',
         '1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA',
         'IDNPawFev2E+W1xhHYi6NKuj7BY2Xe9qvXfddoWL4XZcPridoizzm8pda6jGEIwHlVYe4zrGhYqUR+j2hOsQxD8=',
       ),
-      true,
-    );
+    ).toBe(true);
   });
 
   it('can use mnemonic with passphrase', () => {
@@ -171,13 +164,12 @@ describe('Bech32 Segwit HD (BIP84)', () => {
     hd.setSecret(mnemonic);
     hd.setPassphrase(passphrase);
 
-    assert.strictEqual(
-      hd.getXpub(),
+    expect(hd.getXpub()).toBe(
       'zpub6qNvUL1qNQwaReccveprgd4urE2EUvShpcFe7WB9tzf9L4NJNcWhPzJSk4fzNXqBNZdRr6135hBKaqqp5RVvyxZ6eMbZXL6u5iK4zrfkCaQ',
     );
 
-    assert.strictEqual(hd._getExternalAddressByIndex(0), 'bc1qgaj3satczjem43pz46ct6r3758twhnny4y720z');
-    assert.strictEqual(hd._getInternalAddressByIndex(0), 'bc1qthe7wh5eplzxczslvthyrer36ph3kxpnfnxgjg');
-    assert.strictEqual(hd._getExternalWIFByIndex(0), 'L1tfV6fbRjDNwGQdJqHC9fneM9bTHigApnWgoKoU8JwgziwbbE7i');
+    expect(hd._getExternalAddressByIndex(0)).toBe('bc1qgaj3satczjem43pz46ct6r3758twhnny4y720z');
+    expect(hd._getInternalAddressByIndex(0)).toBe('bc1qthe7wh5eplzxczslvthyrer36ph3kxpnfnxgjg');
+    expect(hd._getExternalWIFByIndex(0)).toBe('L1tfV6fbRjDNwGQdJqHC9fneM9bTHigApnWgoKoU8JwgziwbbE7i');
   });
 });

--- a/tests/unit/hd-segwit-electrum-seed-p2wpkh-wallet.test.js
+++ b/tests/unit/hd-segwit-electrum-seed-p2wpkh-wallet.test.js
@@ -1,52 +1,48 @@
 import { HDSegwitElectrumSeedP2WPKHWallet } from '../../class';
-const assert = require('assert');
 
 describe('HDSegwitElectrumSeedP2WPKHWallet', () => {
   it('wont accept BIP39 seed', () => {
     const hd = new HDSegwitElectrumSeedP2WPKHWallet();
     hd.setSecret('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about');
-    assert.ok(!hd.validateMnemonic());
+    expect(!hd.validateMnemonic()).toBeTruthy();
   });
 
   it('wont accept electrum seed, but STANDARD p2pkh seed', () => {
     const hd = new HDSegwitElectrumSeedP2WPKHWallet();
     hd.setSecret('receive happy  wash prosper update    pet neck acid try profit proud hungry  ');
-    assert.ok(!hd.validateMnemonic());
+    expect(!hd.validateMnemonic()).toBeTruthy();
   });
 
   it('can import mnemonics and generate addresses and WIFs', async function () {
     const hd = new HDSegwitElectrumSeedP2WPKHWallet();
     hd.setSecret('method goddess  humble  crumble output snake essay carpet monster barely trip betray ');
-    assert.ok(hd.validateMnemonic());
-    assert.strictEqual(
-      hd.getXpub(),
+    expect(hd.validateMnemonic()).toBeTruthy();
+    expect(hd.getXpub()).toBe(
       'zpub6n6X5F7QEogTDXchPXXhrvDQ38D5JTFNFWhFrFyri3Sazo4x225nENMeN1kKs1cYbeZDtuDUXhDQepUkxjnAi67z2PJ4d33qo8Cu3HLw74c',
     );
 
     let address = hd._getExternalAddressByIndex(0);
-    assert.strictEqual(address, 'bc1q2yv6rhtw9ycqeq2rkch65sucf66ytwsd3csawr');
-    assert.ok(hd.getAllExternalAddresses().includes('bc1q2yv6rhtw9ycqeq2rkch65sucf66ytwsd3csawr'));
+    expect(address).toBe('bc1q2yv6rhtw9ycqeq2rkch65sucf66ytwsd3csawr');
+    expect(hd.getAllExternalAddresses().includes('bc1q2yv6rhtw9ycqeq2rkch65sucf66ytwsd3csawr')).toBeTruthy();
 
     address = hd._getInternalAddressByIndex(0);
-    assert.strictEqual(address, 'bc1qvdu80q26ghe66zq8tf5y09qr29vay4cg65mvuk');
+    expect(address).toBe('bc1qvdu80q26ghe66zq8tf5y09qr29vay4cg65mvuk');
 
     let wif = hd._getExternalWIFByIndex(0);
-    assert.strictEqual(wif, 'L5a1N5JQzT9wDUmVS9hb2mrd1SMkwPfrWYS8C3Kngp7kiuBkpY2V');
+    expect(wif).toBe('L5a1N5JQzT9wDUmVS9hb2mrd1SMkwPfrWYS8C3Kngp7kiuBkpY2V');
 
     wif = hd._getInternalWIFByIndex(0);
-    assert.strictEqual(wif, 'KwsLfaB2y9QZRd5cxY3uM3L4r2fE7ZPzocwjkPbp1cSFMFfE9tBq');
+    expect(wif).toBe('KwsLfaB2y9QZRd5cxY3uM3L4r2fE7ZPzocwjkPbp1cSFMFfE9tBq');
 
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex'),
+    expect(hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex')).toBe(
       '023cb68c37a1ca627c414e63dfb23706091eafb50e50d7de4e2a1a56d7085d42e6',
     );
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex'),
+    expect(hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex')).toBe(
       '02e7e6a8dc1fe62f7de88a7de3c5030f36ec6aec28c610bc1d573435fab18b9f94',
     );
 
     hd.setSecret('bs');
-    assert.ok(!hd.validateMnemonic());
+    expect(!hd.validateMnemonic()).toBeTruthy();
   });
 
   // from electrum tests https://github.com/spesmilo/electrum/blob/9c1a51547a301e765b9b0f9935c6d940bb9d658e/electrum/tests/test_wallet_vertical.py#L130
@@ -57,13 +53,12 @@ describe('HDSegwitElectrumSeedP2WPKHWallet', () => {
     hd.setSecret(mnemonic);
     hd.setPassphrase(UNICODE_HORROR);
 
-    assert.strictEqual(
-      hd.getXpub(),
+    expect(hd.getXpub()).toBe(
       'zpub6nD7dvF6ArArjskKHZLmEL9ky8FqaSti1LN5maDWGwFrqwwGTp1b6ic4EHwciFNaYDmCXcQYxXSiF9BjcLCMPcaYkVN2nQD6QjYQ8vpSR3Z',
     );
 
-    assert.strictEqual(hd._getExternalAddressByIndex(0), 'bc1qx94dutas7ysn2my645cyttujrms5d9p57f6aam');
-    assert.strictEqual(hd._getInternalAddressByIndex(0), 'bc1qcywwsy87sdp8vz5rfjh3sxdv6rt95kujdqq38g');
-    assert.strictEqual(hd._getExternalWIFByIndex(0), 'KyBagP6JHrNTGanqBSDVzKrsBTVbD9hhkTeVe1zEhewKeCU6wJb7');
+    expect(hd._getExternalAddressByIndex(0)).toBe('bc1qx94dutas7ysn2my645cyttujrms5d9p57f6aam');
+    expect(hd._getInternalAddressByIndex(0)).toBe('bc1qcywwsy87sdp8vz5rfjh3sxdv6rt95kujdqq38g');
+    expect(hd._getExternalWIFByIndex(0)).toBe('KyBagP6JHrNTGanqBSDVzKrsBTVbD9hhkTeVe1zEhewKeCU6wJb7');
   });
 });

--- a/tests/unit/hd-segwit-p2sh-wallet.test.js
+++ b/tests/unit/hd-segwit-p2sh-wallet.test.js
@@ -1,5 +1,3 @@
-import assert from 'assert';
-
 import { SegwitP2SHWallet, SegwitBech32Wallet, HDSegwitP2SHWallet, HDLegacyP2PKHWallet, LegacyWallet } from '../../class';
 
 describe('P2SH Segwit HD (BIP49)', () => {
@@ -8,80 +6,77 @@ describe('P2SH Segwit HD (BIP49)', () => {
       'honey risk juice trip orient galaxy win situate shoot anchor bounce remind horse traffic exotic since escape mimic ramp skin judge owner topple erode';
     const hd = new HDSegwitP2SHWallet();
     hd.setSecret(mnemonic);
-    assert.strictEqual('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', hd._getExternalAddressByIndex(0));
-    assert.strictEqual('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3', hd._getExternalAddressByIndex(1));
-    assert.strictEqual('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei', hd._getInternalAddressByIndex(0));
-    assert.ok(hd.getAllExternalAddresses().includes('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK'));
-    assert.ok(hd.getAllExternalAddresses().includes('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3'));
-    assert.ok(!hd.getAllExternalAddresses().includes('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei')); // not internal
-    assert.strictEqual(true, hd.validateMnemonic());
+    expect('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK').toBe(hd._getExternalAddressByIndex(0));
+    expect('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3').toBe(hd._getExternalAddressByIndex(1));
+    expect('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei').toBe(hd._getInternalAddressByIndex(0));
+    expect(hd.getAllExternalAddresses().includes('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK')).toBeTruthy();
+    expect(hd.getAllExternalAddresses().includes('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3')).toBeTruthy();
+    expect(!hd.getAllExternalAddresses().includes('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei')).toBeTruthy(); // not internal
+    expect(true).toBe(hd.validateMnemonic());
 
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex'),
+    expect(hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex')).toBe(
       '0348192db90b753484601aaf1e6220644ffe37d83a9a5feff32b4da43739f736be',
     );
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex'),
+    expect(hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex')).toBe(
       '03c107e6976d59e17490513fbed3fb321736b7231d24f3d09306c72714acf1859d',
     );
 
-    assert.strictEqual(hd._getDerivationPathByAddress(hd._getExternalAddressByIndex(0)), "m/49'/0'/0'/0/0");
-    assert.strictEqual(hd._getDerivationPathByAddress(hd._getInternalAddressByIndex(0)), "m/49'/0'/0'/1/0");
+    expect(hd._getDerivationPathByAddress(hd._getExternalAddressByIndex(0))).toBe("m/49'/0'/0'/0/0");
+    expect(hd._getDerivationPathByAddress(hd._getInternalAddressByIndex(0))).toBe("m/49'/0'/0'/1/0");
 
-    assert.strictEqual('L4MqtwJm6hkbACLG4ho5DF8GhcXdLEbbvpJnbzA9abfD6RDpbr2m', hd._getExternalWIFByIndex(0));
-    assert.strictEqual(
-      'ypub6WhHmKBmHNjcrUVNCa3sXduH9yxutMipDcwiKW31vWjcMbfhQHjXdyx4rqXbEtVgzdbhFJ5mZJWmfWwnP4Vjzx97admTUYKQt6b9D7jjSCp',
+    expect('L4MqtwJm6hkbACLG4ho5DF8GhcXdLEbbvpJnbzA9abfD6RDpbr2m').toBe(hd._getExternalWIFByIndex(0));
+    expect('ypub6WhHmKBmHNjcrUVNCa3sXduH9yxutMipDcwiKW31vWjcMbfhQHjXdyx4rqXbEtVgzdbhFJ5mZJWmfWwnP4Vjzx97admTUYKQt6b9D7jjSCp').toBe(
       hd.getXpub(),
     );
   });
 
   it('can convert witness to address', () => {
     let address = SegwitP2SHWallet.witnessToAddress('035c618df829af694cb99e664ce1b34f80ad2c3b49bcd0d9c0b1836c66b2d25fd8');
-    assert.strictEqual(address, '34ZVGb3gT8xMLT6fpqC6dNVqJtJmvdjbD7');
+    expect(address).toBe('34ZVGb3gT8xMLT6fpqC6dNVqJtJmvdjbD7');
     address = SegwitP2SHWallet.witnessToAddress();
-    assert.strictEqual(address, false);
+    expect(address).toBe(false);
     address = SegwitP2SHWallet.witnessToAddress('trololo');
-    assert.strictEqual(address, false);
+    expect(address).toBe(false);
 
     address = SegwitP2SHWallet.scriptPubKeyToAddress('a914e286d58e53f9247a4710e51232cce0686f16873c87');
-    assert.strictEqual(address, '3NLnALo49CFEF4tCRhCvz45ySSfz3UktZC');
+    expect(address).toBe('3NLnALo49CFEF4tCRhCvz45ySSfz3UktZC');
     address = SegwitP2SHWallet.scriptPubKeyToAddress();
-    assert.strictEqual(address, false);
+    expect(address).toBe(false);
     address = SegwitP2SHWallet.scriptPubKeyToAddress('trololo');
-    assert.strictEqual(address, false);
+    expect(address).toBe(false);
 
     address = SegwitBech32Wallet.witnessToAddress('035c618df829af694cb99e664ce1b34f80ad2c3b49bcd0d9c0b1836c66b2d25fd8');
-    assert.strictEqual(address, 'bc1quhnve8q4tk3unhmjts7ymxv8cd6w9xv8wy29uv');
+    expect(address).toBe('bc1quhnve8q4tk3unhmjts7ymxv8cd6w9xv8wy29uv');
     address = SegwitBech32Wallet.witnessToAddress();
-    assert.strictEqual(address, false);
+    expect(address).toBe(false);
     address = SegwitBech32Wallet.witnessToAddress('trololo');
-    assert.strictEqual(address, false);
+    expect(address).toBe(false);
 
     address = SegwitBech32Wallet.scriptPubKeyToAddress('00144d757460da5fcaf84cc22f3847faaa1078e84f6a');
-    assert.strictEqual(address, 'bc1qf46hgcx6tl90snxz9uuy0742zpuwsnm27ysdh7');
+    expect(address).toBe('bc1qf46hgcx6tl90snxz9uuy0742zpuwsnm27ysdh7');
     address = SegwitBech32Wallet.scriptPubKeyToAddress();
-    assert.strictEqual(address, false);
+    expect(address).toBe(false);
     address = SegwitBech32Wallet.scriptPubKeyToAddress('trololo');
-    assert.strictEqual(address, false);
+    expect(address).toBe(false);
 
     address = LegacyWallet.scriptPubKeyToAddress('76a914d0b77eb1502c81c4093da9aa6eccfdf560cdd6b288ac');
-    assert.strictEqual(address, '1L2bNMGRQQLT2AVUek4K9L7sn3SSMioMgE');
+    expect(address).toBe('1L2bNMGRQQLT2AVUek4K9L7sn3SSMioMgE');
     address = LegacyWallet.scriptPubKeyToAddress();
-    assert.strictEqual(address, false);
+    expect(address).toBe(false);
     address = LegacyWallet.scriptPubKeyToAddress('trololo');
-    assert.strictEqual(address, false);
+    expect(address).toBe(false);
   });
 
   it('Segwit HD (BIP49) can generate addressess only via ypub', function () {
     const ypub = 'ypub6WhHmKBmHNjcrUVNCa3sXduH9yxutMipDcwiKW31vWjcMbfhQHjXdyx4rqXbEtVgzdbhFJ5mZJWmfWwnP4Vjzx97admTUYKQt6b9D7jjSCp';
     const hd = new HDSegwitP2SHWallet();
     hd._xpub = ypub;
-    assert.strictEqual('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK', hd._getExternalAddressByIndex(0));
-    assert.strictEqual('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3', hd._getExternalAddressByIndex(1));
-    assert.strictEqual('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei', hd._getInternalAddressByIndex(0));
-    assert.ok(hd.getAllExternalAddresses().includes('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK'));
-    assert.ok(hd.getAllExternalAddresses().includes('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3'));
-    assert.ok(!hd.getAllExternalAddresses().includes('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei')); // not internal
+    expect('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK').toBe(hd._getExternalAddressByIndex(0));
+    expect('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3').toBe(hd._getExternalAddressByIndex(1));
+    expect('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei').toBe(hd._getInternalAddressByIndex(0));
+    expect(hd.getAllExternalAddresses().includes('3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK')).toBeTruthy();
+    expect(hd.getAllExternalAddresses().includes('35p5LwCAE7mH2css7onyQ1VuS1jgWtQ4U3')).toBeTruthy();
+    expect(!hd.getAllExternalAddresses().includes('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei')).toBeTruthy(); // not internal
   });
 
   it('can generate Segwit HD (BIP49)', async () => {
@@ -94,12 +89,12 @@ describe('P2SH Segwit HD (BIP49)', () => {
         throw new Error('Duplicate secret generated!');
       }
       hashmap[secret] = 1;
-      assert.ok(secret.split(' ').length === 12 || secret.split(' ').length === 24);
+      expect(secret.split(' ').length === 12 || secret.split(' ').length === 24).toBeTruthy();
     }
 
     const hd2 = new HDSegwitP2SHWallet();
     hd2.setSecret(hd.getSecret());
-    assert.ok(hd2.validateMnemonic());
+    expect(hd2.validateMnemonic()).toBeTruthy();
   });
 
   it('can work with malformed mnemonic', () => {
@@ -108,12 +103,12 @@ describe('P2SH Segwit HD (BIP49)', () => {
     let hd = new HDSegwitP2SHWallet();
     hd.setSecret(mnemonic);
     const seed1 = hd._getSeed().toString('hex');
-    assert.ok(hd.validateMnemonic());
+    expect(hd.validateMnemonic()).toBeTruthy();
 
     mnemonic = 'hell';
     hd = new HDSegwitP2SHWallet();
     hd.setSecret(mnemonic);
-    assert.ok(!hd.validateMnemonic());
+    expect(!hd.validateMnemonic()).toBeTruthy();
 
     // now, malformed mnemonic
 
@@ -122,29 +117,28 @@ describe('P2SH Segwit HD (BIP49)', () => {
     hd = new HDSegwitP2SHWallet();
     hd.setSecret(mnemonic);
     const seed2 = hd._getSeed().toString('hex');
-    assert.strictEqual(seed1, seed2);
-    assert.ok(hd.validateMnemonic());
+    expect(seed1).toBe(seed2);
+    expect(hd.validateMnemonic()).toBeTruthy();
   });
 
   it('can generate addressess based on xpub', async function () {
     const xpub = 'xpub6CQdfC3v9gU86eaSn7AhUFcBVxiGhdtYxdC5Cw2vLmFkfth2KXCMmYcPpvZviA89X6DXDs4PJDk5QVL2G2xaVjv7SM4roWHr1gR4xB3Z7Ps';
     const hd = new HDLegacyP2PKHWallet();
     hd._xpub = xpub;
-    assert.strictEqual(hd._getExternalAddressByIndex(0), '12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG');
-    assert.strictEqual(hd._getInternalAddressByIndex(0), '1KZjqYHm7a1DjhjcdcjfQvYfF2h6PqatjX');
-    assert.strictEqual(hd._getExternalAddressByIndex(1), '1QDCFcpnrZ4yrAQxmbvSgeUC9iZZ8ehcR5');
-    assert.strictEqual(hd._getInternalAddressByIndex(1), '13CW9WWBsWpDUvLtbFqYziWBWTYUoQb4nU');
-    assert.ok(hd.getAllExternalAddresses().includes('12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG'));
-    assert.ok(hd.getAllExternalAddresses().includes('1QDCFcpnrZ4yrAQxmbvSgeUC9iZZ8ehcR5'));
-    assert.ok(!hd.getAllExternalAddresses().includes('1KZjqYHm7a1DjhjcdcjfQvYfF2h6PqatjX')); // not internal
+    expect(hd._getExternalAddressByIndex(0)).toBe('12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG');
+    expect(hd._getInternalAddressByIndex(0)).toBe('1KZjqYHm7a1DjhjcdcjfQvYfF2h6PqatjX');
+    expect(hd._getExternalAddressByIndex(1)).toBe('1QDCFcpnrZ4yrAQxmbvSgeUC9iZZ8ehcR5');
+    expect(hd._getInternalAddressByIndex(1)).toBe('13CW9WWBsWpDUvLtbFqYziWBWTYUoQb4nU');
+    expect(hd.getAllExternalAddresses().includes('12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG')).toBeTruthy();
+    expect(hd.getAllExternalAddresses().includes('1QDCFcpnrZ4yrAQxmbvSgeUC9iZZ8ehcR5')).toBeTruthy();
+    expect(!hd.getAllExternalAddresses().includes('1KZjqYHm7a1DjhjcdcjfQvYfF2h6PqatjX')).toBeTruthy(); // not internal
   });
 
   it('can consume user generated entropy', async () => {
     const hd = new HDSegwitP2SHWallet();
     const zeroes = [...Array(32)].map(() => 0);
     await hd.generateFromEntropy(Buffer.from(zeroes));
-    assert.strictEqual(
-      hd.getSecret(),
+    expect(hd.getSecret()).toBe(
       'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art',
     );
   });
@@ -154,17 +148,16 @@ describe('P2SH Segwit HD (BIP49)', () => {
     const zeroes = [...Array(16)].map(() => 0);
     await hd.generateFromEntropy(Buffer.from(zeroes));
     const secret = hd.getSecret();
-    assert.strictEqual(secret.startsWith('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon'), true);
+    expect(secret.startsWith('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon')).toBe(true);
 
     let secretWithoutChecksum = secret.split(' ');
     secretWithoutChecksum.pop();
     secretWithoutChecksum = secretWithoutChecksum.join(' ');
-    assert.strictEqual(
-      secretWithoutChecksum.endsWith('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon'),
+    expect(secretWithoutChecksum.endsWith('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon')).toBe(
       false,
     );
 
-    assert.ok(secret.split(' ').length === 12 || secret.split(' ').length === 24);
+    expect(secret.split(' ').length === 12 || secret.split(' ').length === 24).toBeTruthy();
   });
 
   it('can sign and verify messages', async () => {
@@ -175,20 +168,20 @@ describe('P2SH Segwit HD (BIP49)', () => {
 
     // external address
     signature = hd.signMessage('vires is numeris', hd._getExternalAddressByIndex(0));
-    assert.strictEqual(signature, 'JMgoRSlLLLw6mw/Gbbg8Uj3fACkIJ85CZ52T5ZQfBnpUBkz0myRju6Rmgvmq7ugytc4WyYbzdGEc3wufNbjP09g=');
-    assert.strictEqual(hd.verifyMessage('vires is numeris', hd._getExternalAddressByIndex(0), signature), true);
+    expect(signature).toBe('JMgoRSlLLLw6mw/Gbbg8Uj3fACkIJ85CZ52T5ZQfBnpUBkz0myRju6Rmgvmq7ugytc4WyYbzdGEc3wufNbjP09g=');
+    expect(hd.verifyMessage('vires is numeris', hd._getExternalAddressByIndex(0), signature)).toBe(true);
 
     // internal address
     signature = hd.signMessage('vires is numeris', hd._getInternalAddressByIndex(0));
-    assert.strictEqual(signature, 'I5WkniWTnJhTW74t3kTAkHq3HdiupTNgOZLpMp0hvUfAJw2HMuyRiNLl2pbNWobNCCrmvffSWM7IgkOBz/J9fYA=');
-    assert.strictEqual(hd.verifyMessage('vires is numeris', hd._getInternalAddressByIndex(0), signature), true);
+    expect(signature).toBe('I5WkniWTnJhTW74t3kTAkHq3HdiupTNgOZLpMp0hvUfAJw2HMuyRiNLl2pbNWobNCCrmvffSWM7IgkOBz/J9fYA=');
+    expect(hd.verifyMessage('vires is numeris', hd._getInternalAddressByIndex(0), signature)).toBe(true);
   });
 
   it('can show fingerprint', async () => {
     const mnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
     const hd = new HDSegwitP2SHWallet();
     hd.setSecret(mnemonic);
-    assert.strictEqual(hd.getMasterFingerprintHex(), '73C5DA0A');
+    expect(hd.getMasterFingerprintHex()).toBe('73C5DA0A');
   });
 
   it('can use mnemonic with passphrase', () => {
@@ -198,13 +191,12 @@ describe('P2SH Segwit HD (BIP49)', () => {
     hd.setSecret(mnemonic);
     hd.setPassphrase(passphrase);
 
-    assert.strictEqual(
-      hd.getXpub(),
+    expect(hd.getXpub()).toBe(
       'ypub6Xa3WiyXHriYt1fxZGWS8B1iduw92yxHCMWKSwJkW6w92FUCTJxwWQQHLXjRHBSsMLY6SvRu8ErqFEC3JmrkTHEm7KSUfbzhUhj7Yopo2JR',
     );
 
-    assert.strictEqual(hd._getExternalAddressByIndex(0), '3BtnNenqpGTXwwjb5a1KgzzoKV4TjCuySm');
-    assert.strictEqual(hd._getInternalAddressByIndex(0), '3EJctafkUBvcSHYhunQRa2iYUHjrMGLXBV');
-    assert.strictEqual(hd._getExternalWIFByIndex(0), 'L489rJZvUMrFsNop9EyuG2XdEmyKNTbjC1DWkg9WGEc1ddK6jgDg');
+    expect(hd._getExternalAddressByIndex(0)).toBe('3BtnNenqpGTXwwjb5a1KgzzoKV4TjCuySm');
+    expect(hd._getInternalAddressByIndex(0)).toBe('3EJctafkUBvcSHYhunQRa2iYUHjrMGLXBV');
+    expect(hd._getExternalWIFByIndex(0)).toBe('L489rJZvUMrFsNop9EyuG2XdEmyKNTbjC1DWkg9WGEc1ddK6jgDg');
   });
 });

--- a/tests/unit/legacy-wallet.test.js
+++ b/tests/unit/legacy-wallet.test.js
@@ -1,14 +1,13 @@
+import * as bitcoin from 'bitcoinjs-lib';
 import { LegacyWallet } from '../../class';
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
 
 describe('Legacy wallet', () => {
   it('can create transaction', async () => {
     const l = new LegacyWallet();
     l.setSecret('L4ccWrPMmFDZw4kzAKFqJNxgHANjdy6b7YKNXMwB4xac4FLF3Tov');
-    assert.strictEqual(l.getAddress(), '14YZ6iymQtBVQJk6gKnLCk49UScJK7SH4M');
-    assert.deepStrictEqual(l.getAllExternalAddresses(), ['14YZ6iymQtBVQJk6gKnLCk49UScJK7SH4M']);
-    assert.strictEqual(await l.getChangeAddressAsync(), l.getAddress());
+    expect(l.getAddress()).toBe('14YZ6iymQtBVQJk6gKnLCk49UScJK7SH4M');
+    expect(l.getAllExternalAddresses()).toEqual(['14YZ6iymQtBVQJk6gKnLCk49UScJK7SH4M']);
+    expect(await l.getChangeAddressAsync()).toBe(l.getAddress());
 
     const utxos = [
       {
@@ -23,21 +22,20 @@ describe('Legacy wallet', () => {
 
     let txNew = l.createTransaction(utxos, [{ value: 90000, address: '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB' }], 1, l.getAddress());
     let tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-    assert.strictEqual(
-      txNew.tx.toHex(),
+    expect(txNew.tx.toHex()).toBe(
       '0200000001c4ce4282c157a7f1e4524d153d3a251669f10673ad24e49f6d2994a033e944cc000000006b48304502210091e58bd2021f2eeea8d39d7f7b053c9ccc52a747b60f1c3584ba33285e2d150602205b2d35a2536cbe157015e8c54a26f5fc350cc7c72b5ca80b9e548917993f652201210337c09b3cb889801638078fd4e6998218b28c92d338ea2602720a88847aedceb3ffffffff02905f0100000000001976a914aa381cd428a4e91327fd4434aa0a08ff131f1a5a88ac2e260000000000001976a91426e01119d265aa980390c49eece923976c218f1588ac00000000',
     );
-    assert.strictEqual(tx.ins.length, 1);
-    assert.strictEqual(tx.outs.length, 2);
-    assert.strictEqual('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB', bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
-    assert.strictEqual(l.getAddress(), bitcoin.address.fromOutputScript(tx.outs[1].script)); // change address
+    expect(tx.ins.length).toBe(1);
+    expect(tx.outs.length).toBe(2);
+    expect('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB').toBe(bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
+    expect(l.getAddress()).toBe(bitcoin.address.fromOutputScript(tx.outs[1].script)); // change address
 
     // sendMax
     txNew = l.createTransaction(utxos, [{ address: '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB' }], 1, l.getAddress());
     tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-    assert.strictEqual(tx.ins.length, 1);
-    assert.strictEqual(tx.outs.length, 1);
-    assert.strictEqual('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB', bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
+    expect(tx.ins.length).toBe(1);
+    expect(tx.outs.length).toBe(1);
+    expect('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB').toBe(bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
 
     // batch send + send max
     txNew = l.createTransaction(
@@ -47,10 +45,10 @@ describe('Legacy wallet', () => {
       l.getAddress(),
     );
     tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-    assert.strictEqual(tx.ins.length, 1);
-    assert.strictEqual(tx.outs.length, 2);
-    assert.strictEqual('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB', bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
-    assert.strictEqual('bc1q3rl0mkyk0zrtxfmqn9wpcd3gnaz00yv9yp0hxe', bitcoin.address.fromOutputScript(tx.outs[1].script)); // to address
+    expect(tx.ins.length).toBe(1);
+    expect(tx.outs.length).toBe(2);
+    expect('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB').toBe(bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
+    expect('bc1q3rl0mkyk0zrtxfmqn9wpcd3gnaz00yv9yp0hxe').toBe(bitcoin.address.fromOutputScript(tx.outs[1].script)); // to address
   });
 
   it('can create transaction with better UTXO selection', async () => {
@@ -91,36 +89,33 @@ describe('Legacy wallet', () => {
       0,
       true,
     );
-    assert.strictEqual(psbt.data.inputs.length, 1);
+    expect(psbt.data.inputs.length).toBe(1);
   });
 
   it("throws error if you can't create wallet from this entropy", async () => {
     const l = new LegacyWallet();
     const zeroes = [...Array(32)].map(() => 0);
-    await assert.rejects(async () => await l.generateFromEntropy(Buffer.from(zeroes)), {
-      name: 'TypeError',
-      message: 'Private key not in range [1, n)',
-    });
+    await expect(async () => await l.generateFromEntropy(Buffer.from(zeroes))).rejects.toThrow('Private key not in range [1, n)');
   });
 
   it('can consume user generated entropy', async () => {
     const l = new LegacyWallet();
     const values = [...Array(32)].map(() => 1);
     await l.generateFromEntropy(Buffer.from(values));
-    assert.strictEqual(l.getSecret(), 'KwFfNUhSDaASSAwtG7ssQM1uVX8RgX5GHWnnLfhfiQDigjioWXHH');
+    expect(l.getSecret()).toBe('KwFfNUhSDaASSAwtG7ssQM1uVX8RgX5GHWnnLfhfiQDigjioWXHH');
   });
 
   it('can fullfill user generated entropy if less than 32 bytes provided', async () => {
     const l = new LegacyWallet();
     const values = [...Array(16)].map(() => 1);
     await l.generateFromEntropy(Buffer.from(values));
-    assert.strictEqual(l.getSecret().startsWith('KwFfNUhSDaASSAwtG7ssQM'), true);
-    assert.strictEqual(l.getSecret().endsWith('GHWnnLfhfiQDigjioWXHH'), false);
+    expect(l.getSecret().startsWith('KwFfNUhSDaASSAwtG7ssQM')).toBe(true);
+    expect(l.getSecret().endsWith('GHWnnLfhfiQDigjioWXHH')).toBe(false);
     const keyPair = bitcoin.ECPair.fromWIF(l.getSecret());
-    assert.strictEqual(keyPair.privateKey.toString('hex').startsWith('01010101'), true);
-    assert.strictEqual(keyPair.privateKey.toString('hex').endsWith('01010101'), false);
-    assert.strictEqual(keyPair.privateKey.toString('hex').endsWith('00000000'), false);
-    assert.strictEqual(keyPair.privateKey.toString('hex').endsWith('ffffffff'), false);
+    expect(keyPair.privateKey.toString('hex').startsWith('01010101')).toBe(true);
+    expect(keyPair.privateKey.toString('hex').endsWith('01010101')).toBe(false);
+    expect(keyPair.privateKey.toString('hex').endsWith('00000000')).toBe(false);
+    expect(keyPair.privateKey.toString('hex').endsWith('ffffffff')).toBe(false);
   });
 
   it('can sign and verify messages', async () => {
@@ -128,7 +123,7 @@ describe('Legacy wallet', () => {
     l.setSecret('L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1'); // from bitcoinjs-message examples
 
     const signature = l.signMessage('This is an example of a signed message.', l.getAddress());
-    assert.strictEqual(signature, 'H9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk=');
-    assert.strictEqual(l.verifyMessage('This is an example of a signed message.', l.getAddress(), signature), true);
+    expect(signature).toBe('H9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk=');
+    expect(l.verifyMessage('This is an example of a signed message.', l.getAddress(), signature)).toBe(true);
   });
 });

--- a/tests/unit/lnurl.test.js
+++ b/tests/unit/lnurl.test.js
@@ -1,45 +1,42 @@
 import Lnurl from '../../class/lnurl';
-const assert = require('assert');
 
 describe('LNURL', function () {
   it('can findlnurl', () => {
     const base = 'lnurl1dp68gurn8ghj7mrww3uxymm59e3xjemnw4hzu7re0ghkcmn4wfkz7urp0ylh2um9wf5kg0fhxycnv9g9w58';
-    assert.strictEqual(Lnurl.findlnurl(base), base);
-    assert.strictEqual(Lnurl.findlnurl(base.toUpperCase()), base);
-    assert.strictEqual(Lnurl.findlnurl('https://site.com/?lightning=' + base), base);
-    assert.strictEqual(Lnurl.findlnurl('https://site.com/?lightning=' + base.toUpperCase()), base);
-    assert.strictEqual(Lnurl.findlnurl('https://site.com/?nada=nada&lightning=' + base), base);
-    assert.strictEqual(Lnurl.findlnurl('https://site.com/?nada=nada&lightning=' + base.toUpperCase()), base);
-    assert.strictEqual(Lnurl.findlnurl('bs'), null);
-    assert.strictEqual(Lnurl.findlnurl('https://site.com'), null);
-    assert.strictEqual(Lnurl.findlnurl('https://site.com/?bs=' + base), null);
+    expect(Lnurl.findlnurl(base)).toBe(base);
+    expect(Lnurl.findlnurl(base.toUpperCase())).toBe(base);
+    expect(Lnurl.findlnurl('https://site.com/?lightning=' + base)).toBe(base);
+    expect(Lnurl.findlnurl('https://site.com/?lightning=' + base.toUpperCase())).toBe(base);
+    expect(Lnurl.findlnurl('https://site.com/?nada=nada&lightning=' + base)).toBe(base);
+    expect(Lnurl.findlnurl('https://site.com/?nada=nada&lightning=' + base.toUpperCase())).toBe(base);
+    expect(Lnurl.findlnurl('bs')).toBe(null);
+    expect(Lnurl.findlnurl('https://site.com')).toBe(null);
+    expect(Lnurl.findlnurl('https://site.com/?bs=' + base)).toBe(null);
   });
 
   it('can getUrlFromLnurl()', () => {
-    assert.strictEqual(
-      Lnurl.getUrlFromLnurl('LNURL1DP68GURN8GHJ7MRWW3UXYMM59E3XJEMNW4HZU7RE0GHKCMN4WFKZ7URP0YLH2UM9WF5KG0FHXYCNV9G9W58'),
+    expect(Lnurl.getUrlFromLnurl('LNURL1DP68GURN8GHJ7MRWW3UXYMM59E3XJEMNW4HZU7RE0GHKCMN4WFKZ7URP0YLH2UM9WF5KG0FHXYCNV9G9W58')).toBe(
       'https://lntxbot.bigsun.xyz/lnurl/pay?userid=7116',
     );
-    assert.strictEqual(
+    expect(
       Lnurl.getUrlFromLnurl(
         'https://lnbits.com/?lightning=LNURL1DP68GURN8GHJ7MRWVF5HGUEWVDHK6TMHD96XSERJV9MJ7CTSDYHHVVF0D3H82UNV9UM9JDENFPN5SMMK2359J5RKWVMKZ5ZVWAV4VJD63TM',
       ),
-      'https://lnbits.com/withdraw/api/v1/lnurl/6Y73HgHovThYPvs7aPLwYV',
-    );
-    assert.strictEqual(Lnurl.getUrlFromLnurl('bs'), false);
+    ).toBe('https://lnbits.com/withdraw/api/v1/lnurl/6Y73HgHovThYPvs7aPLwYV');
+    expect(Lnurl.getUrlFromLnurl('bs')).toBe(false);
   });
 
   it('can isLnurl()', () => {
-    assert.ok(Lnurl.isLnurl('LNURL1DP68GURN8GHJ7MRWW3UXYMM59E3XJEMNW4HZU7RE0GHKCMN4WFKZ7URP0YLH2UM9WF5KG0FHXYCNV9G9W58'));
-    assert.ok(
+    expect(Lnurl.isLnurl('LNURL1DP68GURN8GHJ7MRWW3UXYMM59E3XJEMNW4HZU7RE0GHKCMN4WFKZ7URP0YLH2UM9WF5KG0FHXYCNV9G9W58')).toBeTruthy();
+    expect(
       Lnurl.isLnurl(
         'https://site.com/?lightning=LNURL1DP68GURN8GHJ7MRWW3UXYMM59E3XJEMNW4HZU7RE0GHKCMN4WFKZ7URP0YLH2UM9WF5KG0FHXYCNV9G9W58',
       ),
-    );
-    assert.ok(
+    ).toBeTruthy();
+    expect(
       !Lnurl.isLnurl('https://site.com/?bs=LNURL1DP68GURN8GHJ7MRWW3UXYMM59E3XJEMNW4HZU7RE0GHKCMN4WFKZ7URP0YLH2UM9WF5KG0FHXYCNV9G9W58'),
-    );
-    assert.ok(!Lnurl.isLnurl('bs'));
+    ).toBeTruthy();
+    expect(!Lnurl.isLnurl('bs')).toBeTruthy();
   });
 
   it('can callLnurlPayService() and requestBolt11FromLnurlPayService()', async () => {
@@ -58,7 +55,7 @@ describe('LNURL', function () {
       };
     };
     const lnurlpayPayload = await LN.callLnurlPayService();
-    assert.deepStrictEqual(lnurlpayPayload, {
+    expect(lnurlpayPayload).toEqual({
       amount: 1,
       callback: 'https://lntxbot.bigsun.xyz/lnurl/pay/callback?userid=7116',
       description: 'Fund @overtorment account on t.me/lntxbot.',
@@ -82,7 +79,7 @@ describe('LNURL', function () {
       };
     };
     const rez = await LN.requestBolt11FromLnurlPayService(2);
-    assert.deepStrictEqual(rez, {
+    expect(rez).toEqual({
       status: 'OK',
       successAction: null,
       routes: [],
@@ -91,12 +88,12 @@ describe('LNURL', function () {
       disposable: false,
     });
 
-    assert.strictEqual(LN.getSuccessAction(), null);
-    assert.strictEqual(LN.getDomain(), 'lntxbot.bigsun.xyz');
-    assert.strictEqual(LN.getDescription(), 'Fund @overtorment account on t.me/lntxbot.');
-    assert.strictEqual(LN.getImage(), undefined);
-    assert.strictEqual(LN.getLnurl(), 'LNURL1DP68GURN8GHJ7MRWW3UXYMM59E3XJEMNW4HZU7RE0GHKCMN4WFKZ7URP0YLH2UM9WF5KG0FHXYCNV9G9W58');
-    assert.strictEqual(LN.getDisposable(), false);
+    expect(LN.getSuccessAction()).toBe(null);
+    expect(LN.getDomain()).toBe('lntxbot.bigsun.xyz');
+    expect(LN.getDescription()).toBe('Fund @overtorment account on t.me/lntxbot.');
+    expect(LN.getImage()).toBe(undefined);
+    expect(LN.getLnurl()).toBe('LNURL1DP68GURN8GHJ7MRWW3UXYMM59E3XJEMNW4HZU7RE0GHKCMN4WFKZ7URP0YLH2UM9WF5KG0FHXYCNV9G9W58');
+    expect(LN.getDisposable()).toBe(false);
   });
 
   it('can decipher AES', () => {
@@ -104,6 +101,6 @@ describe('LNURL', function () {
     const iv = 'eTGduB45hWTOxHj1dR+LJw==';
     const preimage = 'bf62911aa53c017c27ba34391f694bc8bf8aaf59b4ebfd9020e66ac0412e189b';
 
-    assert.strictEqual(Lnurl.decipherAES(ciphertext, preimage, iv), '1234');
+    expect(Lnurl.decipherAES(ciphertext, preimage, iv)).toBe('1234');
   });
 });

--- a/tests/unit/loc.test.js
+++ b/tests/unit/loc.test.js
@@ -1,47 +1,47 @@
 import { BitcoinUnit } from '../../models/bitcoinUnits';
 import { FiatUnit } from '../../models/fiatUnit';
 import { _leaveNumbersAndDots, formatBalanceWithoutSuffix, formatBalancePlain, formatBalance } from '../../loc';
-const assert = require('assert');
 const currency = require('../../blue_modules/currency');
+
 jest.useFakeTimers();
 
 describe('Localization', () => {
   it('internal formatter', () => {
-    assert.strictEqual(_leaveNumbersAndDots('1,00 ₽'), '1');
-    assert.strictEqual(_leaveNumbersAndDots('0,50 ₽"'), '0.50');
-    assert.strictEqual(_leaveNumbersAndDots('RUB 1,00'), '1');
+    expect(_leaveNumbersAndDots('1,00 ₽')).toBe('1');
+    expect(_leaveNumbersAndDots('0,50 ₽"')).toBe('0.50');
+    expect(_leaveNumbersAndDots('RUB 1,00')).toBe('1');
   });
 
   it('formatBalancePlain() && formatBalancePlain()', () => {
     currency._setExchangeRate('BTC_RUB', 660180.143);
     currency._setPreferredFiatCurrency(FiatUnit.RUB);
     let newInputValue = formatBalanceWithoutSuffix(152, BitcoinUnit.LOCAL_CURRENCY, false);
-    assert.ok(newInputValue === 'RUB 1.00' || newInputValue === '1,00 ₽', 'Unexpected: ' + newInputValue);
+    expect(newInputValue === 'RUB 1.00' || newInputValue === '1,00 ₽').toBeTruthy();
     newInputValue = formatBalancePlain(152, BitcoinUnit.LOCAL_CURRENCY, false);
-    assert.strictEqual(newInputValue, '1');
+    expect(newInputValue).toBe('1');
 
     newInputValue = formatBalanceWithoutSuffix(1515, BitcoinUnit.LOCAL_CURRENCY, false);
-    assert.ok(newInputValue === 'RUB 10.00' || newInputValue === '10,00 ₽', 'Unexpected: ' + newInputValue);
+    expect(newInputValue === 'RUB 10.00' || newInputValue === '10,00 ₽').toBeTruthy();
     newInputValue = formatBalancePlain(1515, BitcoinUnit.LOCAL_CURRENCY, false);
-    assert.strictEqual(newInputValue, '10');
+    expect(newInputValue).toBe('10');
 
     newInputValue = formatBalanceWithoutSuffix(16793829, BitcoinUnit.LOCAL_CURRENCY, false);
-    assert.ok(newInputValue === 'RUB 110,869.52' || newInputValue === '110 869,52 ₽', 'Unexpected: ' + newInputValue);
+    expect(newInputValue === 'RUB 110,869.52' || newInputValue === '110 869,52 ₽').toBeTruthy();
     newInputValue = formatBalancePlain(16793829, BitcoinUnit.LOCAL_CURRENCY, false);
-    assert.strictEqual(newInputValue, '110869.52');
+    expect(newInputValue).toBe('110869.52');
 
     newInputValue = formatBalancePlain(76, BitcoinUnit.LOCAL_CURRENCY, false);
-    assert.strictEqual(newInputValue, '0.50');
+    expect(newInputValue).toBe('0.50');
 
     currency._setExchangeRate('BTC_USD', 10000);
     currency._setPreferredFiatCurrency(FiatUnit.USD);
     newInputValue = formatBalanceWithoutSuffix(16793829, BitcoinUnit.LOCAL_CURRENCY, false);
-    assert.strictEqual(newInputValue, '$1,679.38');
+    expect(newInputValue).toBe('$1,679.38');
     newInputValue = formatBalancePlain(16793829, BitcoinUnit.LOCAL_CURRENCY, false);
-    assert.strictEqual(newInputValue, '1679.38');
+    expect(newInputValue).toBe('1679.38');
 
     newInputValue = formatBalancePlain(16000000, BitcoinUnit.LOCAL_CURRENCY, false);
-    assert.strictEqual(newInputValue, '1600');
+    expect(newInputValue).toBe('1600');
   });
 
   it.each([
@@ -62,7 +62,7 @@ describe('Localization', () => {
         currency._setExchangeRate('BTC_USD', false);
       }
       const actualResult = formatBalanceWithoutSuffix(balance, toUnit, withFormatting);
-      assert.strictEqual(actualResult, expectedResult);
+      expect(actualResult).toBe(expectedResult);
     },
     240000,
   );
@@ -77,7 +77,7 @@ describe('Localization', () => {
       currency._setExchangeRate('BTC_USD', 1);
       currency._setPreferredFiatCurrency(FiatUnit.USD);
       const actualResult = formatBalance(balance, toUnit, withFormatting);
-      assert.strictEqual(actualResult, expectedResult);
+      expect(actualResult).toBe(expectedResult);
     },
     240000,
   );

--- a/tests/unit/multisig-hd-wallet.test.js
+++ b/tests/unit/multisig-hd-wallet.test.js
@@ -1,8 +1,7 @@
-import assert from 'assert';
+import * as bitcoin from 'bitcoinjs-lib';
 import { MultisigHDWallet } from '../../class/';
 import { decodeUR, encodeUR } from '../../blue_modules/ur';
 import { MultisigCosigner } from '../../class/multisig-cosigner';
-const bitcoin = require('bitcoinjs-lib');
 const Base43 = require('../../blue_modules/base43');
 
 const fp1cobo = 'D37EAD88';
@@ -36,30 +35,28 @@ describe('multisig-wallet (p2sh)', () => {
     const w = new MultisigHDWallet();
     w.setSecret(txtFileFormatMultisigLegacy);
 
-    assert.strictEqual(w.getDerivationPath(), "m/45'");
-    assert.strictEqual(w.getM(), 2);
-    assert.strictEqual(w.getN(), 2);
-    assert.strictEqual(w.howManySignaturesCanWeMake(), 0);
-    assert.strictEqual(
-      w.getCosigner(1),
+    expect(w.getDerivationPath()).toBe("m/45'");
+    expect(w.getM()).toBe(2);
+    expect(w.getN()).toBe(2);
+    expect(w.howManySignaturesCanWeMake()).toBe(0);
+    expect(w.getCosigner(1)).toBe(
       'xpub69SfFhG5eA9cqxHKM6b1HhXMpDzipUPDBNMBrjNgWWbbzKqnqwx2mvMyB5bRgmLAi7cBgr8euuz4Lvz3maWxpfUmdM71dyQuvq68mTAG4Cp',
     );
-    assert.strictEqual(
-      w.getCosigner(2),
+    expect(w.getCosigner(2)).toBe(
       'xpub6847W6cYUqq4ixcmFb83iqPtJZfnMPTkpYiCsuUybzFppJp2qzh3KCVHsLGQy4WhaxGqkK9aDDZnSfhB92PkHDKihbH6WLztzmN7WW9GYpR',
     );
-    assert.strictEqual(w.getCosignerForFingerprint(fp1cobo), w.getCosigner(1));
-    assert.strictEqual(w.getCosignerForFingerprint(fp2coldcard), w.getCosigner(2));
-    assert.strictEqual(w.getFingerprint(1), fp1cobo);
-    assert.strictEqual(w.getFormat(), MultisigHDWallet.FORMAT_P2SH);
+    expect(w.getCosignerForFingerprint(fp1cobo)).toBe(w.getCosigner(1));
+    expect(w.getCosignerForFingerprint(fp2coldcard)).toBe(w.getCosigner(2));
+    expect(w.getFingerprint(1)).toBe(fp1cobo);
+    expect(w.getFormat()).toBe(MultisigHDWallet.FORMAT_P2SH);
 
-    assert.strictEqual(w._getExternalAddressByIndex(0), '3J5xQcgBqoykSHhmDJLYp87SgVSNhYrvnz');
-    assert.strictEqual(w._getExternalAddressByIndex(1), '3GkEXFYUifSmQ9SgzJDWL37pjMj4LT6vbq');
-    assert.strictEqual(w._getInternalAddressByIndex(0), '365MagKko4t7L9XPXSYGkFj23dknTCx4UW');
-    assert.strictEqual(w._getInternalAddressByIndex(1), '36j8Qx6vxUknTxGFa5yYuxifEK9PGPEKso');
-    assert.ok(!w.isWrappedSegwit());
-    assert.ok(!w.isNativeSegwit());
-    assert.ok(w.isLegacy());
+    expect(w._getExternalAddressByIndex(0)).toBe('3J5xQcgBqoykSHhmDJLYp87SgVSNhYrvnz');
+    expect(w._getExternalAddressByIndex(1)).toBe('3GkEXFYUifSmQ9SgzJDWL37pjMj4LT6vbq');
+    expect(w._getInternalAddressByIndex(0)).toBe('365MagKko4t7L9XPXSYGkFj23dknTCx4UW');
+    expect(w._getInternalAddressByIndex(1)).toBe('36j8Qx6vxUknTxGFa5yYuxifEK9PGPEKso');
+    expect(!w.isWrappedSegwit()).toBeTruthy();
+    expect(!w.isNativeSegwit()).toBeTruthy();
+    expect(w.isLegacy()).toBeTruthy();
   });
 
   it('can coordinate tx creation', async () => {
@@ -82,30 +79,28 @@ describe('multisig-wallet (p2sh)', () => {
     const w = new MultisigHDWallet();
     w.setSecret(txtFileFormatMultisigLegacy);
 
-    assert.strictEqual(w.getDerivationPath(), "m/45'");
-    assert.strictEqual(w.getM(), 2);
-    assert.strictEqual(w.getN(), 2);
-    assert.strictEqual(w.howManySignaturesCanWeMake(), 0);
-    assert.strictEqual(
-      w.getCosigner(1),
+    expect(w.getDerivationPath()).toBe("m/45'");
+    expect(w.getM()).toBe(2);
+    expect(w.getN()).toBe(2);
+    expect(w.howManySignaturesCanWeMake()).toBe(0);
+    expect(w.getCosigner(1)).toBe(
       'xpub69SfFhG5eA9cqxHKM6b1HhXMpDzipUPDBNMBrjNgWWbbzKqnqwx2mvMyB5bRgmLAi7cBgr8euuz4Lvz3maWxpfUmdM71dyQuvq68mTAG4Cp',
     );
-    assert.strictEqual(
-      w.getCosigner(2),
+    expect(w.getCosigner(2)).toBe(
       'xpub6847W6cYUqq4ixcmFb83iqPtJZfnMPTkpYiCsuUybzFppJp2qzh3KCVHsLGQy4WhaxGqkK9aDDZnSfhB92PkHDKihbH6WLztzmN7WW9GYpR',
     );
-    assert.strictEqual(w.getCosignerForFingerprint(fp1cobo), w.getCosigner(1));
-    assert.strictEqual(w.getCosignerForFingerprint(fp2coldcard), w.getCosigner(2));
-    assert.strictEqual(w.getFingerprint(1), fp1cobo);
-    assert.strictEqual(w.getFingerprint(2), fp2coldcard);
+    expect(w.getCosignerForFingerprint(fp1cobo)).toBe(w.getCosigner(1));
+    expect(w.getCosignerForFingerprint(fp2coldcard)).toBe(w.getCosigner(2));
+    expect(w.getFingerprint(1)).toBe(fp1cobo);
+    expect(w.getFingerprint(2)).toBe(fp2coldcard);
 
-    assert.strictEqual(w._getExternalAddressByIndex(0), '3J5xQcgBqoykSHhmDJLYp87SgVSNhYrvnz');
-    assert.strictEqual(w._getExternalAddressByIndex(1), '3GkEXFYUifSmQ9SgzJDWL37pjMj4LT6vbq');
-    assert.strictEqual(w._getInternalAddressByIndex(0), '365MagKko4t7L9XPXSYGkFj23dknTCx4UW');
-    assert.strictEqual(w._getInternalAddressByIndex(1), '36j8Qx6vxUknTxGFa5yYuxifEK9PGPEKso');
-    assert.ok(!w.isWrappedSegwit());
-    assert.ok(!w.isNativeSegwit());
-    assert.ok(w.isLegacy());
+    expect(w._getExternalAddressByIndex(0)).toBe('3J5xQcgBqoykSHhmDJLYp87SgVSNhYrvnz');
+    expect(w._getExternalAddressByIndex(1)).toBe('3GkEXFYUifSmQ9SgzJDWL37pjMj4LT6vbq');
+    expect(w._getInternalAddressByIndex(0)).toBe('365MagKko4t7L9XPXSYGkFj23dknTCx4UW');
+    expect(w._getInternalAddressByIndex(1)).toBe('36j8Qx6vxUknTxGFa5yYuxifEK9PGPEKso');
+    expect(!w.isWrappedSegwit()).toBeTruthy();
+    expect(!w.isNativeSegwit()).toBeTruthy();
+    expect(w.isLegacy()).toBeTruthy();
 
     // transaction is gona be UNsigned because we have no keys
     const { psbt, tx } = w.createTransaction(
@@ -116,15 +111,14 @@ describe('multisig-wallet (p2sh)', () => {
       false,
       false,
     );
-    assert.ok(!tx, 'tx should not be provided when PSBT is only partially signed');
-    assert.throws(() => psbt.finalizeAllInputs().extractTransaction());
+    expect(!tx).toBeTruthy();
+    expect(() => psbt.finalizeAllInputs().extractTransaction()).toThrow();
 
-    assert.strictEqual(w.calculateHowManySignaturesWeHaveFromPsbt(psbt), 0);
-    assert.ok(w.calculateFeeFromPsbt(psbt) < 3000);
-    assert.ok(w.calculateFeeFromPsbt(psbt) > 0);
+    expect(w.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(0);
+    expect(w.calculateFeeFromPsbt(psbt) < 3000).toBeTruthy();
+    expect(w.calculateFeeFromPsbt(psbt) > 0).toBeTruthy();
 
-    assert.strictEqual(
-      psbt.toBase64(),
+    expect(psbt.toBase64()).toBe(
       'cHNidP8BAHUCAAAAAeze/Q5jJotU+uEMc2FdzH9A4DEN1ImGyQujTAt8IgpjAAAAAAAAAACAAhAnAAAAAAAAGXapFBkSnVPmMZuvGdugWb6tFm35Crj1iKy8VgEAAAAAABepFPI8FESPOvVVeCas7ULqnnFYnc5JhwAAAAAAAQD9cwECAAAAAAECEfjNx7ElW40+uVHbL8aWR2aq9ubRtC53fJClKXez6OUAAAAAAP////8AaW8YwJ2ITBACVIJfPKT0HKNfu16YjTUmy9z8swwzWwAAAAAA/////wKghgEAAAAAABepFLPYpQgalHfdXTVNTIp+/A5kaJ0Qh+g0DwAAAAAAFgAU7vEJEUm6Nlil3+nIqJJLOk8OG6oCRzBEAiBoVI1DaXMOkPM9QkNCC0DUx+8kC7rB2zM1TA4QjVA/JAIgYq3MHRl1a8s+yun+mIr3wxR7p99f9rJvShNQN2afzvABIQIR7fi1GKGsKNH5qVal3e3a6g30NfI4bn+4bw6f3oGN2gJHMEQCIDFA+O6DEVYvFesfBi876Y++QWFSYkka1WJdhUHOLkOGAiB3NDiR00ERKit1ZH1aH67A8KedrIBSJJ4i6zlZGku3DAEhAj8FwUXmExHrcl/eqYNP4gxOe7tjne+ORxN6JpYAH56dAAAAAAEER1IhAuKpQFZsreTHbjczMj+gmPaW2MpWjN/NE9t30TCFV6boIQMM4zcNTGSH1VK788aPJgBwsMhTJ20S4lg/3JkC8mJIjVKuIgYC4qlAVmyt5MduNzMyP6CY9pbYylaM380T23fRMIVXpugQFo3WAy0AAIAAAAAAAAAAACIGAwzjNw1MZIfVUrvzxo8mAHCwyFMnbRLiWD/cmQLyYkiNENN+rYgtAACAAAAAAAAAAAAAAAEAR1IhAoJkVao8TQcPGdH2rhAUNLNEoDTaWVlIZXZEEk77O3NoIQOJYtHCrnVaHKX4kVFrtjn9dVGJENMKTTOYLAY/aCS3rFKuIgICgmRVqjxNBw8Z0fauEBQ0s0SgNNpZWUhldkQSTvs7c2gQ036tiC0AAIABAAAAAwAAACICA4li0cKudVocpfiRUWu2Of11UYkQ0wpNM5gsBj9oJLesEBaN1gMtAACAAQAAAAMAAAAA',
     );
 
@@ -133,7 +127,7 @@ describe('multisig-wallet (p2sh)', () => {
       'cHNidP8BAHUCAAAAAeze/Q5jJotU+uEMc2FdzH9A4DEN1ImGyQujTAt8IgpjAAAAAAAAAACAAhAnAAAAAAAAGXapFBkSnVPmMZuvGdugWb6tFm35Crj1iKy8VgEAAAAAABepFPI8FESPOvVVeCas7ULqnnFYnc5JhwAAAAAAAQD9cwECAAAAAAECEfjNx7ElW40+uVHbL8aWR2aq9ubRtC53fJClKXez6OUAAAAAAP////8AaW8YwJ2ITBACVIJfPKT0HKNfu16YjTUmy9z8swwzWwAAAAAA/////wKghgEAAAAAABepFLPYpQgalHfdXTVNTIp+/A5kaJ0Qh+g0DwAAAAAAFgAU7vEJEUm6Nlil3+nIqJJLOk8OG6oCRzBEAiBoVI1DaXMOkPM9QkNCC0DUx+8kC7rB2zM1TA4QjVA/JAIgYq3MHRl1a8s+yun+mIr3wxR7p99f9rJvShNQN2afzvABIQIR7fi1GKGsKNH5qVal3e3a6g30NfI4bn+4bw6f3oGN2gJHMEQCIDFA+O6DEVYvFesfBi876Y++QWFSYkka1WJdhUHOLkOGAiB3NDiR00ERKit1ZH1aH67A8KedrIBSJJ4i6zlZGku3DAEhAj8FwUXmExHrcl/eqYNP4gxOe7tjne+ORxN6JpYAH56dAAAAACICAuKpQFZsreTHbjczMj+gmPaW2MpWjN/NE9t30TCFV6boRzBEAiA7xMszlRAzEJDo++ZfweUQ1qQS+N7hCHnuZe9ifT11swIgFzcqL0y6iTN9OqIIfLLYA7aydcK3EgtCIpjPl+u//kQBAQMEAQAAACIGAwzjNw1MZIfVUrvzxo8mAHCwyFMnbRLiWD/cmQLyYkiNENN+rYgtAACAAAAAAAAAAAAiBgLiqUBWbK3kx243MzI/oJj2ltjKVozfzRPbd9EwhVem6BAWjdYDLQAAgAAAAAAAAAAAAQRHUiEC4qlAVmyt5MduNzMyP6CY9pbYylaM380T23fRMIVXpughAwzjNw1MZIfVUrvzxo8mAHCwyFMnbRLiWD/cmQLyYkiNUq4AACICAoJkVao8TQcPGdH2rhAUNLNEoDTaWVlIZXZEEk77O3NoENN+rYgtAACAAQAAAAMAAAAiAgOJYtHCrnVaHKX4kVFrtjn9dVGJENMKTTOYLAY/aCS3rBAWjdYDLQAAgAEAAAADAAAAAQBHUiECgmRVqjxNBw8Z0fauEBQ0s0SgNNpZWUhldkQSTvs7c2ghA4li0cKudVocpfiRUWu2Of11UYkQ0wpNM5gsBj9oJLesUq4A\n';
     const psbtFromColdcard = bitcoin.Psbt.fromBase64(partSignedFromColdcard);
 
-    assert.throws(() => psbt.finalizeAllInputs().extractTransaction());
+    expect(() => psbt.finalizeAllInputs().extractTransaction()).toThrow();
     psbt.combine(psbtFromColdcard); // should not throw an exception
 
     // signed on real Cobo device:
@@ -146,8 +140,7 @@ describe('multisig-wallet (p2sh)', () => {
 
     psbt.combine(psbtFromCobo);
     const txhex = psbt.finalizeAllInputs().extractTransaction().toHex();
-    assert.strictEqual(
-      txhex,
+    expect(txhex).toBe(
       '0200000001ecdefd0e63268b54fae10c73615dcc7f40e0310dd48986c90ba34c0b7c220a6300000000d90047304402203bc4cb339510331090e8fbe65fc1e510d6a412f8dee10879ee65ef627d3d75b3022017372a2f4cba89337d3aa2087cb2d803b6b275c2b7120b422298cf97ebbffe440147304402202ac48d42623e988e038627113594e36c3c0e9c4069792ef385739105cf843c9d0220722f32d64d6f91a59325d1c494cc4d0cf8ae506c0cb25c46442dba1cb65e156d0147522102e2a940566cade4c76e3733323fa098f696d8ca568cdfcd13db77d1308557a6e821030ce3370d4c6487d552bbf3c68f260070b0c853276d12e2583fdc9902f262488d52ae000000800210270000000000001976a91419129d53e6319baf19dba059bead166df90ab8f588acbc5601000000000017a914f23c14448f3af5557826aced42ea9e71589dce498700000000',
     );
   });
@@ -180,24 +173,23 @@ describe('multisig-wallet (p2sh)', () => {
     w.setDerivationPath(path);
     w.setM(2);
 
-    assert.strictEqual(w.getDerivationPath(), "m/45'");
-    assert.strictEqual(w.getM(), 2);
-    assert.strictEqual(w.getN(), 2);
-    assert.strictEqual(w.howManySignaturesCanWeMake(), 1);
-    assert.strictEqual(
-      w.getCosigner(1),
+    expect(w.getDerivationPath()).toBe("m/45'");
+    expect(w.getM()).toBe(2);
+    expect(w.getN()).toBe(2);
+    expect(w.howManySignaturesCanWeMake()).toBe(1);
+    expect(w.getCosigner(1)).toBe(
       'xpub69SfFhG5eA9cqxHKM6b1HhXMpDzipUPDBNMBrjNgWWbbzKqnqwx2mvMyB5bRgmLAi7cBgr8euuz4Lvz3maWxpfUmdM71dyQuvq68mTAG4Cp',
     );
-    assert.strictEqual(w.getFingerprint(1), fp1cobo);
-    assert.strictEqual(w.getFingerprint(2), fp2coldcard);
+    expect(w.getFingerprint(1)).toBe(fp1cobo);
+    expect(w.getFingerprint(2)).toBe(fp2coldcard);
 
-    assert.strictEqual(w._getExternalAddressByIndex(0), '3J5xQcgBqoykSHhmDJLYp87SgVSNhYrvnz');
-    assert.strictEqual(w._getExternalAddressByIndex(1), '3GkEXFYUifSmQ9SgzJDWL37pjMj4LT6vbq');
-    assert.strictEqual(w._getInternalAddressByIndex(0), '365MagKko4t7L9XPXSYGkFj23dknTCx4UW');
-    assert.strictEqual(w._getInternalAddressByIndex(1), '36j8Qx6vxUknTxGFa5yYuxifEK9PGPEKso');
-    assert.ok(!w.isWrappedSegwit());
-    assert.ok(!w.isNativeSegwit());
-    assert.ok(w.isLegacy());
+    expect(w._getExternalAddressByIndex(0)).toBe('3J5xQcgBqoykSHhmDJLYp87SgVSNhYrvnz');
+    expect(w._getExternalAddressByIndex(1)).toBe('3GkEXFYUifSmQ9SgzJDWL37pjMj4LT6vbq');
+    expect(w._getInternalAddressByIndex(0)).toBe('365MagKko4t7L9XPXSYGkFj23dknTCx4UW');
+    expect(w._getInternalAddressByIndex(1)).toBe('36j8Qx6vxUknTxGFa5yYuxifEK9PGPEKso');
+    expect(!w.isWrappedSegwit()).toBeTruthy();
+    expect(!w.isNativeSegwit()).toBeTruthy();
+    expect(w.isLegacy()).toBeTruthy();
 
     // transaction is gona be signed with one key
     const { tx, psbt } = w.createTransaction(
@@ -208,11 +200,10 @@ describe('multisig-wallet (p2sh)', () => {
       false,
       false,
     );
-    assert.ok(!tx, 'tx should not be provided when PSBT is only partially signed');
+    expect(!tx).toBeTruthy();
 
-    assert.strictEqual(w.calculateHowManySignaturesWeHaveFromPsbt(psbt), 1);
-    assert.strictEqual(
-      psbt.toBase64(),
+    expect(w.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(1);
+    expect(psbt.toBase64()).toBe(
       'cHNidP8BAHUCAAAAAeze/Q5jJotU+uEMc2FdzH9A4DEN1ImGyQujTAt8IgpjAAAAAAAAAACAAhAnAAAAAAAAGXapFBkSnVPmMZuvGdugWb6tFm35Crj1iKy8VgEAAAAAABepFPI8FESPOvVVeCas7ULqnnFYnc5JhwAAAAAAAQD9cwECAAAAAAECEfjNx7ElW40+uVHbL8aWR2aq9ubRtC53fJClKXez6OUAAAAAAP////8AaW8YwJ2ITBACVIJfPKT0HKNfu16YjTUmy9z8swwzWwAAAAAA/////wKghgEAAAAAABepFLPYpQgalHfdXTVNTIp+/A5kaJ0Qh+g0DwAAAAAAFgAU7vEJEUm6Nlil3+nIqJJLOk8OG6oCRzBEAiBoVI1DaXMOkPM9QkNCC0DUx+8kC7rB2zM1TA4QjVA/JAIgYq3MHRl1a8s+yun+mIr3wxR7p99f9rJvShNQN2afzvABIQIR7fi1GKGsKNH5qVal3e3a6g30NfI4bn+4bw6f3oGN2gJHMEQCIDFA+O6DEVYvFesfBi876Y++QWFSYkka1WJdhUHOLkOGAiB3NDiR00ERKit1ZH1aH67A8KedrIBSJJ4i6zlZGku3DAEhAj8FwUXmExHrcl/eqYNP4gxOe7tjne+ORxN6JpYAH56dAAAAACICAuKpQFZsreTHbjczMj+gmPaW2MpWjN/NE9t30TCFV6boRzBEAiA7xMszlRAzEJDo++ZfweUQ1qQS+N7hCHnuZe9ifT11swIgFzcqL0y6iTN9OqIIfLLYA7aydcK3EgtCIpjPl+u//kQBAQRHUiEC4qlAVmyt5MduNzMyP6CY9pbYylaM380T23fRMIVXpughAwzjNw1MZIfVUrvzxo8mAHCwyFMnbRLiWD/cmQLyYkiNUq4iBgLiqUBWbK3kx243MzI/oJj2ltjKVozfzRPbd9EwhVem6BAWjdYDLQAAgAAAAAAAAAAAIgYDDOM3DUxkh9VSu/PGjyYAcLDIUydtEuJYP9yZAvJiSI0Q036tiC0AAIAAAAAAAAAAAAAAAQBHUiECgmRVqjxNBw8Z0fauEBQ0s0SgNNpZWUhldkQSTvs7c2ghA4li0cKudVocpfiRUWu2Of11UYkQ0wpNM5gsBj9oJLesUq4iAgKCZFWqPE0HDxnR9q4QFDSzRKA02llZSGV2RBJO+ztzaBDTfq2ILQAAgAEAAAADAAAAIgIDiWLRwq51Whyl+JFRa7Y5/XVRiRDTCk0zmCwGP2gkt6wQFo3WAy0AAIABAAAAAwAAAAA=',
     );
 
@@ -226,8 +217,7 @@ describe('multisig-wallet (p2sh)', () => {
     psbt.combine(psbtSignedOnCobo);
 
     const hex = psbt.finalizeAllInputs().extractTransaction().toHex();
-    assert.strictEqual(
-      hex,
+    expect(hex).toBe(
       '0200000001ecdefd0e63268b54fae10c73615dcc7f40e0310dd48986c90ba34c0b7c220a6300000000d90047304402203bc4cb339510331090e8fbe65fc1e510d6a412f8dee10879ee65ef627d3d75b3022017372a2f4cba89337d3aa2087cb2d803b6b275c2b7120b422298cf97ebbffe440147304402206da375097c3df9b4927f756518b01beacf886cb77aaa4421a675812174e1f4e802206ecb07d0b569a5b061b77e9435a4bc9dee2d83767f862f8e93a8891ee7c9d14f0147522102e2a940566cade4c76e3733323fa098f696d8ca568cdfcd13db77d1308557a6e821030ce3370d4c6487d552bbf3c68f260070b0c853276d12e2583fdc9902f262488d52ae000000800210270000000000001976a91419129d53e6319baf19dba059bead166df90ab8f588acbc5601000000000017a914f23c14448f3af5557826aced42ea9e71589dce498700000000',
     );
   });
@@ -257,21 +247,21 @@ describe('multisig-wallet (p2sh)', () => {
     w.setDerivationPath(path);
     w.setM(2);
 
-    assert.strictEqual(w.getDerivationPath(), "m/45'");
-    assert.strictEqual(w.getM(), 2);
-    assert.strictEqual(w.getN(), 2);
-    assert.strictEqual(w.howManySignaturesCanWeMake(), 2);
-    assert.strictEqual(w.getFingerprint(1), fp1cobo);
-    assert.strictEqual(w.getFingerprint(2), fp2coldcard);
+    expect(w.getDerivationPath()).toBe("m/45'");
+    expect(w.getM()).toBe(2);
+    expect(w.getN()).toBe(2);
+    expect(w.howManySignaturesCanWeMake()).toBe(2);
+    expect(w.getFingerprint(1)).toBe(fp1cobo);
+    expect(w.getFingerprint(2)).toBe(fp2coldcard);
 
-    assert.strictEqual(w._getExternalAddressByIndex(0), '3J5xQcgBqoykSHhmDJLYp87SgVSNhYrvnz');
-    assert.strictEqual(w._getExternalAddressByIndex(1), '3GkEXFYUifSmQ9SgzJDWL37pjMj4LT6vbq');
-    assert.strictEqual(w._getInternalAddressByIndex(0), '365MagKko4t7L9XPXSYGkFj23dknTCx4UW');
-    assert.strictEqual(w._getInternalAddressByIndex(1), '36j8Qx6vxUknTxGFa5yYuxifEK9PGPEKso');
-    assert.strictEqual(w._getInternalAddressByIndex(3), '3PmqRLiPnBXhdYGN6mAHChXLPvw8wb3Yt8');
-    assert.ok(!w.isWrappedSegwit());
-    assert.ok(!w.isNativeSegwit());
-    assert.ok(w.isLegacy());
+    expect(w._getExternalAddressByIndex(0)).toBe('3J5xQcgBqoykSHhmDJLYp87SgVSNhYrvnz');
+    expect(w._getExternalAddressByIndex(1)).toBe('3GkEXFYUifSmQ9SgzJDWL37pjMj4LT6vbq');
+    expect(w._getInternalAddressByIndex(0)).toBe('365MagKko4t7L9XPXSYGkFj23dknTCx4UW');
+    expect(w._getInternalAddressByIndex(1)).toBe('36j8Qx6vxUknTxGFa5yYuxifEK9PGPEKso');
+    expect(w._getInternalAddressByIndex(3)).toBe('3PmqRLiPnBXhdYGN6mAHChXLPvw8wb3Yt8');
+    expect(!w.isWrappedSegwit()).toBeTruthy();
+    expect(!w.isNativeSegwit()).toBeTruthy();
+    expect(w.isLegacy()).toBeTruthy();
 
     // transaction is gona be signed with both keys
     const { tx, psbt } = w.createTransaction(
@@ -282,19 +272,17 @@ describe('multisig-wallet (p2sh)', () => {
       false,
       false,
     );
-    assert.ok(tx);
-    assert.ok(psbt);
+    expect(tx).toBeTruthy();
+    expect(psbt).toBeTruthy();
 
-    assert.throws(() => psbt.finalizeAllInputs()); // throws as it is already finalized
-    assert.strictEqual(w.calculateHowManySignaturesWeHaveFromPsbt(psbt), 2);
+    expect(() => psbt.finalizeAllInputs()).toThrow(); // throws as it is already finalized
+    expect(w.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(2);
 
-    assert.strictEqual(
-      psbt.toBase64(),
+    expect(psbt.toBase64()).toBe(
       'cHNidP8BAFUCAAAAASPuAITGfKAeBZpHhacERdEkiJPJUoiW651RcTwZpeozAQAAAAAAAACAATxPAQAAAAAAGXapFBkSnVPmMZuvGdugWb6tFm35Crj1iKwAAAAAAAEA/U4BAgAAAAHs3v0OYyaLVPrhDHNhXcx/QOAxDdSJhskLo0wLfCIKYwAAAADZAEcwRAIgO8TLM5UQMxCQ6PvmX8HlENakEvje4Qh57mXvYn09dbMCIBc3Ki9MuokzfTqiCHyy2AO2snXCtxILQiKYz5frv/5EAUcwRAIgKsSNQmI+mI4DhicRNZTjbDwOnEBpeS7zhXORBc+EPJ0CIHIvMtZNb5GlkyXRxJTMTQz4rlBsDLJcRkQtuhy2XhVtAUdSIQLiqUBWbK3kx243MzI/oJj2ltjKVozfzRPbd9EwhVem6CEDDOM3DUxkh9VSu/PGjyYAcLDIUydtEuJYP9yZAvJiSI1SrgAAAIACECcAAAAAAAAZdqkUGRKdU+Yxm68Z26BZvq0WbfkKuPWIrLxWAQAAAAAAF6kU8jwURI869VV4JqztQuqecVidzkmHAAAAAAEH2gBIMEUCIQDiNd/+7jidaMNr62dXs0PaHebV/u/XeOin63Jvb8r0vQIgc48RIH515lkuia5Mo6cgSBJzhSCDX8EJqE8jjrFbiaYBRzBEAiBhF7Q0mzTS/KF9YAvGbnWpwOjFot1cwjITOS8GkWk1wQIgWvvztERtgktCQIAy1qm3ON7iknfmCuXLiwheD/xZeVcBR1IhAoJkVao8TQcPGdH2rhAUNLNEoDTaWVlIZXZEEk77O3NoIQOJYtHCrnVaHKX4kVFrtjn9dVGJENMKTTOYLAY/aCS3rFKuAAA=',
     );
 
-    assert.strictEqual(
-      psbt.extractTransaction().toHex(),
+    expect(psbt.extractTransaction().toHex()).toBe(
       '020000000123ee0084c67ca01e059a4785a70445d1248893c9528896eb9d51713c19a5ea3301000000da00483045022100e235dffeee389d68c36beb6757b343da1de6d5feefd778e8a7eb726f6fcaf4bd0220738f11207e75e6592e89ae4ca3a7204812738520835fc109a84f238eb15b89a60147304402206117b4349b34d2fca17d600bc66e75a9c0e8c5a2dd5cc23213392f06916935c102205afbf3b4446d824b42408032d6a9b738dee29277e60ae5cb8b085e0ffc5979570147522102826455aa3c4d070f19d1f6ae101434b344a034da595948657644124efb3b736821038962d1c2ae755a1ca5f891516bb639fd75518910d30a4d33982c063f6824b7ac52ae00000080013c4f0100000000001976a91419129d53e6319baf19dba059bead166df90ab8f588ac00000000',
     );
   });
@@ -313,31 +301,29 @@ describe('multisig-wallet (wrapped segwit)', () => {
   it('basic operations work', async () => {
     const w = new MultisigHDWallet();
     w.setSecret(txtFileFormatMultisigWrappedSegwit);
-    assert.strictEqual(w.getDerivationPath(), "m/48'/0'/0'/1'");
-    assert.strictEqual(w.getM(), 2);
-    assert.strictEqual(w.getN(), 2);
-    assert.strictEqual(w.howManySignaturesCanWeMake(), 0);
-    assert.strictEqual(
-      w.getCosigner(1),
+    expect(w.getDerivationPath()).toBe("m/48'/0'/0'/1'");
+    expect(w.getM()).toBe(2);
+    expect(w.getN()).toBe(2);
+    expect(w.howManySignaturesCanWeMake()).toBe(0);
+    expect(w.getCosigner(1)).toBe(
       'Ypub6jtUX12KGcqFosZWP4YcHc9qbKRTvgBpb8aE58hsYqby3SQVTr5KGfMmdMg38ekmQ9iLhCdgbAbjih7AWSkA7pgRhiLfah3zT6u1PFvVEbc',
     );
-    assert.strictEqual(
-      w.getCosigner(2),
+    expect(w.getCosigner(2)).toBe(
       'Ypub6kvtvTZpqGuWtQfg9bL5xe4vDWtwsirR8LzDvsY3vgXvyncW1NGXCUJ9Ps7CiizSSLV6NnnXSYyVDnxCu26QChWzWLg5YCAHam6cYjGtzRz',
     );
-    assert.strictEqual(w.getCosignerForFingerprint(fp1cobo), w.getCosigner(1));
-    assert.strictEqual(w.getCosignerForFingerprint(fp2coldcard), w.getCosigner(2));
-    assert.strictEqual(w.getFingerprint(1), fp1cobo);
-    assert.strictEqual(w.getFingerprint(2), fp2coldcard);
-    assert.strictEqual(w.getFormat(), MultisigHDWallet.FORMAT_P2SH_P2WSH);
+    expect(w.getCosignerForFingerprint(fp1cobo)).toBe(w.getCosigner(1));
+    expect(w.getCosignerForFingerprint(fp2coldcard)).toBe(w.getCosigner(2));
+    expect(w.getFingerprint(1)).toBe(fp1cobo);
+    expect(w.getFingerprint(2)).toBe(fp2coldcard);
+    expect(w.getFormat()).toBe(MultisigHDWallet.FORMAT_P2SH_P2WSH);
 
-    assert.strictEqual(w._getExternalAddressByIndex(0), '38xA38nfy649CC2JjjZj1CYAhtrcRc67dk');
-    assert.strictEqual(w._getExternalAddressByIndex(1), '35ixkuzbrLb7Pr3j89uVYvYPe3jKSrbeB3');
-    assert.strictEqual(w._getInternalAddressByIndex(0), '35yBZiSz9aBCz7HcobJzYpsuKhcgJ1Vrnd');
-    assert.strictEqual(w._getInternalAddressByIndex(1), '36uoZnudzSSUryHmWyNy3xfChmzvK35AL9');
-    assert.ok(w.isWrappedSegwit());
-    assert.ok(!w.isNativeSegwit());
-    assert.ok(!w.isLegacy());
+    expect(w._getExternalAddressByIndex(0)).toBe('38xA38nfy649CC2JjjZj1CYAhtrcRc67dk');
+    expect(w._getExternalAddressByIndex(1)).toBe('35ixkuzbrLb7Pr3j89uVYvYPe3jKSrbeB3');
+    expect(w._getInternalAddressByIndex(0)).toBe('35yBZiSz9aBCz7HcobJzYpsuKhcgJ1Vrnd');
+    expect(w._getInternalAddressByIndex(1)).toBe('36uoZnudzSSUryHmWyNy3xfChmzvK35AL9');
+    expect(w.isWrappedSegwit()).toBeTruthy();
+    expect(!w.isNativeSegwit()).toBeTruthy();
+    expect(!w.isLegacy()).toBeTruthy();
   });
 
   it('can coordinate tx creation', async () => {
@@ -369,14 +355,13 @@ describe('multisig-wallet (wrapped segwit)', () => {
       false,
       false,
     );
-    assert.ok(!tx, 'tx should not be provided when PSBT is only partially signed');
+    expect(!tx).toBeTruthy();
 
-    assert.strictEqual(w.calculateHowManySignaturesWeHaveFromPsbt(psbt), 0);
-    assert.ok(w.calculateFeeFromPsbt(psbt) < 3000);
-    assert.ok(w.calculateFeeFromPsbt(psbt) > 0);
+    expect(w.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(0);
+    expect(w.calculateFeeFromPsbt(psbt) < 3000).toBeTruthy();
+    expect(w.calculateFeeFromPsbt(psbt) > 0).toBeTruthy();
 
-    assert.strictEqual(
-      psbt.toBase64(),
+    expect(psbt.toBase64()).toBe(
       'cHNidP8BAHICAAAAAY7x3PvXW/LHFETXUFwliCB5Q7S9c34oqZSw9RcFY2/jAAAAAAAAAACAAhAnAAAAAAAAFgAU/cPeWXWo+efWvANS+4VAg/i3hLG8VgEAAAAAABepFO7ireZCjVtHj35I/Nl7BehvwLUehwAAAAAAAQDfAgAAAAABAZbTXp+PF26DiVo/6VlaYkXfurKNarZ7N5L9XeIuH2tmAQAAAAAAAACAAqCGAQAAAAAAF6kUT6XkkUken/ekoaz60TsfQDlKgHWHzB4EAAAAAAAWABQmZCUojIsrD/kPLP+2MPF0seGRVgJHMEQCICekZ709Sus9fjfZ4SGAFuBq0NXVXONvKFLcaF5CYdX7AiAGrLPk7LbIuIetlIk6i0R6cAOjTAQihk0kA0k9irB/1gEhAil0OX3KlYIyGBpxdADcMWKbTarYfh4xTjsC3QWeiBQQAAAAAAEBIKCGAQAAAAAAF6kUT6XkkUken/ekoaz60TsfQDlKgHWHAQQiACDPTtxNIhrXXpN96Ge4RqNg6G5S2ekVWeRIxC6lrW7xpgEFR1IhAs4nrGikNjRB6wBod7xyiPlsajHLe784+TGSBSn1La1FIQNdxFn6ZgrWx54rXwjY8th8oxuC1GGaYJuwUCPwiHLvMlKuIgYCziesaKQ2NEHrAGh3vHKI+WxqMct7vzj5MZIFKfUtrUUcFo3WAzAAAIAAAACAAAAAgAEAAIAAAAAAAAAAACIGA13EWfpmCtbHnitfCNjy2HyjG4LUYZpgm7BQI/CIcu8yHNN+rYgwAACAAAAAgAAAAIABAACAAAAAAAAAAAAAAAEAIgAgmEK/lrkZU6YPI0E7hA3gl4FCIJrzjUCO1HWnberBUHMBAUdSIQJiYhkhelPzRR4CoVURPwwFCiw4bloiKfu5PeiBcpsoBiEDu+RSG3dUJUlQnENUxiTZbrK1Nfe7LV+YDo2tmbD+GOBSriICAmJiGSF6U/NFHgKhVRE/DAUKLDhuWiIp+7k96IFymygGHNN+rYgwAACAAAAAgAAAAIABAACAAQAAAAMAAAAiAgO75FIbd1QlSVCcQ1TGJNlusrU197stX5gOja2ZsP4Y4BwWjdYDMAAAgAAAAIAAAACAAQAAgAEAAAADAAAAAA==',
     );
 
@@ -398,8 +383,7 @@ describe('multisig-wallet (wrapped segwit)', () => {
 
     psbt.combine(psbtFromCobo);
     const txhex = psbt.finalizeAllInputs().extractTransaction().toHex();
-    assert.strictEqual(
-      txhex,
+    expect(txhex).toBe(
       '020000000001018ef1dcfbd75bf2c71444d7505c2588207943b4bd737e28a994b0f51705636fe30000000023220020cf4edc4d221ad75e937de867b846a360e86e52d9e91559e448c42ea5ad6ef1a600000080021027000000000000160014fdc3de5975a8f9e7d6bc0352fb854083f8b784b1bc5601000000000017a914eee2ade6428d5b478f7e48fcd97b05e86fc0b51e87040047304402206a5b6a616789ce1732e347382f00ba5426b94cd5744fbaeda58e642d25c304090220752c80fe2de242f3b6cbed4d301ad01fccb6a1f2249ccb0a4887356b548ae87f0147304402204de21ef3bf7667a55f3ec26f01a0be8520cee0c9fc3ea3a2a64c1f58c7b9f8bc02205f430cd762561cd2c97394b452b81a729e68430468316d12fef6e7561e63ed080147522102ce27ac68a4363441eb006877bc7288f96c6a31cb7bbf38f931920529f52dad4521035dc459fa660ad6c79e2b5f08d8f2d87ca31b82d4619a609bb05023f08872ef3252ae00000000',
     );
   });
@@ -430,21 +414,20 @@ describe('multisig-wallet (wrapped segwit)', () => {
     w.setDerivationPath(path);
     w.setM(2);
 
-    assert.strictEqual(
-      w.convertXpubToMultisignatureXpub(MultisigHDWallet.seedToXpub(process.env.MNEMONICS_COLDCARD, path)),
+    expect(w.convertXpubToMultisignatureXpub(MultisigHDWallet.seedToXpub(process.env.MNEMONICS_COLDCARD, path))).toBe(
       'Ypub6kvtvTZpqGuWtQfg9bL5xe4vDWtwsirR8LzDvsY3vgXvyncW1NGXCUJ9Ps7CiizSSLV6NnnXSYyVDnxCu26QChWzWLg5YCAHam6cYjGtzRz',
     );
-    assert.strictEqual(w.getCosignerForFingerprint(fp1cobo), w.getCosigner(1));
-    assert.strictEqual(w.getCosignerForFingerprint(fp2coldcard), w.getCosigner(2));
-    assert.strictEqual(w._getExternalAddressByIndex(0), '38xA38nfy649CC2JjjZj1CYAhtrcRc67dk');
-    assert.strictEqual(w._getExternalAddressByIndex(1), '35ixkuzbrLb7Pr3j89uVYvYPe3jKSrbeB3');
-    assert.strictEqual(w._getInternalAddressByIndex(0), '35yBZiSz9aBCz7HcobJzYpsuKhcgJ1Vrnd');
-    assert.strictEqual(w._getInternalAddressByIndex(1), '36uoZnudzSSUryHmWyNy3xfChmzvK35AL9');
-    assert.strictEqual(w._getInternalAddressByIndex(3), '3PU8J9pdiKAMsLnrhyrG7RZ4LZiTURQp5r');
-    assert.strictEqual(w.howManySignaturesCanWeMake(), 1);
-    assert.ok(w.isWrappedSegwit());
-    assert.ok(!w.isNativeSegwit());
-    assert.ok(!w.isLegacy());
+    expect(w.getCosignerForFingerprint(fp1cobo)).toBe(w.getCosigner(1));
+    expect(w.getCosignerForFingerprint(fp2coldcard)).toBe(w.getCosigner(2));
+    expect(w._getExternalAddressByIndex(0)).toBe('38xA38nfy649CC2JjjZj1CYAhtrcRc67dk');
+    expect(w._getExternalAddressByIndex(1)).toBe('35ixkuzbrLb7Pr3j89uVYvYPe3jKSrbeB3');
+    expect(w._getInternalAddressByIndex(0)).toBe('35yBZiSz9aBCz7HcobJzYpsuKhcgJ1Vrnd');
+    expect(w._getInternalAddressByIndex(1)).toBe('36uoZnudzSSUryHmWyNy3xfChmzvK35AL9');
+    expect(w._getInternalAddressByIndex(3)).toBe('3PU8J9pdiKAMsLnrhyrG7RZ4LZiTURQp5r');
+    expect(w.howManySignaturesCanWeMake()).toBe(1);
+    expect(w.isWrappedSegwit()).toBeTruthy();
+    expect(!w.isNativeSegwit()).toBeTruthy();
+    expect(!w.isLegacy()).toBeTruthy();
 
     // transaction is gona be partially signed because we have one of two signing keys
     const { psbt, tx } = w.createTransaction(
@@ -455,11 +438,10 @@ describe('multisig-wallet (wrapped segwit)', () => {
       false,
       false,
     );
-    assert.ok(!tx, 'tx should not be provided when PSBT is only partially signed');
-    assert.strictEqual(w.calculateHowManySignaturesWeHaveFromPsbt(psbt), 1);
+    expect(!tx).toBeTruthy();
+    expect(w.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(1);
 
-    assert.strictEqual(
-      psbt.toBase64(),
+    expect(psbt.toBase64()).toBe(
       'cHNidP8BAHUCAAAAAY7x3PvXW/LHFETXUFwliCB5Q7S9c34oqZSw9RcFY2/jAAAAAAAAAACAAhAnAAAAAAAAGXapFBkSnVPmMZuvGdugWb6tFm35Crj1iKy8VgEAAAAAABepFO7ireZCjVtHj35I/Nl7BehvwLUehwAAAAAAAQDfAgAAAAABAZbTXp+PF26DiVo/6VlaYkXfurKNarZ7N5L9XeIuH2tmAQAAAAAAAACAAqCGAQAAAAAAF6kUT6XkkUken/ekoaz60TsfQDlKgHWHzB4EAAAAAAAWABQmZCUojIsrD/kPLP+2MPF0seGRVgJHMEQCICekZ709Sus9fjfZ4SGAFuBq0NXVXONvKFLcaF5CYdX7AiAGrLPk7LbIuIetlIk6i0R6cAOjTAQihk0kA0k9irB/1gEhAil0OX3KlYIyGBpxdADcMWKbTarYfh4xTjsC3QWeiBQQAAAAAAEBIKCGAQAAAAAAF6kUT6XkkUken/ekoaz60TsfQDlKgHWHIgICziesaKQ2NEHrAGh3vHKI+WxqMct7vzj5MZIFKfUtrUVHMEQCIHgfpvZsDT4VkHSxGL5nGcRpP55V4r7jmNRj4vr85NNXAiBio79Ta0Tr9skEiLJ/hXnNFR+3ZdRcpFRX59HIqGmorQEBBCIAIM9O3E0iGtdek33oZ7hGo2DoblLZ6RVZ5EjELqWtbvGmAQVHUiECziesaKQ2NEHrAGh3vHKI+WxqMct7vzj5MZIFKfUtrUUhA13EWfpmCtbHnitfCNjy2HyjG4LUYZpgm7BQI/CIcu8yUq4iBgLOJ6xopDY0QesAaHe8coj5bGoxy3u/OPkxkgUp9S2tRRwWjdYDMAAAgAAAAIAAAACAAQAAgAAAAAAAAAAAIgYDXcRZ+mYK1seeK18I2PLYfKMbgtRhmmCbsFAj8Ihy7zIc036tiDAAAIAAAACAAAAAgAEAAIAAAAAAAAAAAAAAAQAiACCYQr+WuRlTpg8jQTuEDeCXgUIgmvONQI7Udadt6sFQcwEBR1IhAmJiGSF6U/NFHgKhVRE/DAUKLDhuWiIp+7k96IFymygGIQO75FIbd1QlSVCcQ1TGJNlusrU197stX5gOja2ZsP4Y4FKuIgICYmIZIXpT80UeAqFVET8MBQosOG5aIin7uT3ogXKbKAYc036tiDAAAIAAAACAAAAAgAEAAIABAAAAAwAAACICA7vkUht3VCVJUJxDVMYk2W6ytTX3uy1fmA6NrZmw/hjgHBaN1gMwAACAAAAAgAAAAIABAACAAQAAAAMAAAAA',
     );
 
@@ -473,8 +455,7 @@ describe('multisig-wallet (wrapped segwit)', () => {
     const psbtFromCobo = bitcoin.Psbt.fromHex(payload);
     psbt.combine(psbtFromCobo);
     const tx2 = psbt.finalizeAllInputs().extractTransaction();
-    assert.strictEqual(
-      tx2.toHex(),
+    expect(tx2.toHex()).toBe(
       '020000000001018ef1dcfbd75bf2c71444d7505c2588207943b4bd737e28a994b0f51705636fe30000000023220020cf4edc4d221ad75e937de867b846a360e86e52d9e91559e448c42ea5ad6ef1a6000000800210270000000000001976a91419129d53e6319baf19dba059bead166df90ab8f588acbc5601000000000017a914eee2ade6428d5b478f7e48fcd97b05e86fc0b51e8704004730440220781fa6f66c0d3e159074b118be6719c4693f9e55e2bee398d463e2fafce4d357022062a3bf536b44ebf6c90488b27f8579cd151fb765d45ca45457e7d1c8a869a8ad0147304402205514802a84c3993ed37d73b6734b743ab7c56dad8788e90ab27cc2f305f9faf602200b06aefbb74085265b5103a0f886b7952f7b1277b111c24526285aa6e1256bc40147522102ce27ac68a4363441eb006877bc7288f96c6a31cb7bbf38f931920529f52dad4521035dc459fa660ad6c79e2b5f08d8f2d87ca31b82d4619a609bb05023f08872ef3252ae00000000',
     );
   });
@@ -505,21 +486,20 @@ describe('multisig-wallet (wrapped segwit)', () => {
     w.setDerivationPath(path);
     w.setM(2);
 
-    assert.strictEqual(
-      w.convertXpubToMultisignatureXpub(MultisigHDWallet.seedToXpub(process.env.MNEMONICS_COLDCARD, path)),
+    expect(w.convertXpubToMultisignatureXpub(MultisigHDWallet.seedToXpub(process.env.MNEMONICS_COLDCARD, path))).toBe(
       'Ypub6kvtvTZpqGuWtQfg9bL5xe4vDWtwsirR8LzDvsY3vgXvyncW1NGXCUJ9Ps7CiizSSLV6NnnXSYyVDnxCu26QChWzWLg5YCAHam6cYjGtzRz',
     );
-    assert.strictEqual(w.getCosignerForFingerprint(fp1cobo), w.getCosigner(1));
-    assert.strictEqual(w.getCosignerForFingerprint(fp2coldcard), w.getCosigner(2));
-    assert.strictEqual(w._getExternalAddressByIndex(0), '38xA38nfy649CC2JjjZj1CYAhtrcRc67dk');
-    assert.strictEqual(w._getExternalAddressByIndex(1), '35ixkuzbrLb7Pr3j89uVYvYPe3jKSrbeB3');
-    assert.strictEqual(w._getInternalAddressByIndex(0), '35yBZiSz9aBCz7HcobJzYpsuKhcgJ1Vrnd');
-    assert.strictEqual(w._getInternalAddressByIndex(1), '36uoZnudzSSUryHmWyNy3xfChmzvK35AL9');
-    assert.strictEqual(w._getInternalAddressByIndex(3), '3PU8J9pdiKAMsLnrhyrG7RZ4LZiTURQp5r');
-    assert.strictEqual(w.howManySignaturesCanWeMake(), 1);
-    assert.ok(w.isWrappedSegwit());
-    assert.ok(!w.isNativeSegwit());
-    assert.ok(!w.isLegacy());
+    expect(w.getCosignerForFingerprint(fp1cobo)).toBe(w.getCosigner(1));
+    expect(w.getCosignerForFingerprint(fp2coldcard)).toBe(w.getCosigner(2));
+    expect(w._getExternalAddressByIndex(0)).toBe('38xA38nfy649CC2JjjZj1CYAhtrcRc67dk');
+    expect(w._getExternalAddressByIndex(1)).toBe('35ixkuzbrLb7Pr3j89uVYvYPe3jKSrbeB3');
+    expect(w._getInternalAddressByIndex(0)).toBe('35yBZiSz9aBCz7HcobJzYpsuKhcgJ1Vrnd');
+    expect(w._getInternalAddressByIndex(1)).toBe('36uoZnudzSSUryHmWyNy3xfChmzvK35AL9');
+    expect(w._getInternalAddressByIndex(3)).toBe('3PU8J9pdiKAMsLnrhyrG7RZ4LZiTURQp5r');
+    expect(w.howManySignaturesCanWeMake()).toBe(1);
+    expect(w.isWrappedSegwit()).toBeTruthy();
+    expect(!w.isNativeSegwit()).toBeTruthy();
+    expect(!w.isLegacy()).toBeTruthy();
 
     // transaction is gona be partially signed because we have one of two signing keys
     const { psbt, tx } = w.createTransaction(
@@ -530,10 +510,9 @@ describe('multisig-wallet (wrapped segwit)', () => {
       false,
       false,
     );
-    assert.ok(!tx, 'tx should not be provided when PSBT is only partially signed');
+    expect(!tx).toBeTruthy();
 
-    assert.strictEqual(
-      psbt.toBase64(),
+    expect(psbt.toBase64()).toBe(
       'cHNidP8BAFUCAAAAAWTtb7gbP6DkliMMy/ggSXgZ5tKHX1g/J8vLbx28FNYxAQAAAAAAAACAATxPAQAAAAAAGXapFBkSnVPmMZuvGdugWb6tFm35Crj1iKwAAAAAAAEA/XQBAgAAAAABAY7x3PvXW/LHFETXUFwliCB5Q7S9c34oqZSw9RcFY2/jAAAAACMiACDPTtxNIhrXXpN96Ge4RqNg6G5S2ekVWeRIxC6lrW7xpgAAAIACECcAAAAAAAAZdqkUGRKdU+Yxm68Z26BZvq0WbfkKuPWIrLxWAQAAAAAAF6kU7uKt5kKNW0ePfkj82XsF6G/AtR6HBABHMEQCIHgfpvZsDT4VkHSxGL5nGcRpP55V4r7jmNRj4vr85NNXAiBio79Ta0Tr9skEiLJ/hXnNFR+3ZdRcpFRX59HIqGmorQFHMEQCIH4T/iMhq4uA89QVso43oRIk/5ucr4vnENDzD0GTmrPfAiADHadz0N0T+ZsMfjPnyy28WvSAzyGeeTPAku6zVHh/eAFHUiECziesaKQ2NEHrAGh3vHKI+WxqMct7vzj5MZIFKfUtrUUhA13EWfpmCtbHnitfCNjy2HyjG4LUYZpgm7BQI/CIcu8yUq4AAAAAAQEgvFYBAAAAAAAXqRTu4q3mQo1bR49+SPzZewXob8C1HociAgO75FIbd1QlSVCcQ1TGJNlusrU197stX5gOja2ZsP4Y4EgwRQIhAP3v+3DseVI63T8N9TGi3j9mQvjkIFZTUu0aeQbRhm+NAiASJatbXcK+36jF34Eeg5Hvy+vx+Q5bNB3tJWWBS3tqDAEBBCIAIJhCv5a5GVOmDyNBO4QN4JeBQiCa841AjtR1p23qwVBzAQVHUiECYmIZIXpT80UeAqFVET8MBQosOG5aIin7uT3ogXKbKAYhA7vkUht3VCVJUJxDVMYk2W6ytTX3uy1fmA6NrZmw/hjgUq4iBgJiYhkhelPzRR4CoVURPwwFCiw4bloiKfu5PeiBcpsoBhzTfq2IMAAAgAAAAIAAAACAAQAAgAEAAAADAAAAIgYDu+RSG3dUJUlQnENUxiTZbrK1Nfe7LV+YDo2tmbD+GOAcFo3WAzAAAIAAAACAAAAAgAEAAIABAAAAAwAAAAAA',
     );
 
@@ -546,8 +525,7 @@ describe('multisig-wallet (wrapped segwit)', () => {
     const psbtFromCobo = bitcoin.Psbt.fromHex(payload);
     psbt.combine(psbtFromCobo);
     const tx2 = psbt.finalizeAllInputs().extractTransaction();
-    assert.strictEqual(
-      tx2.toHex(),
+    expect(tx2.toHex()).toBe(
       '0200000000010164ed6fb81b3fa0e496230ccbf820497819e6d2875f583f27cbcb6f1dbc14d63101000000232200209842bf96b91953a60f23413b840de0978142209af38d408ed475a76deac1507300000080013c4f0100000000001976a91419129d53e6319baf19dba059bead166df90ab8f588ac0400473044022045d8d508f51e6faeaebe164d279bafaeb00dd95391776fa44f96bbe587ed5e2d0220767bdacc4b25d17fab44c09b45cf47ed358038752c49af346940ff57a95a748301483045022100fdeffb70ec79523add3f0df531a2de3f6642f8e420565352ed1a7906d1866f8d02201225ab5b5dc2bedfa8c5df811e8391efcbebf1f90e5b341ded2565814b7b6a0c0147522102626219217a53f3451e02a155113f0c050a2c386e5a2229fbb93de881729b28062103bbe4521b77542549509c4354c624d96eb2b535f7bb2d5f980e8dad99b0fe18e052ae00000000',
     );
   });
@@ -566,26 +544,26 @@ describe('multisig-wallet (native segwit)', () => {
   it('can sort buffers', async () => {
     let sorted;
     sorted = MultisigHDWallet.sortBuffers([Buffer.from('10', 'hex'), Buffer.from('0011', 'hex')]);
-    assert.strictEqual(sorted[0].toString('hex'), '0011');
-    assert.strictEqual(sorted[1].toString('hex'), '10');
+    expect(sorted[0].toString('hex')).toBe('0011');
+    expect(sorted[1].toString('hex')).toBe('10');
 
     sorted = MultisigHDWallet.sortBuffers([
       Buffer.from('022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da', 'hex'),
       Buffer.from('03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9', 'hex'),
       Buffer.from('021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18', 'hex'),
     ]);
-    assert.strictEqual(sorted[0].toString('hex'), '021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18');
-    assert.strictEqual(sorted[1].toString('hex'), '022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da');
-    assert.strictEqual(sorted[2].toString('hex'), '03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9');
+    expect(sorted[0].toString('hex')).toBe('021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18');
+    expect(sorted[1].toString('hex')).toBe('022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da');
+    expect(sorted[2].toString('hex')).toBe('03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9');
 
     sorted = MultisigHDWallet.sortBuffers([
       Buffer.from('02632b12f4ac5b1d1b72b2a3b508c19172de44f6f46bcee50ba33f3f9291e47ed0', 'hex'),
       Buffer.from('027735a29bae7780a9755fae7a1c4374c656ac6a69ea9f3697fda61bb99a4f3e77', 'hex'),
       Buffer.from('02e2cc6bd5f45edd43bebe7cb9b675f0ce9ed3efe613b177588290ad188d11b404', 'hex'),
     ]);
-    assert.strictEqual(sorted[0].toString('hex'), '02632b12f4ac5b1d1b72b2a3b508c19172de44f6f46bcee50ba33f3f9291e47ed0');
-    assert.strictEqual(sorted[1].toString('hex'), '027735a29bae7780a9755fae7a1c4374c656ac6a69ea9f3697fda61bb99a4f3e77');
-    assert.strictEqual(sorted[2].toString('hex'), '02e2cc6bd5f45edd43bebe7cb9b675f0ce9ed3efe613b177588290ad188d11b404');
+    expect(sorted[0].toString('hex')).toBe('02632b12f4ac5b1d1b72b2a3b508c19172de44f6f46bcee50ba33f3f9291e47ed0');
+    expect(sorted[1].toString('hex')).toBe('027735a29bae7780a9755fae7a1c4374c656ac6a69ea9f3697fda61bb99a4f3e77');
+    expect(sorted[2].toString('hex')).toBe('02e2cc6bd5f45edd43bebe7cb9b675f0ce9ed3efe613b177588290ad188d11b404');
 
     sorted = MultisigHDWallet.sortBuffers([
       Buffer.from('030000000000000000000000000000000000004141414141414141414141414141', 'hex'),
@@ -593,59 +571,55 @@ describe('multisig-wallet (native segwit)', () => {
       Buffer.from('020000000000000000000000000000000000004141414141414141414141414140', 'hex'),
       Buffer.from('030000000000000000000000000000000000004141414141414141414141414140', 'hex'),
     ]);
-    assert.strictEqual(sorted[0].toString('hex'), '020000000000000000000000000000000000004141414141414141414141414140');
-    assert.strictEqual(sorted[1].toString('hex'), '020000000000000000000000000000000000004141414141414141414141414141');
-    assert.strictEqual(sorted[2].toString('hex'), '030000000000000000000000000000000000004141414141414141414141414140');
-    assert.strictEqual(sorted[3].toString('hex'), '030000000000000000000000000000000000004141414141414141414141414141');
+    expect(sorted[0].toString('hex')).toBe('020000000000000000000000000000000000004141414141414141414141414140');
+    expect(sorted[1].toString('hex')).toBe('020000000000000000000000000000000000004141414141414141414141414141');
+    expect(sorted[2].toString('hex')).toBe('030000000000000000000000000000000000004141414141414141414141414140');
+    expect(sorted[3].toString('hex')).toBe('030000000000000000000000000000000000004141414141414141414141414141');
 
     sorted = MultisigHDWallet.sortBuffers([
       Buffer.from('02ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f8', 'hex'),
       Buffer.from('02fe6f0a5a297eb38c391581c4413e084773ea23954d93f7753db7dc0adc188b2f', 'hex'),
     ]);
-    assert.strictEqual(
-      sorted[0].toString('hex'),
-      '02fe6f0a5a297eb38c391581c4413e084773ea23954d93f7753db7dc0adc188b2f',
-      JSON.stringify(sorted),
-    );
-    assert.strictEqual(sorted[1].toString('hex'), '02ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f8');
+    expect(sorted[0].toString('hex')).toBe('02fe6f0a5a297eb38c391581c4413e084773ea23954d93f7753db7dc0adc188b2f');
+    expect(sorted[1].toString('hex')).toBe('02ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f8');
   });
 
   it('some validations work', () => {
-    assert.ok(MultisigHDWallet.isXpubValid(Zpub1));
-    assert.ok(!MultisigHDWallet.isXpubValid('invalid'));
-    assert.ok(!MultisigHDWallet.isXpubValid('xpubinvalid'));
-    assert.ok(!MultisigHDWallet.isXpubValid('ypubinvalid'));
-    assert.ok(!MultisigHDWallet.isXpubValid('Zpubinvalid'));
+    expect(MultisigHDWallet.isXpubValid(Zpub1)).toBeTruthy();
+    expect(!MultisigHDWallet.isXpubValid('invalid')).toBeTruthy();
+    expect(!MultisigHDWallet.isXpubValid('xpubinvalid')).toBeTruthy();
+    expect(!MultisigHDWallet.isXpubValid('ypubinvalid')).toBeTruthy();
+    expect(!MultisigHDWallet.isXpubValid('Zpubinvalid')).toBeTruthy();
 
-    assert.ok(MultisigHDWallet.isPathValid("m/45'"));
-    assert.ok(MultisigHDWallet.isPathValid("m/48'/0'/0'/2'"));
-    assert.ok(!MultisigHDWallet.isPathValid('ROFLBOATS'));
-    assert.ok(!MultisigHDWallet.isPathValid(''));
+    expect(MultisigHDWallet.isPathValid("m/45'")).toBeTruthy();
+    expect(MultisigHDWallet.isPathValid("m/48'/0'/0'/2'")).toBeTruthy();
+    expect(!MultisigHDWallet.isPathValid('ROFLBOATS')).toBeTruthy();
+    expect(!MultisigHDWallet.isPathValid('')).toBeTruthy();
 
-    assert.ok(
+    expect(
       MultisigHDWallet.isXprvValid(
         'ZprvAkUsoZMLiqxrhaM8VpmVJ6QhjH4dZnYpTNNHGMZ3VoE6vRv7xfDeMEiKAeH1eUcN3CFUP87CgM1anM2UytMkykUMtVmXkkohRsiVGth1VMG',
       ),
-    );
-    assert.ok(!MultisigHDWallet.isXprvValid(''));
-    assert.ok(!MultisigHDWallet.isXprvValid('Zprvlabla'));
-    assert.ok(!MultisigHDWallet.isXprvValid('xprvblabla'));
-    assert.ok(
+    ).toBeTruthy();
+    expect(!MultisigHDWallet.isXprvValid('')).toBeTruthy();
+    expect(!MultisigHDWallet.isXprvValid('Zprvlabla')).toBeTruthy();
+    expect(!MultisigHDWallet.isXprvValid('xprvblabla')).toBeTruthy();
+    expect(
       !MultisigHDWallet.isXprvValid(
         'xprv9tpBCBeAwBnVgYroSvicqDR2XhAj6sth3idqBWhRqnrq99x17WZvZHQup679rXc3ndPLN3fwbpLkv4WTQhfhZN89B2NbTMmYFePPPHJ5jVP',
       ),
-    ); // invalid fp
+    ).toBeTruthy(); // invalid fp
 
-    assert.ok(MultisigHDWallet.isFpValid(fp1cobo));
-    assert.ok(MultisigHDWallet.isFpValid(fp2coldcard));
-    assert.ok(MultisigHDWallet.isFpValid('00000000'));
-    assert.ok(MultisigHDWallet.isFpValid('DEADFEEF'));
-    assert.ok(MultisigHDWallet.isFpValid('deadbeef'));
-    assert.ok(MultisigHDWallet.isFpValid('dEaDbeEF'));
-    assert.ok(!MultisigHDWallet.isFpValid('rmjiweg3'));
-    assert.ok(!MultisigHDWallet.isFpValid('bruh'));
-    assert.ok(!MultisigHDWallet.isFpValid('0'));
-    assert.ok(!MultisigHDWallet.isFpValid('0'));
+    expect(MultisigHDWallet.isFpValid(fp1cobo)).toBeTruthy();
+    expect(MultisigHDWallet.isFpValid(fp2coldcard)).toBeTruthy();
+    expect(MultisigHDWallet.isFpValid('00000000')).toBeTruthy();
+    expect(MultisigHDWallet.isFpValid('DEADFEEF')).toBeTruthy();
+    expect(MultisigHDWallet.isFpValid('deadbeef')).toBeTruthy();
+    expect(MultisigHDWallet.isFpValid('dEaDbeEF')).toBeTruthy();
+    expect(!MultisigHDWallet.isFpValid('rmjiweg3')).toBeTruthy();
+    expect(!MultisigHDWallet.isFpValid('bruh')).toBeTruthy();
+    expect(!MultisigHDWallet.isFpValid('0')).toBeTruthy();
+    expect(!MultisigHDWallet.isFpValid('0')).toBeTruthy();
   });
 
   it('basic operations work', async () => {
@@ -656,50 +630,42 @@ describe('multisig-wallet (native segwit)', () => {
     w.addCosigner(Zpub2, fp2coldcard);
     w.setDerivationPath(path);
     w.setM(2);
-    assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
-    assert.strictEqual(w._getInternalAddressByIndex(0), 'bc1qtah0p50d4qlftn049k7lldcwh7cs3zkjy9g8xegv63p308hsh9zsf5567q');
-    assert.strictEqual(
-      w._getDerivationPathByAddressWithCustomPath(w._getExternalAddressByIndex(2), w.getDerivationPath()),
-      "m/48'/0'/0'/2'/0/2",
-    );
-    assert.strictEqual(
-      w._getDerivationPathByAddressWithCustomPath(w._getInternalAddressByIndex(3), w.getDerivationPath()),
-      "m/48'/0'/0'/2'/1/3",
-    );
-    assert.strictEqual(
-      MultisigHDWallet.seedToXpub(process.env.MNEMONICS_COLDCARD, path),
+    expect(w._getExternalAddressByIndex(0)).toBe('bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
+    expect(w._getInternalAddressByIndex(0)).toBe('bc1qtah0p50d4qlftn049k7lldcwh7cs3zkjy9g8xegv63p308hsh9zsf5567q');
+    expect(w._getDerivationPathByAddressWithCustomPath(w._getExternalAddressByIndex(2), w.getDerivationPath())).toBe("m/48'/0'/0'/2'/0/2");
+    expect(w._getDerivationPathByAddressWithCustomPath(w._getInternalAddressByIndex(3), w.getDerivationPath())).toBe("m/48'/0'/0'/2'/1/3");
+    expect(MultisigHDWallet.seedToXpub(process.env.MNEMONICS_COLDCARD, path)).toBe(
       'xpub6FCYVZAU7dofgor9fQaqyqqA9NqBAn83iQpoayuWrwBPfwiPgCXGCD7dvAG93M5MZs5VWVP7FErGA5UeiALqaPt7KV67fL9WX9bqXTyeWxb',
     );
-    assert.strictEqual(
+    expect(
       w.convertXpubToMultisignatureXpub(
         'xpub6FCYVZAU7dofgor9fQaqyqqA9NqBAn83iQpoayuWrwBPfwiPgCXGCD7dvAG93M5MZs5VWVP7FErGA5UeiALqaPt7KV67fL9WX9bqXTyeWxb',
       ),
-      Zpub2,
-    );
-    assert.throws(() => w.addCosigner('invalid'));
-    assert.throws(() => w.addCosigner('xpubinvalid'));
-    assert.throws(() => w.addCosigner('ypubinvalid'));
-    assert.throws(() => w.addCosigner('Zpubinvalid'));
-    assert.throws(() => w.addCosigner(Zpub1, fp1cobo, 'ROFLBOATS')); // invalid path
-    assert.throws(() => w.addCosigner(Zpub1, fp1cobo)); // duplicates are not allowed
-    assert.throws(() => w.addCosigner(Zpub2, fp2coldcard)); // duplicates are not allowed
-    assert.throws(() => w.addCosigner(process.env.MNEMONICS_COBO)); // duplicates are not allowed
-    assert.throws(() => w.addCosigner(process.env.MNEMONICS_COLDCARD)); // duplicates are not allowed
+    ).toBe(Zpub2);
+    expect(() => w.addCosigner('invalid')).toThrow();
+    expect(() => w.addCosigner('xpubinvalid')).toThrow();
+    expect(() => w.addCosigner('ypubinvalid')).toThrow();
+    expect(() => w.addCosigner('Zpubinvalid')).toThrow();
+    expect(() => w.addCosigner(Zpub1, fp1cobo, 'ROFLBOATS')).toThrow(); // invalid path
+    expect(() => w.addCosigner(Zpub1, fp1cobo)).toThrow(); // duplicates are not allowed
+    expect(() => w.addCosigner(Zpub2, fp2coldcard)).toThrow(); // duplicates are not allowed
+    expect(() => w.addCosigner(process.env.MNEMONICS_COBO)).toThrow(); // duplicates are not allowed
+    expect(() => w.addCosigner(process.env.MNEMONICS_COLDCARD)).toThrow(); // duplicates are not allowed
 
-    assert.strictEqual(w.getM(), 2);
-    assert.strictEqual(w.getN(), 2);
-    assert.strictEqual(w.getDerivationPath(), path);
-    assert.strictEqual(w.getCosigner(1), Zpub1);
-    assert.strictEqual(w.getCosigner(2), Zpub2);
-    assert.strictEqual(w.getFingerprint(1), fp1cobo);
-    assert.strictEqual(w.getFingerprint(2), fp2coldcard);
-    assert.strictEqual(w.getCosignerForFingerprint(fp1cobo), Zpub1);
-    assert.strictEqual(w.getCosignerForFingerprint(fp2coldcard), Zpub2);
-    assert.strictEqual(w.howManySignaturesCanWeMake(), 0);
-    assert.ok(!w.isWrappedSegwit());
-    assert.ok(w.isNativeSegwit());
-    assert.ok(!w.isLegacy());
-    assert.strictEqual(w.getFormat(), MultisigHDWallet.FORMAT_P2WSH);
+    expect(w.getM()).toBe(2);
+    expect(w.getN()).toBe(2);
+    expect(w.getDerivationPath()).toBe(path);
+    expect(w.getCosigner(1)).toBe(Zpub1);
+    expect(w.getCosigner(2)).toBe(Zpub2);
+    expect(w.getFingerprint(1)).toBe(fp1cobo);
+    expect(w.getFingerprint(2)).toBe(fp2coldcard);
+    expect(w.getCosignerForFingerprint(fp1cobo)).toBe(Zpub1);
+    expect(w.getCosignerForFingerprint(fp2coldcard)).toBe(Zpub2);
+    expect(w.howManySignaturesCanWeMake()).toBe(0);
+    expect(!w.isWrappedSegwit()).toBeTruthy();
+    expect(w.isNativeSegwit()).toBeTruthy();
+    expect(!w.isLegacy()).toBeTruthy();
+    expect(w.getFormat()).toBe(MultisigHDWallet.FORMAT_P2WSH);
 
     // now, one of cosigners is mnemonics
 
@@ -708,26 +674,26 @@ describe('multisig-wallet (native segwit)', () => {
     w.addCosigner(process.env.MNEMONICS_COLDCARD);
     w.setDerivationPath(path);
     w.setM(2);
-    assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
-    assert.strictEqual(w._getExternalAddressByIndex(1), 'bc1qvwd2d7r46j7u9qyxpedfhe5p075sxuhzd0n6napuvvhq2u5nrmqs9ex90q');
-    assert.strictEqual(w._getInternalAddressByIndex(0), 'bc1qtah0p50d4qlftn049k7lldcwh7cs3zkjy9g8xegv63p308hsh9zsf5567q');
-    assert.strictEqual(w._getInternalAddressByIndex(1), 'bc1qv84pedzkqz2p4sd2dxm9krs0tcfatqcn73nndycaky9qttczj9qq3az9ma');
+    expect(w._getExternalAddressByIndex(0)).toBe('bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
+    expect(w._getExternalAddressByIndex(1)).toBe('bc1qvwd2d7r46j7u9qyxpedfhe5p075sxuhzd0n6napuvvhq2u5nrmqs9ex90q');
+    expect(w._getInternalAddressByIndex(0)).toBe('bc1qtah0p50d4qlftn049k7lldcwh7cs3zkjy9g8xegv63p308hsh9zsf5567q');
+    expect(w._getInternalAddressByIndex(1)).toBe('bc1qv84pedzkqz2p4sd2dxm9krs0tcfatqcn73nndycaky9qttczj9qq3az9ma');
 
-    assert.strictEqual(w.getM(), 2);
-    assert.strictEqual(w.getN(), 2);
-    assert.strictEqual(w.getDerivationPath(), path);
-    assert.strictEqual(w.getCosigner(1), Zpub1);
-    assert.strictEqual(w.getCosigner(2), process.env.MNEMONICS_COLDCARD);
-    assert.strictEqual(w.getCosignerForFingerprint(fp1cobo), Zpub1);
-    assert.strictEqual(w.getCosignerForFingerprint(fp2coldcard), process.env.MNEMONICS_COLDCARD);
-    assert.strictEqual(w.howManySignaturesCanWeMake(), 1);
+    expect(w.getM()).toBe(2);
+    expect(w.getN()).toBe(2);
+    expect(w.getDerivationPath()).toBe(path);
+    expect(w.getCosigner(1)).toBe(Zpub1);
+    expect(w.getCosigner(2)).toBe(process.env.MNEMONICS_COLDCARD);
+    expect(w.getCosignerForFingerprint(fp1cobo)).toBe(Zpub1);
+    expect(w.getCosignerForFingerprint(fp2coldcard)).toBe(process.env.MNEMONICS_COLDCARD);
+    expect(w.howManySignaturesCanWeMake()).toBe(1);
 
     // now, provide fp with mnemonics and expect that wallet wont recalculate fp, and will use provided
     w = new MultisigHDWallet();
     w.addCosigner(process.env.MNEMONICS_COLDCARD, 'DEADBABE');
     w.addCosigner(process.env.MNEMONICS_COBO);
-    assert.strictEqual(w.getFingerprint(1), 'DEADBABE');
-    assert.strictEqual(w.getCosignerForFingerprint('DEADBABE'), process.env.MNEMONICS_COLDCARD);
+    expect(w.getFingerprint(1)).toBe('DEADBABE');
+    expect(w.getCosignerForFingerprint('DEADBABE')).toBe(process.env.MNEMONICS_COLDCARD);
   });
 
   it('basic operations work for 2-of-3', async () => {
@@ -742,27 +708,26 @@ describe('multisig-wallet (native segwit)', () => {
     w.setDerivationPath(path);
     w.setM(2);
 
-    assert.strictEqual(
+    expect(
       w.convertXpubToMultisignatureXpub(
         MultisigHDWallet.seedToXpub(
           'accident olympic spawn spider cable track pluck fat code grab fine salt garment kidney crime old often worth member impulse brother smoke garden trash',
           path,
         ),
       ),
-      'Zpub74k35j5DkSA6t6SFhPeHv8ENBHdNgAPALWodSWoWxsHo6vbAu2FUGq9QmUEvdEPzBoMswizfsAbTWQYU2ZnvCjdKsFje5TEfjLxuH8arBtp',
-    );
+    ).toBe('Zpub74k35j5DkSA6t6SFhPeHv8ENBHdNgAPALWodSWoWxsHo6vbAu2FUGq9QmUEvdEPzBoMswizfsAbTWQYU2ZnvCjdKsFje5TEfjLxuH8arBtp');
 
-    assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1qnpy7c7wz6tvmhdwgyk8ka4du3s9x6uhgjal305xdatmwfa538zxsys5l0t');
-    assert.strictEqual(w._getExternalAddressByIndex(1), 'bc1qvuum7egsw4r4utzart88pergghy9rp8m4j5m4s464lz6u39sn6usn89w7c');
-    assert.strictEqual(w._getInternalAddressByIndex(0), 'bc1qatmvfj5nzh4z3njxeg8z86y592clqe7sfgvp5cpund47knnm6pxsswl2lr');
-    assert.strictEqual(w._getInternalAddressByIndex(1), 'bc1qpqa9c6nkqgcruegnh8wcsr0gzc4x9y90v9k0nxr6lww0gts430zqp7wm86');
+    expect(w._getExternalAddressByIndex(0)).toBe('bc1qnpy7c7wz6tvmhdwgyk8ka4du3s9x6uhgjal305xdatmwfa538zxsys5l0t');
+    expect(w._getExternalAddressByIndex(1)).toBe('bc1qvuum7egsw4r4utzart88pergghy9rp8m4j5m4s464lz6u39sn6usn89w7c');
+    expect(w._getInternalAddressByIndex(0)).toBe('bc1qatmvfj5nzh4z3njxeg8z86y592clqe7sfgvp5cpund47knnm6pxsswl2lr');
+    expect(w._getInternalAddressByIndex(1)).toBe('bc1qpqa9c6nkqgcruegnh8wcsr0gzc4x9y90v9k0nxr6lww0gts430zqp7wm86');
 
-    assert.strictEqual(w.getM(), 2);
-    assert.strictEqual(w.getN(), 3);
-    assert.strictEqual(w.howManySignaturesCanWeMake(), 1);
-    assert.ok(!w.isWrappedSegwit());
-    assert.ok(w.isNativeSegwit());
-    assert.ok(!w.isLegacy());
+    expect(w.getM()).toBe(2);
+    expect(w.getN()).toBe(3);
+    expect(w.howManySignaturesCanWeMake()).toBe(1);
+    expect(!w.isWrappedSegwit()).toBeTruthy();
+    expect(w.isNativeSegwit()).toBeTruthy();
+    expect(!w.isLegacy()).toBeTruthy();
   });
 
   it('can coordinate tx creation', async () => {
@@ -790,9 +755,9 @@ describe('multisig-wallet (native segwit)', () => {
     w.setDerivationPath(path);
     w.setM(2);
 
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(1), path); // not provided, so should be default
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(1), w.getDerivationPath()); // not provided, so should be default
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(2), w.getDerivationPath()); // not provided, so should be default
+    expect(w.getCustomDerivationPathForCosigner(1)).toBe(path); // not provided, so should be default
+    expect(w.getCustomDerivationPathForCosigner(1)).toBe(w.getDerivationPath()); // not provided, so should be default
+    expect(w.getCustomDerivationPathForCosigner(2)).toBe(w.getDerivationPath()); // not provided, so should be default
 
     const { psbt } = w.createTransaction(
       utxos,
@@ -803,18 +768,17 @@ describe('multisig-wallet (native segwit)', () => {
       false,
     );
 
-    assert.strictEqual(
-      psbt.toBase64(),
+    expect(psbt.toBase64()).toBe(
       'cHNidP8BAF4CAAAAAZbTXp+PF26DiVo/6VlaYkXfurKNarZ7N5L9XeIuH2tmAAAAAAAAAACAAeCFAQAAAAAAIgAgMIYr1x13sxRmbl/as01ik+y0/9u6VfvVMj39edmLZisAAAAAAAEA6gIAAAAAAQG2fkVQaaD0TJ30hJ7hFnsGwm+EeNrvqciu7fHaPX2Bhg8AAAAAAAAAgAKghgEAAAAAACIAIDCGK9cdd7MUZm5f2rNNYpPstP/bulX71TI9/XnZi2YrBLAFAAAAAAAWABRh43cCWC7PjIfB61AI8q+xesydPAJHMEQCIHcmi7DzBgtze2V8PJkBB75dtB/TEcxkq+q5bP9iEUb8AiB2biQJwGaQIOohYLNYA3/bF/SeWfr46cUKyUYBm+B55gEhA8PtFwNQM7LLDOA2lNQCw3owfw7qK5CbAnKBa/zqg3FPAAAAAAEBK6CGAQAAAAAAIgAgMIYr1x13sxRmbl/as01ik+y0/9u6VfvVMj39edmLZisBBUdSIQL3PcZ3OXAqrpAGpxAfeH8tGlIosSQDQjFhbP8RIOZRyyED1Ql1CX8NiH3x6Uj22iu8SEwewHmhRSyqJtbmfw+g11pSriIGAvc9xnc5cCqukAanEB94fy0aUiixJANCMWFs/xEg5lHLHNN+rYgwAACAAAAAgAAAAIACAACAAAAAAAAAAAAiBgPVCXUJfw2IffHpSPbaK7xITB7AeaFFLKom1uZ/D6DXWhwWjdYDMAAAgAAAAIAAAACAAgAAgAAAAAAAAAAAAAA=',
     );
 
-    assert.strictEqual(w.calculateHowManySignaturesWeHaveFromPsbt(psbt), 0);
+    expect(w.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(0);
 
     const signedOnColdcard =
       'cHNidP8BAF4CAAAAAZbTXp+PF26DiVo/6VlaYkXfurKNarZ7N5L9XeIuH2tmAAAAAAAAAACAAeCFAQAAAAAAIgAgMIYr1x13sxRmbl/as01ik+y0/9u6VfvVMj39edmLZisAAAAAAAEA6gIAAAAAAQG2fkVQaaD0TJ30hJ7hFnsGwm+EeNrvqciu7fHaPX2Bhg8AAAAAAAAAgAKghgEAAAAAACIAIDCGK9cdd7MUZm5f2rNNYpPstP/bulX71TI9/XnZi2YrBLAFAAAAAAAWABRh43cCWC7PjIfB61AI8q+xesydPAJHMEQCIHcmi7DzBgtze2V8PJkBB75dtB/TEcxkq+q5bP9iEUb8AiB2biQJwGaQIOohYLNYA3/bF/SeWfr46cUKyUYBm+B55gEhA8PtFwNQM7LLDOA2lNQCw3owfw7qK5CbAnKBa/zqg3FPAAAAAAEBK6CGAQAAAAAAIgAgMIYr1x13sxRmbl/as01ik+y0/9u6VfvVMj39edmLZisiAgPVCXUJfw2IffHpSPbaK7xITB7AeaFFLKom1uZ/D6DXWkcwRAIgfydmSzg/YjlUZDjgfrZGPKOXv5z7do3r5L8YePt5srYCIAD0JWkLVVPeeMsLOUHngsTd01Dx8OezzEmzRGYg9I+2AQEDBAEAAAAiBgPVCXUJfw2IffHpSPbaK7xITB7AeaFFLKom1uZ/D6DXWhwWjdYDMAAAgAAAAIAAAACAAgAAgAAAAAAAAAAAIgYC9z3GdzlwKq6QBqcQH3h/LRpSKLEkA0IxYWz/ESDmUcsc036tiDAAAIAAAACAAAAAgAIAAIAAAAAAAAAAAAEFR1IhAvc9xnc5cCqukAanEB94fy0aUiixJANCMWFs/xEg5lHLIQPVCXUJfw2IffHpSPbaK7xITB7AeaFFLKom1uZ/D6DXWlKuAAA=';
     const psbtSignedOnColdcard = bitcoin.Psbt.fromBase64(signedOnColdcard);
     psbt.combine(psbtSignedOnColdcard); // should not throw
-    assert.strictEqual(w.calculateHowManySignaturesWeHaveFromPsbt(psbt), 1);
+    expect(w.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(1);
 
     // signed on real Cobo device:
     const psbtFromCobo = bitcoin.Psbt.fromHex(
@@ -825,10 +789,9 @@ describe('multisig-wallet (native segwit)', () => {
     );
 
     psbt.combine(psbtFromCobo);
-    assert.strictEqual(w.calculateHowManySignaturesWeHaveFromPsbt(psbt), 2);
+    expect(w.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(2);
     const txhex = psbt.finalizeAllInputs().extractTransaction().toHex();
-    assert.strictEqual(
-      txhex,
+    expect(txhex).toBe(
       '0200000000010196d35e9f8f176e83895a3fe9595a6245dfbab28d6ab67b3792fd5de22e1f6b6600000000000000008001e08501000000000022002030862bd71d77b314666e5fdab34d6293ecb4ffdbba55fbd5323dfd79d98b662b040047304402200c5985870cf4ddcb18c0e43498ccf7dbd215a566bd6ac721d04b349d9b6f1f090220452d20d0514b3c16f74052c9dea0c8b0d8b88914e42863d757f3ee32a06425420147304402207f27664b383f6239546438e07eb6463ca397bf9cfb768debe4bf1878fb79b2b6022000f425690b5553de78cb0b3941e782c4ddd350f1f0e7b3cc49b3446620f48fb60147522102f73dc67739702aae9006a7101f787f2d1a5228b124034231616cff1120e651cb2103d50975097f0d887df1e948f6da2bbc484c1ec079a1452caa26d6e67f0fa0d75a52ae00000000',
     );
 
@@ -840,8 +803,8 @@ describe('multisig-wallet (native segwit)', () => {
     w2.setDerivationPath(path);
     w2.setM(2);
 
-    assert.strictEqual(w2.getCustomDerivationPathForCosigner(1), "m/6'/7'/8'/2'");
-    assert.strictEqual(w2.getCustomDerivationPathForCosigner(2), "m/5'/4'/3'/2'");
+    expect(w2.getCustomDerivationPathForCosigner(1)).toBe("m/6'/7'/8'/2'");
+    expect(w2.getCustomDerivationPathForCosigner(2)).toBe("m/5'/4'/3'/2'");
 
     const { psbt: psbt2 } = w2.createTransaction(
       utxos,
@@ -852,25 +815,23 @@ describe('multisig-wallet (native segwit)', () => {
       false,
     );
 
-    assert.ok(w2.calculateFeeFromPsbt(psbt2) < 300);
-    assert.ok(w2.calculateFeeFromPsbt(psbt2) > 0);
+    expect(w2.calculateFeeFromPsbt(psbt2) < 300).toBeTruthy();
+    expect(w2.calculateFeeFromPsbt(psbt2) > 0).toBeTruthy();
 
-    assert.strictEqual(psbt2.data.outputs[1].bip32Derivation[0].masterFingerprint.toString('hex').toUpperCase(), fp1cobo);
-    assert.strictEqual(psbt2.data.outputs[1].bip32Derivation[1].masterFingerprint.toString('hex').toUpperCase(), fp2coldcard);
-    assert.strictEqual(psbt2.data.outputs[1].bip32Derivation[0].path, "m/6'/7'/8'/2'" + '/1/3');
-    assert.strictEqual(psbt2.data.outputs[1].bip32Derivation[1].path, "m/5'/4'/3'/2'" + '/1/3');
+    expect(psbt2.data.outputs[1].bip32Derivation[0].masterFingerprint.toString('hex').toUpperCase()).toBe(fp1cobo);
+    expect(psbt2.data.outputs[1].bip32Derivation[1].masterFingerprint.toString('hex').toUpperCase()).toBe(fp2coldcard);
+    expect(psbt2.data.outputs[1].bip32Derivation[0].path).toBe("m/6'/7'/8'/2'" + '/1/3');
+    expect(psbt2.data.outputs[1].bip32Derivation[1].path).toBe("m/5'/4'/3'/2'" + '/1/3');
 
-    assert.strictEqual(psbt2.data.inputs[0].bip32Derivation[0].path, "m/6'/7'/8'/2'/0/0");
-    assert.strictEqual(psbt2.data.inputs[0].bip32Derivation[1].path, "m/5'/4'/3'/2'/0/0");
+    expect(psbt2.data.inputs[0].bip32Derivation[0].path).toBe("m/6'/7'/8'/2'/0/0");
+    expect(psbt2.data.inputs[0].bip32Derivation[1].path).toBe("m/5'/4'/3'/2'/0/0");
 
-    assert.strictEqual(psbt2.data.inputs[0].bip32Derivation[0].masterFingerprint.toString('hex').toUpperCase(), fp1cobo);
-    assert.strictEqual(
-      psbt2.data.inputs[0].bip32Derivation[0].pubkey.toString('hex').toUpperCase(),
+    expect(psbt2.data.inputs[0].bip32Derivation[0].masterFingerprint.toString('hex').toUpperCase()).toBe(fp1cobo);
+    expect(psbt2.data.inputs[0].bip32Derivation[0].pubkey.toString('hex').toUpperCase()).toBe(
       '02F73DC67739702AAE9006A7101F787F2D1A5228B124034231616CFF1120E651CB',
     );
-    assert.strictEqual(psbt2.data.inputs[0].bip32Derivation[1].masterFingerprint.toString('hex').toUpperCase(), fp2coldcard);
-    assert.strictEqual(
-      psbt2.data.inputs[0].bip32Derivation[1].pubkey.toString('hex').toUpperCase(),
+    expect(psbt2.data.inputs[0].bip32Derivation[1].masterFingerprint.toString('hex').toUpperCase()).toBe(fp2coldcard);
+    expect(psbt2.data.inputs[0].bip32Derivation[1].pubkey.toString('hex').toUpperCase()).toBe(
       '03D50975097F0D887DF1E948F6DA2BBC484C1EC079A1452CAA26D6E67F0FA0D75A',
     );
   });
@@ -887,33 +848,33 @@ describe('multisig-wallet (native segwit)', () => {
     const ww = new MultisigHDWallet();
     ww.setSecret(w.getSecret());
 
-    assert.strictEqual(ww._getExternalAddressByIndex(0), 'bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
-    assert.strictEqual(ww._getInternalAddressByIndex(0), 'bc1qtah0p50d4qlftn049k7lldcwh7cs3zkjy9g8xegv63p308hsh9zsf5567q');
+    expect(ww._getExternalAddressByIndex(0)).toBe('bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
+    expect(ww._getInternalAddressByIndex(0)).toBe('bc1qtah0p50d4qlftn049k7lldcwh7cs3zkjy9g8xegv63p308hsh9zsf5567q');
 
-    assert.strictEqual(ww.getM(), 2);
-    assert.strictEqual(ww.getN(), 2);
-    assert.strictEqual(ww.howManySignaturesCanWeMake(), 2);
-    assert.ok(!ww.isWrappedSegwit());
-    assert.ok(ww.isNativeSegwit());
-    assert.ok(!ww.isLegacy());
+    expect(ww.getM()).toBe(2);
+    expect(ww.getN()).toBe(2);
+    expect(ww.howManySignaturesCanWeMake()).toBe(2);
+    expect(!ww.isWrappedSegwit()).toBeTruthy();
+    expect(ww.isNativeSegwit()).toBeTruthy();
+    expect(!ww.isLegacy()).toBeTruthy();
 
-    assert.strictEqual(w.getID(), ww.getID());
-    assert.ok(w.getID() !== new MultisigHDWallet().getID());
+    expect(w.getID()).toBe(ww.getID());
+    expect(w.getID() !== new MultisigHDWallet().getID()).toBeTruthy();
 
     // now, exporting coordination setup:
 
     const w3 = new MultisigHDWallet();
     w3.setSecret(ww.getXpub());
-    assert.strictEqual(w3._getExternalAddressByIndex(0), ww._getExternalAddressByIndex(0));
-    assert.strictEqual(w3._getInternalAddressByIndex(0), ww._getInternalAddressByIndex(0));
-    assert.strictEqual(w3.getM(), 2);
-    assert.strictEqual(w3.getN(), 2);
-    assert.strictEqual(w3.howManySignaturesCanWeMake(), 0);
-    assert.ok(!w3.isWrappedSegwit());
-    assert.ok(w3.isNativeSegwit());
-    assert.ok(!w3.isLegacy());
-    assert.ok(MultisigHDWallet.isXpubString(w3.getCosigner(1)) && MultisigHDWallet.isXpubValid(w3.getCosigner(1)));
-    assert.ok(MultisigHDWallet.isXpubString(w3.getCosigner(2)) && MultisigHDWallet.isXpubValid(w3.getCosigner(2)));
+    expect(w3._getExternalAddressByIndex(0)).toBe(ww._getExternalAddressByIndex(0));
+    expect(w3._getInternalAddressByIndex(0)).toBe(ww._getInternalAddressByIndex(0));
+    expect(w3.getM()).toBe(2);
+    expect(w3.getN()).toBe(2);
+    expect(w3.howManySignaturesCanWeMake()).toBe(0);
+    expect(!w3.isWrappedSegwit()).toBeTruthy();
+    expect(w3.isNativeSegwit()).toBeTruthy();
+    expect(!w3.isLegacy()).toBeTruthy();
+    expect(MultisigHDWallet.isXpubString(w3.getCosigner(1)) && MultisigHDWallet.isXpubValid(w3.getCosigner(1))).toBeTruthy();
+    expect(MultisigHDWallet.isXpubString(w3.getCosigner(2)) && MultisigHDWallet.isXpubValid(w3.getCosigner(2))).toBeTruthy();
   });
 
   it('can coordinate tx creation and cosign 1 of 2', async () => {
@@ -951,12 +912,11 @@ describe('multisig-wallet (native segwit)', () => {
       false,
     );
 
-    assert.strictEqual(w.calculateHowManySignaturesWeHaveFromPsbt(psbt), 1);
+    expect(w.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(1);
 
-    assert.strictEqual(psbt.data.inputs[0].partialSig.length, 1);
-    assert.ok(!tx, 'tx should not be provided when PSBT is only partially signed');
-    assert.strictEqual(
-      psbt.toBase64(),
+    expect(psbt.data.inputs[0].partialSig.length).toBe(1);
+    expect(!tx).toBeTruthy();
+    expect(psbt.toBase64()).toBe(
       'cHNidP8BAFICAAAAAZbTXp+PF26DiVo/6VlaYkXfurKNarZ7N5L9XeIuH2tmAAAAAAAAAACAASB/AQAAAAAAFgAU/cPeWXWo+efWvANS+4VAg/i3hLEAAAAAAAEA6gIAAAAAAQG2fkVQaaD0TJ30hJ7hFnsGwm+EeNrvqciu7fHaPX2Bhg8AAAAAAAAAgAKghgEAAAAAACIAIDCGK9cdd7MUZm5f2rNNYpPstP/bulX71TI9/XnZi2YrBLAFAAAAAAAWABRh43cCWC7PjIfB61AI8q+xesydPAJHMEQCIHcmi7DzBgtze2V8PJkBB75dtB/TEcxkq+q5bP9iEUb8AiB2biQJwGaQIOohYLNYA3/bF/SeWfr46cUKyUYBm+B55gEhA8PtFwNQM7LLDOA2lNQCw3owfw7qK5CbAnKBa/zqg3FPAAAAAAEBK6CGAQAAAAAAIgAgMIYr1x13sxRmbl/as01ik+y0/9u6VfvVMj39edmLZisiAgPVCXUJfw2IffHpSPbaK7xITB7AeaFFLKom1uZ/D6DXWkgwRQIhAMlUC0EwNieytD8U9AUITLBvorNMUfWwJqsGJXRdZA2TAiA7k6ddbqnLKPwswk/D9ehGBIMNzKEfJYW7DkGGYRJdYAEBBUdSIQL3PcZ3OXAqrpAGpxAfeH8tGlIosSQDQjFhbP8RIOZRyyED1Ql1CX8NiH3x6Uj22iu8SEwewHmhRSyqJtbmfw+g11pSriIGAvc9xnc5cCqukAanEB94fy0aUiixJANCMWFs/xEg5lHLHNN+rYgwAACAAAAAgAAAAIACAACAAAAAAAAAAAAiBgPVCXUJfw2IffHpSPbaK7xITB7AeaFFLKom1uZ/D6DXWhwWjdYDMAAAgAAAAIAAAACAAgAAgAAAAAAAAAAAAAA=',
     );
 
@@ -968,13 +928,12 @@ describe('multisig-wallet (native segwit)', () => {
 
     const psbtFromCobo = bitcoin.Psbt.fromHex(payload);
     psbt.combine(psbtFromCobo);
-    assert.strictEqual(psbt.data.inputs[0].partialSig.length, 2);
+    expect(psbt.data.inputs[0].partialSig.length).toBe(2);
 
-    assert.strictEqual(w.calculateHowManySignaturesWeHaveFromPsbt(psbt), 2);
+    expect(w.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(2);
 
     const tx2 = psbt.finalizeAllInputs().extractTransaction();
-    assert.strictEqual(
-      tx2.toHex(),
+    expect(tx2.toHex()).toBe(
       '0200000000010196d35e9f8f176e83895a3fe9595a6245dfbab28d6ab67b3792fd5de22e1f6b6600000000000000008001207f010000000000160014fdc3de5975a8f9e7d6bc0352fb854083f8b784b104004730440220529df7fb1de0651461c97ecbe29516dbba70beae3146a0b82f28121f7e55147902207a6dc193699aa413342fbf0e1cad2394322d7f305f7af07562f6105c378f6eb201483045022100c9540b41303627b2b43f14f405084cb06fa2b34c51f5b026ab0625745d640d9302203b93a75d6ea9cb28fc2cc24fc3f5e84604830dcca11f2585bb0e418661125d600147522102f73dc67739702aae9006a7101f787f2d1a5228b124034231616cff1120e651cb2103d50975097f0d887df1e948f6da2bbc484c1ec079a1452caa26d6e67f0fa0d75a52ae00000000',
     );
 
@@ -1014,14 +973,13 @@ describe('multisig-wallet (native segwit)', () => {
       false,
       false,
     );
-    assert.strictEqual(
-      psbt.toBase64(),
+    expect(psbt.toBase64()).toBe(
       'cHNidP8BAF4CAAAAAZbTXp+PF26DiVo/6VlaYkXfurKNarZ7N5L9XeIuH2tmAAAAAAAAAACAAeCFAQAAAAAAIgAgMIYr1x13sxRmbl/as01ik+y0/9u6VfvVMj39edmLZisAAAAAAAEA6gIAAAAAAQG2fkVQaaD0TJ30hJ7hFnsGwm+EeNrvqciu7fHaPX2Bhg8AAAAAAAAAgAKghgEAAAAAACIAIDCGK9cdd7MUZm5f2rNNYpPstP/bulX71TI9/XnZi2YrBLAFAAAAAAAWABRh43cCWC7PjIfB61AI8q+xesydPAJHMEQCIHcmi7DzBgtze2V8PJkBB75dtB/TEcxkq+q5bP9iEUb8AiB2biQJwGaQIOohYLNYA3/bF/SeWfr46cUKyUYBm+B55gEhA8PtFwNQM7LLDOA2lNQCw3owfw7qK5CbAnKBa/zqg3FPAAAAAAEBK6CGAQAAAAAAIgAgMIYr1x13sxRmbl/as01ik+y0/9u6VfvVMj39edmLZisBBUdSIQL3PcZ3OXAqrpAGpxAfeH8tGlIosSQDQjFhbP8RIOZRyyED1Ql1CX8NiH3x6Uj22iu8SEwewHmhRSyqJtbmfw+g11pSriIGAvc9xnc5cCqukAanEB94fy0aUiixJANCMWFs/xEg5lHLHNN+rYgwAACAAAAAgAAAAIACAACAAAAAAAAAAAAiBgPVCXUJfw2IffHpSPbaK7xITB7AeaFFLKom1uZ/D6DXWhwWjdYDMAAAgAAAAIAAAACAAgAAgAAAAAAAAAAAAAA=',
     );
 
-    assert.throws(() => psbt.finalizeAllInputs()); // as it is not fully signed yet
+    expect(() => psbt.finalizeAllInputs()).toThrow(); // as it is not fully signed yet
     walletWithNoKeys.cosignPsbt(psbt); // should do nothing, we have no keys
-    assert.strictEqual(walletWithNoKeys.calculateHowManySignaturesWeHaveFromPsbt(psbt), 0);
+    expect(walletWithNoKeys.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(0);
 
     const walletWithFirstKey = new MultisigHDWallet();
     walletWithFirstKey.addCosigner(Zpub1, fp1cobo);
@@ -1031,11 +989,11 @@ describe('multisig-wallet (native segwit)', () => {
 
     walletWithFirstKey.cosignPsbt(psbt); // <-------------------------------------------------------------------------
 
-    assert.strictEqual(walletWithFirstKey.calculateHowManySignaturesWeHaveFromPsbt(psbt), 1);
-    assert.throws(() => psbt.finalizeAllInputs()); // as it is not fully signed yet
+    expect(walletWithFirstKey.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(1);
+    expect(() => psbt.finalizeAllInputs()).toThrow(); // as it is not fully signed yet
 
     walletWithFirstKey.cosignPsbt(psbt); // should do nothing, we already cosigned with this key
-    assert.strictEqual(walletWithFirstKey.calculateHowManySignaturesWeHaveFromPsbt(psbt), 1); // didnt change
+    expect(walletWithFirstKey.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(1); // didnt change
 
     const walletWithSecondKey = new MultisigHDWallet();
     walletWithSecondKey.addCosigner(process.env.MNEMONICS_COBO);
@@ -1045,10 +1003,10 @@ describe('multisig-wallet (native segwit)', () => {
 
     const { tx } = walletWithSecondKey.cosignPsbt(psbt); // <---------------------------------------------------------
 
-    assert.strictEqual(walletWithFirstKey.calculateHowManySignaturesWeHaveFromPsbt(psbt), 2);
-    assert.ok(tx);
-    assert.throws(() => psbt.finalizeAllInputs()); // as it is already finalized
-    assert.ok(tx.toHex());
+    expect(walletWithFirstKey.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(2);
+    expect(tx).toBeTruthy();
+    expect(() => psbt.finalizeAllInputs()).toThrow(); // as it is already finalized
+    expect(tx.toHex()).toBeTruthy();
   });
 
   it('can cosign PSBT that comes from electrum', async () => {
@@ -1067,14 +1025,14 @@ describe('multisig-wallet (native segwit)', () => {
     const psbt = bitcoin.Psbt.fromBase64(
       'cHNidP8BAHsCAAAAAn99yxH8deILgpB2qT23xRUvfnu8v98JSREOvhP5SFhHAAAAAAD9////2NGbHPsAqZoKkO+PsxfYuLT9pN8T5/LtHnQnStXsyWsAAAAAAP3///8B2LECAAAAAAAWABTNx1+3yJfKJVcFfHn3KBn9EVdBLmIkCgAAAQDrAgAAAAABAdjRmxz7AKmaCpDvj7MX2Li0/aTfE+fy7R50J0rV7MlrAQAAAAAAAACAAqCGAQAAAAAAIgAgNjviJkwSkV3MVJI0X8KnLUc+MfW/d4EQvWgykrvTwHDeDAIAAAAAABYAFGPIzN0T0b+DfXhLYiOUdT2c5pEBAkgwRQIhAIyPdquXeaHAXL7PpaYt5+G9rl0lLXMPaDM2u9fVuCp4AiA7EIZQm8bIdC4Z+oWtXh0xCKSvTgiwDQWGsQ2kMC2+LwEhA7+3G393F7pqELKBkYzEka2iEvVsLpGjdTvVuP6nufrLAAAAACICA6qDyEv6617qV3VEJoGIQowgTguor7GTI1qOYIz/M6PpRzBEAiBN+gF6Xa7PO1/NbL7K8Nqa3W5vPiuaAov6v+7zjTNDlgIgf9jYQ76Hf4xoOBdveYCyaOeoq+jwXN05nvJlVgZFngkBAQVHUiEDWcyClcxZ8xFXyF1LM8kiGaXqdqM3aHgKK2/Di976NAohA6qDyEv6617qV3VEJoGIQowgTguor7GTI1qOYIz/M6PpUq4iBgNZzIKVzFnzEVfIXUszySIZpep2ozdoeAorb8OL3vo0CgyRUA3SAAAAAAEAAAAiBgOqg8hL+ute6ld1RCaBiEKMIE4LqK+xkyNajmCM/zOj6RCvgJIDAQAAgAAAAAABAAAAAAEA6wIAAAAAAQHWV2FCU0XMuya/nkpDw/yIOK7U3NehUDZmechoTJQFlQEAAAAAAAAAgAKghgEAAAAAACIAIJi9hmdhYfHNmOEaEADqxlNRmtsZIU/NisM8/b4UVU67JqUDAAAAAAAWABSOkTpoURBU5UZG1VIoBj+EHlF6cgJIMEUCIQCJjUIn/LFJNknngMXEfHUNegppt/olh+2RCYGDZ/yw7AIgLw7SwWCaZvHB8PwMj+9F4Rjhvmq4BZ7gozr7tQZMOY0BIQN3F33l/rnJgyIJQHHYEwfxCympfDiFZ8rV76gttJdnLwAAAAAiAgKk1ZQ+v8BXIY1q1aQcRA1Qy6XQVrrhXEcWtXrOvOzf8kcwRAIgPYRi8+wJVym+EF3LNyOylj1RcdPzMiLxKRqlVm64IUgCIH1JVGxAIvmwKpg1TqlvbeXZbUMCjnr7CkYWqxBqghLfAQEFR1IhAqTVlD6/wFchjWrVpBxEDVDLpdBWuuFcRxa1es687N/yIQPo29i9fz5IsDSF1lSMDBbhehw+ydEhNYmjujZiSfyQD1KuIgYCpNWUPr/AVyGNatWkHEQNUMul0Fa64VxHFrV6zrzs3/IQr4CSAwEAAIAAAAAAAAAAACIGA+jb2L1/PkiwNIXWVIwMFuF6HD7J0SE1iaO6NmJJ/JAPDJFQDdIAAAAAAAAAAAAA',
     );
-    assert.strictEqual(wallet.calculateHowManySignaturesWeHaveFromPsbt(psbt), 1);
+    expect(wallet.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(1);
 
     const { tx } = wallet.cosignPsbt(psbt); // <---------------------------------------------------------
 
-    assert.strictEqual(wallet.calculateHowManySignaturesWeHaveFromPsbt(psbt), 2);
-    assert.ok(tx);
-    assert.throws(() => psbt.finalizeAllInputs()); // as it is already finalized
-    assert.ok(tx.toHex());
+    expect(wallet.calculateHowManySignaturesWeHaveFromPsbt(psbt)).toBe(2);
+    expect(tx).toBeTruthy();
+    expect(() => psbt.finalizeAllInputs()).toThrow(); // as it is already finalized
+    expect(tx.toHex()).toBeTruthy();
   });
 
   it('can export/import when one of cosigners is mnemonic seed', async () => {
@@ -1086,30 +1044,30 @@ describe('multisig-wallet (native segwit)', () => {
     w.setDerivationPath(path);
     w.setM(2);
 
-    assert.ok(w.getID());
+    expect(w.getID()).toBeTruthy();
 
     const w2 = new MultisigHDWallet();
     w2.setSecret(w.getSecret());
-    assert.strictEqual(w2.getID(), w.getID());
+    expect(w2.getID()).toBe(w.getID());
 
-    assert.strictEqual(w._getExternalAddressByIndex(0), w2._getExternalAddressByIndex(0));
-    assert.strictEqual(w._getExternalAddressByIndex(1), w2._getExternalAddressByIndex(1));
-    assert.strictEqual(w._getInternalAddressByIndex(0), w2._getInternalAddressByIndex(0));
-    assert.strictEqual(w._getInternalAddressByIndex(1), w2._getInternalAddressByIndex(1));
-    assert.strictEqual(w.getM(), w2.getM());
-    assert.strictEqual(w.getN(), w2.getN());
-    assert.strictEqual(w.getDerivationPath(), w2.getDerivationPath());
-    assert.strictEqual(w.getCosigner(1), w2.getCosigner(1));
-    assert.strictEqual(w.getCosigner(2), w2.getCosigner(2));
-    assert.strictEqual(w.getCosignerForFingerprint(fp1cobo), w2.getCosignerForFingerprint(fp1cobo));
-    assert.strictEqual(w.getCosignerForFingerprint(fp2coldcard), w2.getCosignerForFingerprint(fp2coldcard));
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(1), w2.getCustomDerivationPathForCosigner(1));
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(2), w2.getCustomDerivationPathForCosigner(2));
-    assert.strictEqual(w.howManySignaturesCanWeMake(), w2.howManySignaturesCanWeMake());
-    assert.strictEqual(w.isNativeSegwit(), w2.isNativeSegwit());
-    assert.strictEqual(w.isWrappedSegwit(), w2.isWrappedSegwit());
-    assert.strictEqual(w.isLegacy(), w2.isLegacy());
-    assert.strictEqual(w.getLabel(), w2.getLabel());
+    expect(w._getExternalAddressByIndex(0)).toBe(w2._getExternalAddressByIndex(0));
+    expect(w._getExternalAddressByIndex(1)).toBe(w2._getExternalAddressByIndex(1));
+    expect(w._getInternalAddressByIndex(0)).toBe(w2._getInternalAddressByIndex(0));
+    expect(w._getInternalAddressByIndex(1)).toBe(w2._getInternalAddressByIndex(1));
+    expect(w.getM()).toBe(w2.getM());
+    expect(w.getN()).toBe(w2.getN());
+    expect(w.getDerivationPath()).toBe(w2.getDerivationPath());
+    expect(w.getCosigner(1)).toBe(w2.getCosigner(1));
+    expect(w.getCosigner(2)).toBe(w2.getCosigner(2));
+    expect(w.getCosignerForFingerprint(fp1cobo)).toBe(w2.getCosignerForFingerprint(fp1cobo));
+    expect(w.getCosignerForFingerprint(fp2coldcard)).toBe(w2.getCosignerForFingerprint(fp2coldcard));
+    expect(w.getCustomDerivationPathForCosigner(1)).toBe(w2.getCustomDerivationPathForCosigner(1));
+    expect(w.getCustomDerivationPathForCosigner(2)).toBe(w2.getCustomDerivationPathForCosigner(2));
+    expect(w.howManySignaturesCanWeMake()).toBe(w2.howManySignaturesCanWeMake());
+    expect(w.isNativeSegwit()).toBe(w2.isNativeSegwit());
+    expect(w.isWrappedSegwit()).toBe(w2.isWrappedSegwit());
+    expect(w.isLegacy()).toBe(w2.isLegacy());
+    expect(w.getLabel()).toBe(w2.getLabel());
   });
 
   it('can import txt from Cobo and export it back', async () => {
@@ -1127,43 +1085,43 @@ describe('multisig-wallet (native segwit)', () => {
       const w = new MultisigHDWallet();
       w.setSecret(secret);
 
-      assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
-      assert.strictEqual(w._getExternalAddressByIndex(1), 'bc1qvwd2d7r46j7u9qyxpedfhe5p075sxuhzd0n6napuvvhq2u5nrmqs9ex90q');
-      assert.strictEqual(w._getInternalAddressByIndex(0), 'bc1qtah0p50d4qlftn049k7lldcwh7cs3zkjy9g8xegv63p308hsh9zsf5567q');
-      assert.strictEqual(w._getInternalAddressByIndex(1), 'bc1qv84pedzkqz2p4sd2dxm9krs0tcfatqcn73nndycaky9qttczj9qq3az9ma');
-      assert.strictEqual(w.getM(), 2);
-      assert.strictEqual(w.getN(), 2);
-      assert.strictEqual(w.getDerivationPath(), path);
-      assert.strictEqual(w.getCosigner(1), Zpub1);
-      assert.strictEqual(w.getCosigner(2), Zpub2);
-      assert.strictEqual(w.getCosignerForFingerprint(fp1cobo), Zpub1);
-      assert.strictEqual(w.getCosignerForFingerprint(fp2coldcard), Zpub2);
-      assert.strictEqual(w.getCustomDerivationPathForCosigner(1), path); // default since custom was not provided
-      assert.strictEqual(w.getCustomDerivationPathForCosigner(2), path); // default since custom was not provided
-      assert.strictEqual(w.howManySignaturesCanWeMake(), 0);
-      assert.strictEqual(w.getLabel(), 'CV_33B5B91A_2-2');
+      expect(w._getExternalAddressByIndex(0)).toBe('bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
+      expect(w._getExternalAddressByIndex(1)).toBe('bc1qvwd2d7r46j7u9qyxpedfhe5p075sxuhzd0n6napuvvhq2u5nrmqs9ex90q');
+      expect(w._getInternalAddressByIndex(0)).toBe('bc1qtah0p50d4qlftn049k7lldcwh7cs3zkjy9g8xegv63p308hsh9zsf5567q');
+      expect(w._getInternalAddressByIndex(1)).toBe('bc1qv84pedzkqz2p4sd2dxm9krs0tcfatqcn73nndycaky9qttczj9qq3az9ma');
+      expect(w.getM()).toBe(2);
+      expect(w.getN()).toBe(2);
+      expect(w.getDerivationPath()).toBe(path);
+      expect(w.getCosigner(1)).toBe(Zpub1);
+      expect(w.getCosigner(2)).toBe(Zpub2);
+      expect(w.getCosignerForFingerprint(fp1cobo)).toBe(Zpub1);
+      expect(w.getCosignerForFingerprint(fp2coldcard)).toBe(Zpub2);
+      expect(w.getCustomDerivationPathForCosigner(1)).toBe(path); // default since custom was not provided
+      expect(w.getCustomDerivationPathForCosigner(2)).toBe(path); // default since custom was not provided
+      expect(w.howManySignaturesCanWeMake()).toBe(0);
+      expect(w.getLabel()).toBe('CV_33B5B91A_2-2');
 
       const w2 = new MultisigHDWallet();
       w2.setSecret(w.getSecret());
 
-      assert.strictEqual(w._getExternalAddressByIndex(0), w2._getExternalAddressByIndex(0));
-      assert.strictEqual(w._getExternalAddressByIndex(1), w2._getExternalAddressByIndex(1));
-      assert.strictEqual(w._getInternalAddressByIndex(0), w2._getInternalAddressByIndex(0));
-      assert.strictEqual(w._getInternalAddressByIndex(1), w2._getInternalAddressByIndex(1));
-      assert.strictEqual(w.getM(), w2.getM());
-      assert.strictEqual(w.getN(), w2.getN());
-      assert.strictEqual(w.getDerivationPath(), w2.getDerivationPath());
-      assert.strictEqual(w.getCosigner(1), w2.getCosigner(1));
-      assert.strictEqual(w.getCosigner(2), w2.getCosigner(2));
-      assert.strictEqual(w.getCosignerForFingerprint(fp1cobo), w2.getCosignerForFingerprint(fp1cobo));
-      assert.strictEqual(w.getCosignerForFingerprint(fp2coldcard), w2.getCosignerForFingerprint(fp2coldcard));
-      assert.strictEqual(w.getCustomDerivationPathForCosigner(1), w2.getCustomDerivationPathForCosigner(1)); // default since custom was not provided
-      assert.strictEqual(w.getCustomDerivationPathForCosigner(2), w2.getCustomDerivationPathForCosigner(2)); // default since custom was not provided
-      assert.strictEqual(w.howManySignaturesCanWeMake(), w2.howManySignaturesCanWeMake());
-      assert.strictEqual(w.isNativeSegwit(), w2.isNativeSegwit());
-      assert.strictEqual(w.isWrappedSegwit(), w2.isWrappedSegwit());
-      assert.strictEqual(w.isLegacy(), w2.isLegacy());
-      assert.strictEqual(w.getLabel(), w2.getLabel());
+      expect(w._getExternalAddressByIndex(0)).toBe(w2._getExternalAddressByIndex(0));
+      expect(w._getExternalAddressByIndex(1)).toBe(w2._getExternalAddressByIndex(1));
+      expect(w._getInternalAddressByIndex(0)).toBe(w2._getInternalAddressByIndex(0));
+      expect(w._getInternalAddressByIndex(1)).toBe(w2._getInternalAddressByIndex(1));
+      expect(w.getM()).toBe(w2.getM());
+      expect(w.getN()).toBe(w2.getN());
+      expect(w.getDerivationPath()).toBe(w2.getDerivationPath());
+      expect(w.getCosigner(1)).toBe(w2.getCosigner(1));
+      expect(w.getCosigner(2)).toBe(w2.getCosigner(2));
+      expect(w.getCosignerForFingerprint(fp1cobo)).toBe(w2.getCosignerForFingerprint(fp1cobo));
+      expect(w.getCosignerForFingerprint(fp2coldcard)).toBe(w2.getCosignerForFingerprint(fp2coldcard));
+      expect(w.getCustomDerivationPathForCosigner(1)).toBe(w2.getCustomDerivationPathForCosigner(1)); // default since custom was not provided
+      expect(w.getCustomDerivationPathForCosigner(2)).toBe(w2.getCustomDerivationPathForCosigner(2)); // default since custom was not provided
+      expect(w.howManySignaturesCanWeMake()).toBe(w2.howManySignaturesCanWeMake());
+      expect(w.isNativeSegwit()).toBe(w2.isNativeSegwit());
+      expect(w.isWrappedSegwit()).toBe(w2.isWrappedSegwit());
+      expect(w.isLegacy()).toBe(w2.isLegacy());
+      expect(w.getLabel()).toBe(w2.getLabel());
     }
   });
 
@@ -1184,20 +1142,20 @@ describe('multisig-wallet (native segwit)', () => {
     const w = new MultisigHDWallet();
     w.setSecret(secret);
 
-    assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
-    assert.strictEqual(w._getExternalAddressByIndex(1), 'bc1qvwd2d7r46j7u9qyxpedfhe5p075sxuhzd0n6napuvvhq2u5nrmqs9ex90q');
-    assert.strictEqual(w._getInternalAddressByIndex(0), 'bc1qtah0p50d4qlftn049k7lldcwh7cs3zkjy9g8xegv63p308hsh9zsf5567q');
-    assert.strictEqual(w._getInternalAddressByIndex(1), 'bc1qv84pedzkqz2p4sd2dxm9krs0tcfatqcn73nndycaky9qttczj9qq3az9ma');
-    assert.strictEqual(w.getM(), 2);
-    assert.strictEqual(w.getN(), 2);
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(1), "m/47'/0'/0'/1'");
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(2), "m/46'/0'/0'/1'");
-    assert.strictEqual(w.getDerivationPath(), '');
-    assert.strictEqual(w.getCosigner(1), Zpub1);
-    assert.strictEqual(w.getCosigner(2), Zpub2);
-    assert.strictEqual(w.getCosignerForFingerprint(fp1cobo), Zpub1);
-    assert.strictEqual(w.getCosignerForFingerprint(fp2coldcard), Zpub2);
-    assert.strictEqual(w.howManySignaturesCanWeMake(), 0);
+    expect(w._getExternalAddressByIndex(0)).toBe('bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
+    expect(w._getExternalAddressByIndex(1)).toBe('bc1qvwd2d7r46j7u9qyxpedfhe5p075sxuhzd0n6napuvvhq2u5nrmqs9ex90q');
+    expect(w._getInternalAddressByIndex(0)).toBe('bc1qtah0p50d4qlftn049k7lldcwh7cs3zkjy9g8xegv63p308hsh9zsf5567q');
+    expect(w._getInternalAddressByIndex(1)).toBe('bc1qv84pedzkqz2p4sd2dxm9krs0tcfatqcn73nndycaky9qttczj9qq3az9ma');
+    expect(w.getM()).toBe(2);
+    expect(w.getN()).toBe(2);
+    expect(w.getCustomDerivationPathForCosigner(1)).toBe("m/47'/0'/0'/1'");
+    expect(w.getCustomDerivationPathForCosigner(2)).toBe("m/46'/0'/0'/1'");
+    expect(w.getDerivationPath()).toBe('');
+    expect(w.getCosigner(1)).toBe(Zpub1);
+    expect(w.getCosigner(2)).toBe(Zpub2);
+    expect(w.getCosignerForFingerprint(fp1cobo)).toBe(Zpub1);
+    expect(w.getCosignerForFingerprint(fp2coldcard)).toBe(Zpub2);
+    expect(w.howManySignaturesCanWeMake()).toBe(0);
 
     const utxos = [
       {
@@ -1224,32 +1182,32 @@ describe('multisig-wallet (native segwit)', () => {
       false,
     );
 
-    assert.strictEqual(psbt2.data.outputs[1].bip32Derivation[0].path, "m/47'/0'/0'/1'" + '/1/3');
-    assert.strictEqual(psbt2.data.outputs[1].bip32Derivation[1].path, "m/46'/0'/0'/1'" + '/1/3');
+    expect(psbt2.data.outputs[1].bip32Derivation[0].path).toBe("m/47'/0'/0'/1'" + '/1/3');
+    expect(psbt2.data.outputs[1].bip32Derivation[1].path).toBe("m/46'/0'/0'/1'" + '/1/3');
 
-    assert.strictEqual(psbt2.data.inputs[0].bip32Derivation[0].path, "m/47'/0'/0'/1'/0/0");
-    assert.strictEqual(psbt2.data.inputs[0].bip32Derivation[1].path, "m/46'/0'/0'/1'/0/0");
+    expect(psbt2.data.inputs[0].bip32Derivation[0].path).toBe("m/47'/0'/0'/1'/0/0");
+    expect(psbt2.data.inputs[0].bip32Derivation[1].path).toBe("m/46'/0'/0'/1'/0/0");
 
     // testing that custom paths survive export/import
 
     const w2 = new MultisigHDWallet();
     w2.setSecret(w.getSecret());
 
-    assert.strictEqual(w._getExternalAddressByIndex(0), w2._getExternalAddressByIndex(0));
-    assert.strictEqual(w._getExternalAddressByIndex(1), w2._getExternalAddressByIndex(1));
-    assert.strictEqual(w._getInternalAddressByIndex(0), w2._getInternalAddressByIndex(0));
-    assert.strictEqual(w._getInternalAddressByIndex(1), w2._getInternalAddressByIndex(1));
-    assert.strictEqual(w.getM(), w2.getM());
-    assert.strictEqual(w.getN(), w2.getN());
-    assert.strictEqual(w.getDerivationPath(), w2.getDerivationPath());
-    assert.strictEqual(w.getCosigner(1), w2.getCosigner(1));
-    assert.strictEqual(w.getCosigner(2), w2.getCosigner(2));
-    assert.strictEqual(w.getCosignerForFingerprint(fp1cobo), w2.getCosignerForFingerprint(fp1cobo));
-    assert.strictEqual(w.getCosignerForFingerprint(fp2coldcard), w2.getCosignerForFingerprint(fp2coldcard));
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(1), w2.getCustomDerivationPathForCosigner(1));
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(2), w2.getCustomDerivationPathForCosigner(2));
-    assert.strictEqual(w.howManySignaturesCanWeMake(), w2.howManySignaturesCanWeMake());
-    assert.strictEqual(w.getLabel(), w2.getLabel());
+    expect(w._getExternalAddressByIndex(0)).toBe(w2._getExternalAddressByIndex(0));
+    expect(w._getExternalAddressByIndex(1)).toBe(w2._getExternalAddressByIndex(1));
+    expect(w._getInternalAddressByIndex(0)).toBe(w2._getInternalAddressByIndex(0));
+    expect(w._getInternalAddressByIndex(1)).toBe(w2._getInternalAddressByIndex(1));
+    expect(w.getM()).toBe(w2.getM());
+    expect(w.getN()).toBe(w2.getN());
+    expect(w.getDerivationPath()).toBe(w2.getDerivationPath());
+    expect(w.getCosigner(1)).toBe(w2.getCosigner(1));
+    expect(w.getCosigner(2)).toBe(w2.getCosigner(2));
+    expect(w.getCosignerForFingerprint(fp1cobo)).toBe(w2.getCosignerForFingerprint(fp1cobo));
+    expect(w.getCosignerForFingerprint(fp2coldcard)).toBe(w2.getCosignerForFingerprint(fp2coldcard));
+    expect(w.getCustomDerivationPathForCosigner(1)).toBe(w2.getCustomDerivationPathForCosigner(1));
+    expect(w.getCustomDerivationPathForCosigner(2)).toBe(w2.getCustomDerivationPathForCosigner(2));
+    expect(w.howManySignaturesCanWeMake()).toBe(w2.howManySignaturesCanWeMake());
+    expect(w.getLabel()).toBe(w2.getLabel());
   });
 
   it('can import incomplete wallet from Coldcard', async () => {
@@ -1258,43 +1216,43 @@ describe('multisig-wallet (native segwit)', () => {
     const w = new MultisigHDWallet();
     w.setSecret(coldcardExport);
 
-    assert.throws(() => w._getExternalAddressByIndex(0));
-    assert.throws(() => w._getInternalAddressByIndex(0));
+    expect(() => w._getExternalAddressByIndex(0)).toThrow();
+    expect(() => w._getInternalAddressByIndex(0)).toThrow();
 
-    assert.strictEqual(w.getM(), 0); // zero means unknown
-    assert.strictEqual(w.getN(), 1); // added only one cosigner
-    assert.strictEqual(w.getCosigner(1), Zpub2);
-    assert.strictEqual(w.getCosignerForFingerprint(fp2coldcard), Zpub2);
-    assert.strictEqual(w.getDerivationPath(), ''); // unknown
+    expect(w.getM()).toBe(0); // zero means unknown
+    expect(w.getN()).toBe(1); // added only one cosigner
+    expect(w.getCosigner(1)).toBe(Zpub2);
+    expect(w.getCosignerForFingerprint(fp2coldcard)).toBe(Zpub2);
+    expect(w.getDerivationPath()).toBe(''); // unknown
   });
 
   it('can import electrum json file format', () => {
-    assert.strictEqual(MultisigHDWallet.ckccXfp2fingerprint(64392470), '168DD603');
-    assert.strictEqual(MultisigHDWallet.ckccXfp2fingerprint('64392470'), '168DD603');
-    assert.strictEqual(MultisigHDWallet.ckccXfp2fingerprint(2389277556), '747B698E');
-    assert.strictEqual(MultisigHDWallet.ckccXfp2fingerprint(1130956047), '0F056943');
-    assert.strictEqual(MultisigHDWallet.ckccXfp2fingerprint(2293071571), 'D37EAD88');
+    expect(MultisigHDWallet.ckccXfp2fingerprint(64392470)).toBe('168DD603');
+    expect(MultisigHDWallet.ckccXfp2fingerprint('64392470')).toBe('168DD603');
+    expect(MultisigHDWallet.ckccXfp2fingerprint(2389277556)).toBe('747B698E');
+    expect(MultisigHDWallet.ckccXfp2fingerprint(1130956047)).toBe('0F056943');
+    expect(MultisigHDWallet.ckccXfp2fingerprint(2293071571)).toBe('D37EAD88');
 
     const w = new MultisigHDWallet();
     w.setSecret(electumJson);
 
-    assert.strictEqual(w.getM(), 2);
-    assert.strictEqual(w.getN(), 2);
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(1), "m/48'/1'/0'/1'");
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(2), "m/48'/1'/0'/1'");
-    assert.strictEqual(w.getCosigner(1), Zpub1);
-    assert.strictEqual(w.getCosigner(2), Zpub2);
-    assert.strictEqual(w.getCosignerForFingerprint(fp1cobo), Zpub1);
-    assert.strictEqual(w.getCosignerForFingerprint(fp2coldcard), Zpub2);
-    assert.strictEqual(w.howManySignaturesCanWeMake(), 0);
-    assert.ok(w.isNativeSegwit());
-    assert.ok(!w.isWrappedSegwit());
-    assert.ok(!w.isLegacy());
+    expect(w.getM()).toBe(2);
+    expect(w.getN()).toBe(2);
+    expect(w.getCustomDerivationPathForCosigner(1)).toBe("m/48'/1'/0'/1'");
+    expect(w.getCustomDerivationPathForCosigner(2)).toBe("m/48'/1'/0'/1'");
+    expect(w.getCosigner(1)).toBe(Zpub1);
+    expect(w.getCosigner(2)).toBe(Zpub2);
+    expect(w.getCosignerForFingerprint(fp1cobo)).toBe(Zpub1);
+    expect(w.getCosignerForFingerprint(fp2coldcard)).toBe(Zpub2);
+    expect(w.howManySignaturesCanWeMake()).toBe(0);
+    expect(w.isNativeSegwit()).toBeTruthy();
+    expect(!w.isWrappedSegwit()).toBeTruthy();
+    expect(!w.isLegacy()).toBeTruthy();
 
-    assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
-    assert.strictEqual(w._getExternalAddressByIndex(1), 'bc1qvwd2d7r46j7u9qyxpedfhe5p075sxuhzd0n6napuvvhq2u5nrmqs9ex90q');
-    assert.strictEqual(w._getInternalAddressByIndex(0), 'bc1qtah0p50d4qlftn049k7lldcwh7cs3zkjy9g8xegv63p308hsh9zsf5567q');
-    assert.strictEqual(w._getInternalAddressByIndex(1), 'bc1qv84pedzkqz2p4sd2dxm9krs0tcfatqcn73nndycaky9qttczj9qq3az9ma');
+    expect(w._getExternalAddressByIndex(0)).toBe('bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
+    expect(w._getExternalAddressByIndex(1)).toBe('bc1qvwd2d7r46j7u9qyxpedfhe5p075sxuhzd0n6napuvvhq2u5nrmqs9ex90q');
+    expect(w._getInternalAddressByIndex(0)).toBe('bc1qtah0p50d4qlftn049k7lldcwh7cs3zkjy9g8xegv63p308hsh9zsf5567q');
+    expect(w._getInternalAddressByIndex(1)).toBe('bc1qv84pedzkqz2p4sd2dxm9krs0tcfatqcn73nndycaky9qttczj9qq3az9ma');
   });
 
   it('can import electrum json file format with seeds', () => {
@@ -1311,30 +1269,30 @@ describe('multisig-wallet (native segwit)', () => {
       const w = new MultisigHDWallet();
       w.setSecret(s);
 
-      assert.strictEqual(w.getM(), 2);
-      assert.strictEqual(w.getN(), 3);
+      expect(w.getM()).toBe(2);
+      expect(w.getN()).toBe(3);
 
-      assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1qkzg22vej70cqnrlsxcee9nfnstcr70jalvsmjn0c8rjf0klwyydsk8nggs');
-      assert.strictEqual(w._getExternalAddressByIndex(1), 'bc1q2mkhkvx9l7aqksvyf0dwd2x4yn8qx2w3sythjltdkjw70r8hsves2evfg6');
-      assert.strictEqual(w._getInternalAddressByIndex(0), 'bc1qqj0zx85x3d2frn4nmdn32fgskq5c2qkvk9sukxp3xsdzuf234mds85w068');
-      assert.strictEqual(w._getInternalAddressByIndex(1), 'bc1qwpxkr4ac7fyp6y8uegfpqa6phyqex3vdf5mwwrfayrp8889adpgszge8m5');
+      expect(w._getExternalAddressByIndex(0)).toBe('bc1qkzg22vej70cqnrlsxcee9nfnstcr70jalvsmjn0c8rjf0klwyydsk8nggs');
+      expect(w._getExternalAddressByIndex(1)).toBe('bc1q2mkhkvx9l7aqksvyf0dwd2x4yn8qx2w3sythjltdkjw70r8hsves2evfg6');
+      expect(w._getInternalAddressByIndex(0)).toBe('bc1qqj0zx85x3d2frn4nmdn32fgskq5c2qkvk9sukxp3xsdzuf234mds85w068');
+      expect(w._getInternalAddressByIndex(1)).toBe('bc1qwpxkr4ac7fyp6y8uegfpqa6phyqex3vdf5mwwrfayrp8889adpgszge8m5');
 
       if (JSON.parse(s)['x1/'].seed) {
-        assert.strictEqual(w.howManySignaturesCanWeMake(), 1);
+        expect(w.howManySignaturesCanWeMake()).toBe(1);
       } else {
-        assert.strictEqual(w.howManySignaturesCanWeMake(), 0);
+        expect(w.howManySignaturesCanWeMake()).toBe(0);
       }
 
-      assert.ok(w.isNativeSegwit());
-      assert.ok(!w.isWrappedSegwit());
-      assert.ok(!w.isLegacy());
+      expect(w.isNativeSegwit()).toBeTruthy();
+      expect(!w.isWrappedSegwit()).toBeTruthy();
+      expect(!w.isLegacy()).toBeTruthy();
 
-      assert.strictEqual(w.getCustomDerivationPathForCosigner(1), "m/1'");
-      assert.strictEqual(w.getCustomDerivationPathForCosigner(2), "m/1'");
+      expect(w.getCustomDerivationPathForCosigner(1)).toBe("m/1'");
+      expect(w.getCustomDerivationPathForCosigner(2)).toBe("m/1'");
 
-      assert.strictEqual(w.getFingerprint(1), '8aaa5d05'.toUpperCase());
-      assert.strictEqual(w.getFingerprint(2), 'ef748d2c'.toUpperCase());
-      assert.strictEqual(w.getFingerprint(3), 'fdb6c4d8'.toUpperCase());
+      expect(w.getFingerprint(1)).toBe('8aaa5d05'.toUpperCase());
+      expect(w.getFingerprint(2)).toBe('ef748d2c'.toUpperCase());
+      expect(w.getFingerprint(3)).toBe('fdb6c4d8'.toUpperCase());
 
       const utxos = [
         {
@@ -1359,28 +1317,28 @@ describe('multisig-wallet (native segwit)', () => {
         false,
         false,
       );
-      assert.ok(psbt);
-      assert.ok(!tx);
+      expect(psbt).toBeTruthy();
+      expect(!tx).toBeTruthy();
     }
   });
 
   it('cant import garbage', () => {
     const w = new MultisigHDWallet();
     w.setSecret('garbage');
-    assert.strictEqual(w.getM(), 0);
-    assert.strictEqual(w.getN(), 0);
+    expect(w.getM()).toBe(0);
+    expect(w.getN()).toBe(0);
 
     w.setSecret(Zpub1);
-    assert.strictEqual(w.getM(), 0);
-    assert.strictEqual(w.getN(), 0);
+    expect(w.getM()).toBe(0);
+    expect(w.getN()).toBe(0);
 
     w.setSecret(process.env.MNEMONICS_COBO);
-    assert.strictEqual(w.getM(), 0);
-    assert.strictEqual(w.getN(), 0);
+    expect(w.getM()).toBe(0);
+    expect(w.getN()).toBe(0);
 
     w.setSecret(MultisigHDWallet.seedToXpub(process.env.MNEMONICS_COLDCARD, "m/48'/0'/0'/1'"));
-    assert.strictEqual(w.getM(), 0);
-    assert.strictEqual(w.getN(), 0);
+    expect(w.getM()).toBe(0);
+    expect(w.getN()).toBe(0);
   });
 
   it('can import from caravan', () => {
@@ -1419,15 +1377,15 @@ describe('multisig-wallet (native segwit)', () => {
     let w = new MultisigHDWallet();
     w.setSecret(json);
 
-    assert.strictEqual(w.getM(), 2);
-    assert.strictEqual(w.getN(), 3);
-    assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1qnpy7c7wz6tvmhdwgyk8ka4du3s9x6uhgjal305xdatmwfa538zxsys5l0t');
-    assert.strictEqual(w._getExternalAddressByIndex(1), 'bc1qvuum7egsw4r4utzart88pergghy9rp8m4j5m4s464lz6u39sn6usn89w7c');
-    assert.strictEqual(w._getInternalAddressByIndex(0), 'bc1qatmvfj5nzh4z3njxeg8z86y592clqe7sfgvp5cpund47knnm6pxsswl2lr');
-    assert.strictEqual(w._getInternalAddressByIndex(1), 'bc1qpqa9c6nkqgcruegnh8wcsr0gzc4x9y90v9k0nxr6lww0gts430zqp7wm86');
-    assert.ok(!w.isWrappedSegwit());
-    assert.ok(w.isNativeSegwit());
-    assert.ok(!w.isLegacy());
+    expect(w.getM()).toBe(2);
+    expect(w.getN()).toBe(3);
+    expect(w._getExternalAddressByIndex(0)).toBe('bc1qnpy7c7wz6tvmhdwgyk8ka4du3s9x6uhgjal305xdatmwfa538zxsys5l0t');
+    expect(w._getExternalAddressByIndex(1)).toBe('bc1qvuum7egsw4r4utzart88pergghy9rp8m4j5m4s464lz6u39sn6usn89w7c');
+    expect(w._getInternalAddressByIndex(0)).toBe('bc1qatmvfj5nzh4z3njxeg8z86y592clqe7sfgvp5cpund47knnm6pxsswl2lr');
+    expect(w._getInternalAddressByIndex(1)).toBe('bc1qpqa9c6nkqgcruegnh8wcsr0gzc4x9y90v9k0nxr6lww0gts430zqp7wm86');
+    expect(!w.isWrappedSegwit()).toBeTruthy();
+    expect(w.isNativeSegwit()).toBeTruthy();
+    expect(!w.isLegacy()).toBeTruthy();
 
     // take 2
 
@@ -1462,17 +1420,17 @@ describe('multisig-wallet (native segwit)', () => {
     w = new MultisigHDWallet();
     w.setSecret(json2);
 
-    assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
-    assert.strictEqual(w._getInternalAddressByIndex(0), 'bc1qtah0p50d4qlftn049k7lldcwh7cs3zkjy9g8xegv63p308hsh9zsf5567q');
+    expect(w._getExternalAddressByIndex(0)).toBe('bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
+    expect(w._getInternalAddressByIndex(0)).toBe('bc1qtah0p50d4qlftn049k7lldcwh7cs3zkjy9g8xegv63p308hsh9zsf5567q');
 
-    assert.strictEqual(w.getM(), 2);
-    assert.strictEqual(w.getN(), 2);
-    assert.strictEqual(w.getFingerprint(1), '00000000'); // should be fp1cobo, but stupid caravan doesnt store fp
-    assert.strictEqual(w.getFingerprint(2), '00000000'); // should be fp2coldcard, but stupid caravan doesnt store fp
-    assert.strictEqual(w.howManySignaturesCanWeMake(), 0);
-    assert.ok(!w.isWrappedSegwit());
-    assert.ok(w.isNativeSegwit());
-    assert.ok(!w.isLegacy());
+    expect(w.getM()).toBe(2);
+    expect(w.getN()).toBe(2);
+    expect(w.getFingerprint(1)).toBe('00000000'); // should be fp1cobo, but stupid caravan doesnt store fp
+    expect(w.getFingerprint(2)).toBe('00000000'); // should be fp2coldcard, but stupid caravan doesnt store fp
+    expect(w.howManySignaturesCanWeMake()).toBe(0);
+    expect(!w.isWrappedSegwit()).toBeTruthy();
+    expect(w.isNativeSegwit()).toBeTruthy();
+    expect(!w.isLegacy()).toBeTruthy();
   });
 
   it('base43 works', () => {
@@ -1482,15 +1440,15 @@ describe('multisig-wallet (native segwit)', () => {
       '0100000001ac01d39c405d31d3d20b00254e84dce9838b9c280f3aa07bf77a1510d8f8779900000000fd4201004830450221009a4065d3b869f20b6e858e0722d9b511213e09dcf1b61072cccbff340c7f424e022034c42927a64fe323d8e8b76d99960322bf0664fdad9994939aedac74a32ca8c701483045022100dda3d5974ae1c06d9742c7aa5e2f789218054c60476f049300c7d4d0395819aa02201f484d7a2b4cc6186b23f54ea4099a728760d71fcc0c7a82bd056c6eaeacf3ab014cad5221020de4d18c5b852a3c1d1f1033a812b019c396b75cab2a248089b09632c7bbdda221024ee8ab3639ea02d7fac7e90078b16c06811573d7046cd06b5d1d8d7e50e0767a21025392159aaf967c2f7e1dca92b68d1b3abaf44a9d3903f7382e76f9f64e7bfa242102df269b98c7ea5bdec1aac268d6107b827163d3a0ca8bd3522279d14c46e1bf1a2103cfbf85d74dddf892b3b6f918fd36dab13cc904d9ba3c9306e9e25fe53ebde08155aeffffffff01131f0000000000001976a914e9cc1b59c97f860f5c629c23d93920da60648d0388ac00000000';
     const badString = 'invalid characters';
 
-    assert.throws(() => {
+    expect(() => {
       Base43.decode(badString);
-    });
-    assert.strictEqual(Base43.decode(electrum43TransactionString), hexTransactionString);
-    assert.ok(
+    }).toThrow();
+    expect(Base43.decode(electrum43TransactionString)).toBe(hexTransactionString);
+    expect(
       Base43.decode(
         '8+065FQS++FH76-QX$/RI8KR6O*V+WR-I0FH.9B49H1+L6I5N1JJ$M+P:3AH:QM2QUFSRR2D1XFX+I2:WTTG3F2HL4P02O2+6JE8VYJNXP:EPJ6KPMHQEJO-I/W.6*ESN:YC6FZ24PJS/QRU0YEAKSZAZM8:$7$HI7UKPG+H:+BNRO20QPOOCI8P45/TNGX-QR.X0P*WP0TAGCHMMO-UGONFLCG2QMMIA$GU6HPNI.9TK2+X99L7GLD0$OHSX2N55/1.X8ZCRH.-06B8L+6A865PIWM8Q.*8BLD2/AY+1E2F-FH6VD+JFZC*-G*IDZQ/U-8G0UOGYV1GA6BC1N.X95R:E12L987Q$TG61X4+SR4SO*IG083GH4L77DF6FL-JAFDX/W5BR4.I*$3S*9CDIW0Z4MXWJE-R9TP-OU3T$L0RHXXV885$GJ$VMOP6DX700GU7CASZGM:-XZQ+QSFXUOE:P/OKNUEIBT.BV8G.V5GRDQ3DT-W5*L4GHD-X2WFV9940YL:4LCTAWQDL..GAD9X6H:ZU064-5MUBKG0O20ZY8FV0RX+O7IL3T3YL0CKGLYZQUYXB+.F2JNN4MV83/V70UWZA6AGSU5SVSJMYXN7RRO02IXX8*QBDCYJU2G*N7+U',
       ).startsWith('70736274'),
-    );
+    ).toBeTruthy();
   });
 
   it('can import from specter-desktop/fullynoded', () => {
@@ -1503,36 +1461,33 @@ describe('multisig-wallet (native segwit)', () => {
     });
     const w = new MultisigHDWallet();
     w.setSecret(json);
-    assert.strictEqual(w.getM(), 2);
-    assert.strictEqual(w.getN(), 3);
-    assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1q338rmdygx0weah4pdrp9xyycxlv2t48276gk3gxmg6m7xdkkglsqgzm6mz');
-    assert.strictEqual(w._getInternalAddressByIndex(0), 'bc1qcgn73pjlwtt6krs2u6as0kh2jp486fa0t93yyq4d7xxxc37rf24qg67ewq');
-    assert.strictEqual(w.getLabel(), 'Multisig');
-    assert.ok(!w.isWrappedSegwit());
-    assert.ok(w.isNativeSegwit());
-    assert.ok(!w.isLegacy());
+    expect(w.getM()).toBe(2);
+    expect(w.getN()).toBe(3);
+    expect(w._getExternalAddressByIndex(0)).toBe('bc1q338rmdygx0weah4pdrp9xyycxlv2t48276gk3gxmg6m7xdkkglsqgzm6mz');
+    expect(w._getInternalAddressByIndex(0)).toBe('bc1qcgn73pjlwtt6krs2u6as0kh2jp486fa0t93yyq4d7xxxc37rf24qg67ewq');
+    expect(w.getLabel()).toBe('Multisig');
+    expect(!w.isWrappedSegwit()).toBeTruthy();
+    expect(w.isNativeSegwit()).toBeTruthy();
+    expect(!w.isLegacy()).toBeTruthy();
 
-    assert.strictEqual(w.getFingerprint(1), '1104442D');
-    assert.strictEqual(w.getFingerprint(2), '8CCE63F8');
-    assert.strictEqual(w.getFingerprint(3), 'BF27BD7B');
+    expect(w.getFingerprint(1)).toBe('1104442D');
+    expect(w.getFingerprint(2)).toBe('8CCE63F8');
+    expect(w.getFingerprint(3)).toBe('BF27BD7B');
 
-    assert.strictEqual(
-      w.getCosigner(1),
+    expect(w.getCosigner(1)).toBe(
       'xpub6ERaLLFZ3qu7X4cpiMAvSZ6UZVXJfxY5FoNvVJgai1V78DmeNHTcNVfu4cK2RmvTNXU4s1tFpGMPTwqoQ1RraE2o9iiNw2s2aHESpandSFY',
     );
-    assert.strictEqual(
-      w.getCosigner(2),
+    expect(w.getCosigner(2)).toBe(
       'xpub6FCSLcRY99737oUAnvXd1k2gSz9P4zi4gQJ8UChSPSCxCK7XS9kLzoLHKNBiR26d3ivT7w3oka9f4BepVLoQ875XzgejjbDo626R6NBUJDW',
     );
-    assert.strictEqual(
-      w.getCosigner(3),
+    expect(w.getCosigner(3)).toBe(
       'xpub6FE9uTPh1RxPRAfFVaET75vdfdQzXKZrT7LxukkqY4KhwUm4haMSPCwERfPouG6da6uZTRCXettvYFDck7nbw6JdBztGr1VBLonWch7NpJo',
     );
 
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(1), "m/48'/0'/0'/2'");
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(2), "m/48'/0'/0'/2'");
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(3), "m/48'/0'/0'/2'");
-    assert.strictEqual(w.getDerivationPath(), '');
+    expect(w.getCustomDerivationPathForCosigner(1)).toBe("m/48'/0'/0'/2'");
+    expect(w.getCustomDerivationPathForCosigner(2)).toBe("m/48'/0'/0'/2'");
+    expect(w.getCustomDerivationPathForCosigner(3)).toBe("m/48'/0'/0'/2'");
+    expect(w.getDerivationPath()).toBe('');
   });
 
   it('can import from specter-desktop/fullynoded (p2sh-p2wsh)', () => {
@@ -1551,36 +1506,33 @@ describe('multisig-wallet (native segwit)', () => {
     for (const secret of secrets) {
       const w = new MultisigHDWallet();
       w.setSecret(secret);
-      assert.strictEqual(w.getM(), 2);
-      assert.strictEqual(w.getN(), 3);
-      assert.strictEqual(w._getExternalAddressByIndex(0), '3GSZaKT3LujScx6JeWejc6xjZsCDRzptsA');
-      assert.strictEqual(w._getExternalAddressByIndex(1), '3GT11kStn8W6q2kj257uZqW9xEKJwPMDkw');
-      assert.ok(w.getLabel() === 'nested2of3' || w.getLabel() === 'Multisig vault');
-      assert.ok(w.isWrappedSegwit());
-      assert.ok(!w.isNativeSegwit());
-      assert.ok(!w.isLegacy());
+      expect(w.getM()).toBe(2);
+      expect(w.getN()).toBe(3);
+      expect(w._getExternalAddressByIndex(0)).toBe('3GSZaKT3LujScx6JeWejc6xjZsCDRzptsA');
+      expect(w._getExternalAddressByIndex(1)).toBe('3GT11kStn8W6q2kj257uZqW9xEKJwPMDkw');
+      expect(w.getLabel() === 'nested2of3' || w.getLabel() === 'Multisig vault').toBeTruthy();
+      expect(w.isWrappedSegwit()).toBeTruthy();
+      expect(!w.isNativeSegwit()).toBeTruthy();
+      expect(!w.isLegacy()).toBeTruthy();
 
-      assert.strictEqual(w.getFingerprint(1), '99FE7770');
-      assert.strictEqual(w.getFingerprint(2), '636BDAD0');
-      assert.strictEqual(w.getFingerprint(3), '99C90B2F');
+      expect(w.getFingerprint(1)).toBe('99FE7770');
+      expect(w.getFingerprint(2)).toBe('636BDAD0');
+      expect(w.getFingerprint(3)).toBe('99C90B2F');
 
-      assert.strictEqual(
-        w.getCosigner(1),
+      expect(w.getCosigner(1)).toBe(
         'xpub6FEEbEaYM9pmY8rxz4g6AuaJVszwKt8g6cFg9nFWeE85EdBrGBcnhHqXAaPbQ4Hi3Xu9vijtYdYnNjERw9eSniF3235Vjde11GieeHjv7XT',
       );
-      assert.strictEqual(
-        w.getCosigner(2),
+      expect(w.getCosigner(2)).toBe(
         'xpub6F67TyyWngU5rkVPxHTdmuYkaXHXeRwwVg5SsDeiPPjt6Mithh4Qzpu2yHjNa5W7nhcTbV6QaJMvppYMDSnB3SxArCkp9GvHQqpr5P17yFv',
       );
-      assert.strictEqual(
-        w.getCosigner(3),
+      expect(w.getCosigner(3)).toBe(
         'xpub6E6FyTrwmuUYeRMULXSAGvUKeP5ba6pQKVhWNuvVZFmGPnDYb9m5vP2XsSEQ4gKUGfXtLcKs4AV31vpfx2P5KuWm9co4HM3FtGov8enmJ6f',
       );
 
-      assert.strictEqual(w.getCustomDerivationPathForCosigner(1), "m/48'/0'/0'/1'");
-      assert.strictEqual(w.getCustomDerivationPathForCosigner(2), "m/48'/0'/0'/1'");
-      assert.strictEqual(w.getCustomDerivationPathForCosigner(3), "m/48'/0'/0'/1'");
-      assert.strictEqual(w.getDerivationPath(), '');
+      expect(w.getCustomDerivationPathForCosigner(1)).toBe("m/48'/0'/0'/1'");
+      expect(w.getCustomDerivationPathForCosigner(2)).toBe("m/48'/0'/0'/1'");
+      expect(w.getCustomDerivationPathForCosigner(3)).toBe("m/48'/0'/0'/1'");
+      expect(w.getDerivationPath()).toBe('');
     }
 
     const ww = new MultisigHDWallet();
@@ -1590,8 +1542,8 @@ describe('multisig-wallet (native segwit)', () => {
     ww.setM(2);
     ww.setDerivationPath("m/48'/0'/0'/1'");
     ww.setWrappedSegwit();
-    assert.strictEqual(ww._getExternalAddressByIndex(0), '3GSZaKT3LujScx6JeWejc6xjZsCDRzptsA');
-    assert.strictEqual(ww.getFingerprint(1), '99FE7770');
+    expect(ww._getExternalAddressByIndex(0)).toBe('3GSZaKT3LujScx6JeWejc6xjZsCDRzptsA');
+    expect(ww.getFingerprint(1)).toBe('99FE7770');
   });
 
   it('can edit cosigners', () => {
@@ -1602,55 +1554,55 @@ describe('multisig-wallet (native segwit)', () => {
     w.addCosigner(process.env.MNEMONICS_COLDCARD);
     w.setDerivationPath(path);
     w.setM(2);
-    assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
+    expect(w._getExternalAddressByIndex(0)).toBe('bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85');
 
-    assert.strictEqual(w.getCosigner(1), Zpub1);
-    assert.strictEqual(w.getCosigner(2), process.env.MNEMONICS_COLDCARD);
-    assert.strictEqual(w.getFingerprint(1), fp1cobo);
-    assert.strictEqual(w.getFingerprint(2), fp2coldcard);
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(1), path);
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(2), path);
+    expect(w.getCosigner(1)).toBe(Zpub1);
+    expect(w.getCosigner(2)).toBe(process.env.MNEMONICS_COLDCARD);
+    expect(w.getFingerprint(1)).toBe(fp1cobo);
+    expect(w.getFingerprint(2)).toBe(fp2coldcard);
+    expect(w.getCustomDerivationPathForCosigner(1)).toBe(path);
+    expect(w.getCustomDerivationPathForCosigner(2)).toBe(path);
 
-    assert.strictEqual(w.getCosignerForFingerprint(fp1cobo), Zpub1);
-    assert.strictEqual(w.getCosignerForFingerprint(fp2coldcard), process.env.MNEMONICS_COLDCARD);
-    assert.strictEqual(w.howManySignaturesCanWeMake(), 1);
+    expect(w.getCosignerForFingerprint(fp1cobo)).toBe(Zpub1);
+    expect(w.getCosignerForFingerprint(fp2coldcard)).toBe(process.env.MNEMONICS_COLDCARD);
+    expect(w.howManySignaturesCanWeMake()).toBe(1);
 
     w.replaceCosigner(fp2coldcard, Zpub2, fp2coldcard, path); // <-------------------
 
-    assert.strictEqual(w.getCosigner(2), Zpub2);
-    assert.strictEqual(w.getFingerprint(2), fp2coldcard);
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(2), path);
+    expect(w.getCosigner(2)).toBe(Zpub2);
+    expect(w.getFingerprint(2)).toBe(fp2coldcard);
+    expect(w.getCustomDerivationPathForCosigner(2)).toBe(path);
 
     w.replaceCosigner(fp2coldcard, process.env.MNEMONICS_COLDCARD); // <---------------------------
 
-    assert.strictEqual(w.getCosigner(2), process.env.MNEMONICS_COLDCARD);
-    assert.strictEqual(w.getFingerprint(2), fp2coldcard);
-    assert.strictEqual(w.getCustomDerivationPathForCosigner(2), path);
+    expect(w.getCosigner(2)).toBe(process.env.MNEMONICS_COLDCARD);
+    expect(w.getFingerprint(2)).toBe(fp2coldcard);
+    expect(w.getCustomDerivationPathForCosigner(2)).toBe(path);
 
     w.deleteCosigner(fp2coldcard);
-    assert.ok(!w.getCosigner(2));
-    assert.ok(!w.getFingerprint(2));
-    assert.ok(!w.getCustomDerivationPathForCosigner(2));
-    assert.strictEqual(w.getN(), 1);
-    assert.strictEqual(w.getM(), 2);
+    expect(!w.getCosigner(2)).toBeTruthy();
+    expect(!w.getFingerprint(2)).toBeTruthy();
+    expect(!w.getCustomDerivationPathForCosigner(2)).toBeTruthy();
+    expect(w.getN()).toBe(1);
+    expect(w.getM()).toBe(2);
 
     w.addCosigner(process.env.MNEMONICS_COLDCARD);
-    assert.strictEqual(w.getN(), 2);
+    expect(w.getN()).toBe(2);
     w.deleteCosigner(fp2coldcard);
-    assert.ok(!w.getCosigner(2));
-    assert.ok(!w.getFingerprint(2));
-    assert.ok(!w.getCustomDerivationPathForCosigner(2));
-    assert.strictEqual(w.getN(), 1);
-    assert.strictEqual(w.getM(), 2);
+    expect(!w.getCosigner(2)).toBeTruthy();
+    expect(!w.getFingerprint(2)).toBeTruthy();
+    expect(!w.getCustomDerivationPathForCosigner(2)).toBeTruthy();
+    expect(w.getN()).toBe(1);
+    expect(w.getM()).toBe(2);
 
     w.addCosigner(Zpub2, fp2coldcard, path);
-    assert.strictEqual(w.getN(), 2);
+    expect(w.getN()).toBe(2);
     w.deleteCosigner(fp2coldcard);
-    assert.ok(!w.getCosigner(2));
-    assert.ok(!w.getFingerprint(2));
-    assert.ok(!w.getCustomDerivationPathForCosigner(2));
-    assert.strictEqual(w.getN(), 1);
-    assert.strictEqual(w.getM(), 2);
+    expect(!w.getCosigner(2)).toBeTruthy();
+    expect(!w.getFingerprint(2)).toBeTruthy();
+    expect(!w.getCustomDerivationPathForCosigner(2)).toBeTruthy();
+    expect(w.getN()).toBe(1);
+    expect(w.getM()).toBe(2);
   });
 
   it('can sign valid tx if we have more keys than quorum ("Too many signatures" error)', async () => {
@@ -1706,11 +1658,11 @@ describe('multisig-wallet (native segwit)', () => {
       w._getInternalAddressByIndex(0),
     );
 
-    assert.ok(tx);
-    assert.ok(psbt);
+    expect(tx).toBeTruthy();
+    expect(psbt).toBeTruthy();
 
-    assert.strictEqual(psbt.data.inputs.length, 1);
-    assert.strictEqual(psbt.data.outputs.length, 1);
+    expect(psbt.data.inputs.length).toBe(1);
+    expect(psbt.data.outputs.length).toBe(1);
   });
 
   it('can sign multiple inputs', async () => {
@@ -1770,11 +1722,11 @@ describe('multisig-wallet (native segwit)', () => {
       w._getInternalAddressByIndex(0),
     );
 
-    assert.ok(tx);
-    assert.ok(psbt);
+    expect(tx).toBeTruthy();
+    expect(psbt).toBeTruthy();
 
-    assert.strictEqual(psbt.data.inputs.length, 2);
-    assert.strictEqual(psbt.data.outputs.length, 1);
+    expect(psbt.data.inputs.length).toBe(2);
+    expect(psbt.data.outputs.length).toBe(1);
   });
 });
 
@@ -1783,11 +1735,11 @@ describe('multisig-cosigner', () => {
     const cosigner = new MultisigCosigner(
       '{"xfp":"D37EAD88","xpub":"Zpub74ijpfhERJNjhCKXRspTdLJV5eoEmSRZdHqDvp9kVtdVEyiXk7pXxRbfZzQvsDFpfDHEHVtVpx4Dz9DGUWGn2Xk5zG5u45QTMsYS2vjohNQ","path":"m\\/48\'\\/0\'\\/0\'\\/2\'"}',
     );
-    assert.ok(cosigner.isValid());
-    assert.strictEqual(cosigner.getFp(), fp1cobo);
-    assert.strictEqual(cosigner.getXpub(), Zpub1);
-    assert.strictEqual(cosigner.getPath(), "m/48'/0'/0'/2'");
-    assert.strictEqual(cosigner.howManyCosignersWeHave(), 1);
+    expect(cosigner.isValid()).toBeTruthy();
+    expect(cosigner.getFp()).toBe(fp1cobo);
+    expect(cosigner.getXpub()).toBe(Zpub1);
+    expect(cosigner.getPath()).toBe("m/48'/0'/0'/2'");
+    expect(cosigner.howManyCosignersWeHave()).toBe(1);
   });
 
   it('can parse cobo URv2 account', () => {
@@ -1797,57 +1749,54 @@ describe('multisig-cosigner', () => {
     decoded = Buffer.from(decoded, 'hex').toString('ascii');
 
     const cosigner = new MultisigCosigner(decoded);
-    assert.ok(cosigner.isValid());
-    assert.strictEqual(
-      cosigner.getXpub(),
+    expect(cosigner.isValid()).toBeTruthy();
+    expect(cosigner.getXpub()).toBe(
       'Zpub756tPxxwHiYkYiT12G2WUD2cpAHyVWhjvKPbXoY5jDZSyo71yG5C14LCuwhycTTAzgTUcQfddR8FFTQ1bSWR6kzmNbMEaVzUrj4Lhxbonjo',
     );
-    assert.strictEqual(cosigner.getPath(), "m/48'/0'/0'/2'");
-    assert.strictEqual(cosigner.howManyCosignersWeHave(), 1);
-    assert.strictEqual(cosigner.getFp(), '01EBDA7D');
+    expect(cosigner.getPath()).toBe("m/48'/0'/0'/2'");
+    expect(cosigner.howManyCosignersWeHave()).toBe(1);
+    expect(cosigner.getFp()).toBe('01EBDA7D');
   });
 
   it('can parse plain Zpub', () => {
     const cosigner = new MultisigCosigner(Zpub1);
-    assert.ok(cosigner.isValid());
-    assert.strictEqual(cosigner.getFp(), '00000000');
-    assert.strictEqual(cosigner.getXpub(), Zpub1);
-    assert.strictEqual(cosigner.getPath(), "m/48'/0'/0'/2'");
-    assert.strictEqual(cosigner.howManyCosignersWeHave(), 1);
+    expect(cosigner.isValid()).toBeTruthy();
+    expect(cosigner.getFp()).toBe('00000000');
+    expect(cosigner.getXpub()).toBe(Zpub1);
+    expect(cosigner.getPath()).toBe("m/48'/0'/0'/2'");
+    expect(cosigner.howManyCosignersWeHave()).toBe(1);
   });
 
   it('can parse wallet descriptor', () => {
     let cosigner = new MultisigCosigner(
       '[73c5da0a/48h/0h/0h/2h]Zpub74Jru6aftwwHxCUCWEvP6DgrfFsdA4U6ZRtQ5i8qJpMcC39yZGv3egBhQfV3MS9pZtH5z8iV5qWkJsK6ESs6mSzt4qvGhzJxPeeVS2e1zUG',
     );
-    assert.ok(cosigner.isValid());
-    assert.strictEqual(cosigner.getFp(), '73c5da0a');
-    assert.strictEqual(
-      cosigner.getXpub(),
+    expect(cosigner.isValid()).toBeTruthy();
+    expect(cosigner.getFp()).toBe('73c5da0a');
+    expect(cosigner.getXpub()).toBe(
       'Zpub74Jru6aftwwHxCUCWEvP6DgrfFsdA4U6ZRtQ5i8qJpMcC39yZGv3egBhQfV3MS9pZtH5z8iV5qWkJsK6ESs6mSzt4qvGhzJxPeeVS2e1zUG',
     );
-    assert.strictEqual(cosigner.getPath(), "m/48'/0'/0'/2'");
-    assert.strictEqual(cosigner.howManyCosignersWeHave(), 1);
+    expect(cosigner.getPath()).toBe("m/48'/0'/0'/2'");
+    expect(cosigner.howManyCosignersWeHave()).toBe(1);
 
     cosigner = new MultisigCosigner(
       '[73c5da0a/48h/0h/0h/2h]xpub6DkFAXWQ2dHxq2vatrt9qyA3bXYU4ToWQwCHbf5XB2mSTexcHZCeKS1VZYcPoBd5X8yVcbXFHJR9R8UCVpt82VX1VhR28mCyxUFL4r6KFrf',
     );
-    assert.ok(cosigner.isValid());
-    assert.strictEqual(cosigner.getFp(), '73c5da0a');
-    assert.strictEqual(
-      cosigner.getXpub(),
+    expect(cosigner.isValid()).toBeTruthy();
+    expect(cosigner.getFp()).toBe('73c5da0a');
+    expect(cosigner.getXpub()).toBe(
       'xpub6DkFAXWQ2dHxq2vatrt9qyA3bXYU4ToWQwCHbf5XB2mSTexcHZCeKS1VZYcPoBd5X8yVcbXFHJR9R8UCVpt82VX1VhR28mCyxUFL4r6KFrf',
     );
-    assert.strictEqual(cosigner.getPath(), "m/48'/0'/0'/2'");
-    assert.strictEqual(cosigner.howManyCosignersWeHave(), 1);
+    expect(cosigner.getPath()).toBe("m/48'/0'/0'/2'");
+    expect(cosigner.howManyCosignersWeHave()).toBe(1);
   });
 
   it('cant parse bs', () => {
     const cosigner = new MultisigCosigner('asdfasdgsqwrgqwegq');
-    assert.ok(!cosigner.isValid());
-    assert.strictEqual(cosigner.getFp(), false);
-    assert.strictEqual(cosigner.getXpub(), false);
-    assert.strictEqual(cosigner.getPath(), false);
+    expect(!cosigner.isValid()).toBeTruthy();
+    expect(cosigner.getFp()).toBe(false);
+    expect(cosigner.getXpub()).toBe(false);
+    expect(cosigner.getPath()).toBe(false);
   });
 
   it('can parse file from coldcard with multiple xpubs (for different formats)', () => {
@@ -1863,34 +1812,31 @@ describe('multisig-cosigner', () => {
       '}\n';
 
     const cosigner = new MultisigCosigner(cc);
-    assert.strictEqual(cosigner.howManyCosignersWeHave(), 3);
-    assert.ok(cosigner.isValid());
-    assert.strictEqual(cosigner.getFp(), false);
-    assert.strictEqual(cosigner.getXpub(), false);
-    assert.strictEqual(cosigner.getPath(), false);
+    expect(cosigner.howManyCosignersWeHave()).toBe(3);
+    expect(cosigner.isValid()).toBeTruthy();
+    expect(cosigner.getFp()).toBe(false);
+    expect(cosigner.getXpub()).toBe(false);
+    expect(cosigner.getPath()).toBe(false);
 
     const [c1, c2, c3] = cosigner.getAllCosigners();
 
-    assert.strictEqual(
-      c1.getXpub(),
+    expect(c1.getXpub()).toBe(
       'xpub6847W6cYUqq4ixcmFb83iqPtJZfnMPTkpYiCsuUybzFppJp2qzh3KCVHsLGQy4WhaxGqkK9aDDZnSfhB92PkHDKihbH6WLztzmN7WW9GYpR',
     );
-    assert.strictEqual(c1.getFp(), '168DD603');
-    assert.strictEqual(c1.getPath(), "m/45'");
+    expect(c1.getFp()).toBe('168DD603');
+    expect(c1.getPath()).toBe("m/45'");
 
-    assert.strictEqual(
-      c2.getXpub(),
+    expect(c2.getXpub()).toBe(
       'Ypub6kvtvTZpqGuWtQfg9bL5xe4vDWtwsirR8LzDvsY3vgXvyncW1NGXCUJ9Ps7CiizSSLV6NnnXSYyVDnxCu26QChWzWLg5YCAHam6cYjGtzRz',
     );
-    assert.strictEqual(c2.getFp(), '168DD603');
-    assert.strictEqual(c2.getPath(), "m/48'/0'/0'/1'");
+    expect(c2.getFp()).toBe('168DD603');
+    expect(c2.getPath()).toBe("m/48'/0'/0'/1'");
 
-    assert.strictEqual(
-      c3.getXpub(),
+    expect(c3.getXpub()).toBe(
       'Zpub75mAE8EjyxSzoyPmGnd5E6MyD7ALGNndruWv52xpzimZQKukwvEfXTHqmH8nbbc6ccP5t2aM3mws3pKYSnKpKMMytdbNEZFUxKzztYFM8Pn',
     );
-    assert.strictEqual(c3.getFp(), '168DD603');
-    assert.strictEqual(c3.getPath(), "m/48'/0'/0'/2'");
+    expect(c3.getFp()).toBe('168DD603');
+    expect(c3.getPath()).toBe("m/48'/0'/0'/2'");
   });
 
   it('can parse files from sparrow wallet', () => {
@@ -1904,28 +1850,26 @@ describe('multisig-cosigner', () => {
       const w = new MultisigHDWallet();
       w.setSecret(s);
 
-      assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1qtysquqsjqjfqvhd6l2h470hdgwhcahs4nq2ca49cyxftwjnjt9ssh8emel');
+      expect(w._getExternalAddressByIndex(0)).toBe('bc1qtysquqsjqjfqvhd6l2h470hdgwhcahs4nq2ca49cyxftwjnjt9ssh8emel');
     }
   });
 
   it('can export to json', () => {
     const result = MultisigCosigner.exportToJson(fp1cobo, Zpub1, "m/48'/0'/0'/2'");
-    assert.strictEqual(
-      result,
+    expect(result).toBe(
       '{"xfp":"D37EAD88","xpub":"Zpub74ijpfhERJNjhCKXRspTdLJV5eoEmSRZdHqDvp9kVtdVEyiXk7pXxRbfZzQvsDFpfDHEHVtVpx4Dz9DGUWGn2Xk5zG5u45QTMsYS2vjohNQ","path":"m/48\'/0\'/0\'/2\'"}',
     );
 
     const cosigner = new MultisigCosigner(MultisigCosigner.exportToJson(fp1cobo, Zpub1, "m/48'/0'/0'/2'"));
-    assert.strictEqual(cosigner.getFp(), 'D37EAD88');
-    assert.strictEqual(
-      cosigner.getXpub(),
+    expect(cosigner.getFp()).toBe('D37EAD88');
+    expect(cosigner.getXpub()).toBe(
       'Zpub74ijpfhERJNjhCKXRspTdLJV5eoEmSRZdHqDvp9kVtdVEyiXk7pXxRbfZzQvsDFpfDHEHVtVpx4Dz9DGUWGn2Xk5zG5u45QTMsYS2vjohNQ',
     );
-    assert.strictEqual(cosigner.getPath(), "m/48'/0'/0'/2'");
-    assert.strictEqual(cosigner.isValid(), true);
-    assert.strictEqual(cosigner.isNativeSegwit(), true);
-    assert.strictEqual(cosigner.isWrappedSegwit(), false);
-    assert.strictEqual(cosigner.isLegacy(), false);
+    expect(cosigner.getPath()).toBe("m/48'/0'/0'/2'");
+    expect(cosigner.isValid()).toBe(true);
+    expect(cosigner.isNativeSegwit()).toBe(true);
+    expect(cosigner.isWrappedSegwit()).toBe(false);
+    expect(cosigner.isLegacy()).toBe(false);
 
     // using bad xpub just to check chaincode & keyhex
     const c2 = new MultisigCosigner(
@@ -1935,15 +1879,15 @@ describe('multisig-cosigner', () => {
         "m/48'/0'/0'/2'",
       ),
     );
-    assert.strictEqual(c2.getChainCodeHex(), '906730ab8a03fb4baa32a912134f2c5bfe6ae70e0264e4e9fe4b0abe3a560692');
-    assert.strictEqual(c2.getKeyHex(), '0395b643f45bd89fede6f4f6416b288e73005419b48cdcd88465913bd31b4be5ea');
-    assert.strictEqual(c2.getParentFingerprintHex(), '125688b1');
-    assert.strictEqual(c2.getDepthNumber(), 3);
+    expect(c2.getChainCodeHex()).toBe('906730ab8a03fb4baa32a912134f2c5bfe6ae70e0264e4e9fe4b0abe3a560692');
+    expect(c2.getKeyHex()).toBe('0395b643f45bd89fede6f4f6416b288e73005419b48cdcd88465913bd31b4be5ea');
+    expect(c2.getParentFingerprintHex()).toBe('125688b1');
+    expect(c2.getDepthNumber()).toBe(3);
   });
 
   it('can export cosigner to URv2', () => {
     let result = encodeUR(MultisigCosigner.exportToJson(fp1cobo, Zpub1, "m/48'/0'/0'/2'"));
-    assert.deepStrictEqual(result, [
+    expect(result).toEqual([
       'ur:crypto-account/oeadcytekbpmloaolytaadmetaaddloxaxhdclaofejnolgudllagdgodyweehzsmeyasnswrpdalnwzfenbmewlrtplsklbjkvdloweaahdcxltjzjpctayfsimuogtpypffrnlisflswwzntbecabtbdwdbstojnfrahdamnpfcyamtaaddyotadlocsdyykaeykaeykaoykaocytekbpmloaxaaaycyghykhpcmkgnstevs',
     ]);
 
@@ -1954,7 +1898,7 @@ describe('multisig-cosigner', () => {
         "m/48'/0'/0'/1'",
       ),
     );
-    assert.deepStrictEqual(result, [
+    expect(result).toEqual([
       'ur:crypto-account/oeadcyfwoefgbaaolytaadmhtaadmetaaddloxaxhdclaxsblplucfptgtwywzcmnshtotqzleihrnndtoeodrfdpfoyeyqzsbenrplbhtdymuaahdcxlgbdsrcxatcmdpuokpwzvymttatphtlftplsvlgmeeflpdtanlromhfgvekbbznyamtaaddyotadlocsdyykaeykaeykadykaocyfwoefgbaaxaaaycywsutbeuyyndacaeh',
     ]);
 
@@ -1965,7 +1909,7 @@ describe('multisig-cosigner', () => {
         "m/45'",
       ),
     );
-    assert.deepStrictEqual(result, [
+    expect(result).toEqual([
       'ur:crypto-account/oeadcywehhhpleaolytaadmhtaaddloxaxhdclaoamutctbahthnislelbwemnkeoefnhddienfetbpygrpaqdkemyrywyldaspyjkdtaahdcxhyneskwdhlehlfbwrpdnjlgsgakplkjtknvyttsgolnnlbwlcagoolcpfgsglkinamtaaddyotadlfcsdpykaocywehhhpleaxadaycywehhhplekpdwveih',
     ]);
   });

--- a/tests/unit/payjoin-transaction.test.js
+++ b/tests/unit/payjoin-transaction.test.js
@@ -1,8 +1,9 @@
+import * as bitcoin from 'bitcoinjs-lib';
+import { PayjoinClient } from 'payjoin-client';
+
 import { HDSegwitBech32Wallet } from '../../class';
 import PayjoinTransaction from '../../class/payjoin-transaction';
-import { PayjoinClient } from 'payjoin-client';
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
+
 jest.useFakeTimers();
 
 const utxos = [
@@ -34,15 +35,15 @@ describe('PayjoinTransaction', () => {
       w._getInternalAddressByIndex(0),
     );
 
-    assert.strictEqual(txOrig.ins.length, 1);
-    assert.strictEqual(txOrig.outs.length, 2);
+    expect(txOrig.ins.length).toBe(1);
+    expect(txOrig.outs.length).toBe(2);
 
     let broadcastWasCalled;
     const wallet = new PayjoinTransaction(
       psbtOrig,
       async txhex => {
         broadcastWasCalled = true;
-        assert.strictEqual(txhex, txOrig.toHex());
+        expect(txhex).toBe(txOrig.toHex());
         return true;
       },
       w,
@@ -61,11 +62,11 @@ describe('PayjoinTransaction', () => {
       payjoinRequester: payjoinRequesterMock,
     });
 
-    await assert.rejects(payjoinClient.run());
+    await expect(payjoinClient.run()).rejects.toThrow();
 
-    assert.ok(broadcastWasCalled);
+    expect(broadcastWasCalled).toBeTruthy();
     const payjoinPsbt = wallet.getPayjoinPsbt();
-    assert.ok(!payjoinPsbt);
+    expect(!payjoinPsbt).toBeTruthy();
   });
 
   it('works', async () => {
@@ -82,8 +83,8 @@ describe('PayjoinTransaction', () => {
       7,
       w._getInternalAddressByIndex(0),
     );
-    assert.strictEqual(txOrigin.ins.length, 1);
-    assert.strictEqual(txOrigin.outs.length, 2);
+    expect(txOrigin.ins.length).toBe(1);
+    expect(txOrigin.outs.length).toBe(2);
 
     let broadcastWasCalled = 0;
     const wallet = new PayjoinTransaction(
@@ -91,10 +92,10 @@ describe('PayjoinTransaction', () => {
       async txhex => {
         broadcastWasCalled++;
         const tx2broadcast = bitcoin.Transaction.fromHex(txhex);
-        assert.strictEqual(tx2broadcast.ins.length, 2);
-        assert.strictEqual(tx2broadcast.outs.length, 2);
+        expect(tx2broadcast.ins.length).toBe(2);
+        expect(tx2broadcast.outs.length).toBe(2);
 
-        assert.notStrictEqual(txhex, txOrigin.toHex());
+        expect(txhex).not.toBe(txOrigin.toHex());
         return true;
       },
       w,
@@ -118,10 +119,10 @@ describe('PayjoinTransaction', () => {
     await payjoinClient.run();
 
     const payjoinPsbt = wallet.getPayjoinPsbt();
-    assert.ok(payjoinPsbt);
+    expect(payjoinPsbt).toBeTruthy();
     const txPayjoin = payjoinPsbt.extractTransaction();
-    assert.strictEqual(txPayjoin.ins.length, 2);
-    assert.strictEqual(txPayjoin.outs.length, 2);
-    assert.strictEqual(broadcastWasCalled, 1);
+    expect(txPayjoin.ins.length).toBe(2);
+    expect(txPayjoin.outs.length).toBe(2);
+    expect(broadcastWasCalled).toBe(1);
   });
 });

--- a/tests/unit/provide-entropy.test.js
+++ b/tests/unit/provide-entropy.test.js
@@ -1,44 +1,42 @@
-import assert from 'assert';
-
 import { eReducer, entropyToHex, getEntropy, convertToBuffer } from '../../screen/wallets/provideEntropy';
 
 describe('Entropy reducer and format', () => {
   it('handles push and pop correctly', () => {
     let state = eReducer(undefined, { type: null });
-    assert.equal(entropyToHex(state), '0x');
+    expect(entropyToHex(state)).toBe('0x');
 
     state = eReducer(state, { type: 'push', value: 0, bits: 1 });
-    assert.equal(entropyToHex(state), '0x0');
+    expect(entropyToHex(state)).toBe('0x0');
 
     state = eReducer(state, { type: 'push', value: 0, bits: 1 });
-    assert.equal(entropyToHex(state), '0x0');
+    expect(entropyToHex(state)).toBe('0x0');
 
     state = eReducer(state, { type: 'push', value: 0, bits: 3 });
-    assert.equal(entropyToHex(state), '0x00');
+    expect(entropyToHex(state)).toBe('0x00');
 
     state = eReducer(state, { type: 'pop' });
-    assert.equal(entropyToHex(state), '0x0');
+    expect(entropyToHex(state)).toBe('0x0');
 
     state = eReducer(state, { type: 'pop' });
     state = eReducer(state, { type: 'pop' });
-    assert.equal(entropyToHex(state), '0x');
+    expect(entropyToHex(state)).toBe('0x');
 
     state = eReducer(state, { type: 'push', value: 1, bits: 1 });
-    assert.equal(entropyToHex(state), '0x1'); // 0b1
+    expect(entropyToHex(state)).toBe('0x1'); // 0b1
 
     state = eReducer(state, { type: 'push', value: 0, bits: 1 });
-    assert.equal(entropyToHex(state), '0x2'); // 0b10
+    expect(entropyToHex(state)).toBe('0x2'); // 0b10
 
     state = eReducer(state, { type: 'push', value: 0b01, bits: 2 });
-    assert.equal(entropyToHex(state), '0x9'); // 0b1001
+    expect(entropyToHex(state)).toBe('0x9'); // 0b1001
 
     state = eReducer(state, { type: 'push', value: 0b10, bits: 2 });
-    assert.equal(entropyToHex(state), '0x26'); // 0b100110
+    expect(entropyToHex(state)).toBe('0x26'); // 0b100110
   });
 
   it('handles 128 bits correctly', () => {
     const state = eReducer(undefined, { type: 'push', value: 0, bits: 128 });
-    assert.equal(entropyToHex(state), '0x00000000000000000000000000000000');
+    expect(entropyToHex(state)).toBe('0x00000000000000000000000000000000');
   });
 
   it('handles 256 bits correctly', () => {
@@ -48,22 +46,22 @@ describe('Entropy reducer and format', () => {
     for (const i of [...Array(256)]) {
       state = eReducer(state, { type: 'push', value: 1, bits: 1 });
     }
-    assert.equal(entropyToHex(state), '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
+    expect(entropyToHex(state)).toBe('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
   });
 
   it('handles pop when empty without error', () => {
     const state = eReducer(undefined, { type: 'pop' });
-    assert.equal(entropyToHex(state), '0x');
+    expect(entropyToHex(state)).toBe('0x');
   });
 
   it('handles 256 bits limit', () => {
     let state = eReducer(undefined, { type: 'push', value: 0, bits: 254 });
     state = eReducer(state, { type: 'push', value: 0b101, bits: 3 });
-    assert.equal(entropyToHex(state), '0x0000000000000000000000000000000000000000000000000000000000000002');
+    expect(entropyToHex(state)).toBe('0x0000000000000000000000000000000000000000000000000000000000000002');
   });
 
   it('Throws error if you try to push value exceeding size in bits', () => {
-    assert.throws(() => eReducer(undefined, { type: 'push', value: 8, bits: 3 }), {
+    expect(() => eReducer(undefined, { type: 'push', value: 8, bits: 3 })).toThrow({
       name: 'TypeError',
       message: "Can't push value exceeding size in bits",
     });
@@ -72,72 +70,72 @@ describe('Entropy reducer and format', () => {
 
 describe('getEntropy function', () => {
   it('handles coin', () => {
-    assert.deepEqual(getEntropy(0, 2), { value: 0, bits: 1 });
-    assert.deepEqual(getEntropy(1, 2), { value: 1, bits: 1 });
+    expect(getEntropy(0, 2)).toEqual({ value: 0, bits: 1 });
+    expect(getEntropy(1, 2)).toEqual({ value: 1, bits: 1 });
   });
 
   it('handles 6 sides dice', () => {
-    assert.deepEqual(getEntropy(0, 6), { value: 0, bits: 2 });
-    assert.deepEqual(getEntropy(1, 6), { value: 1, bits: 2 });
-    assert.deepEqual(getEntropy(2, 6), { value: 2, bits: 2 });
-    assert.deepEqual(getEntropy(3, 6), { value: 3, bits: 2 });
-    assert.deepEqual(getEntropy(4, 6), { value: 0, bits: 1 });
-    assert.deepEqual(getEntropy(5, 6), { value: 1, bits: 1 });
+    expect(getEntropy(0, 6)).toEqual({ value: 0, bits: 2 });
+    expect(getEntropy(1, 6)).toEqual({ value: 1, bits: 2 });
+    expect(getEntropy(2, 6)).toEqual({ value: 2, bits: 2 });
+    expect(getEntropy(3, 6)).toEqual({ value: 3, bits: 2 });
+    expect(getEntropy(4, 6)).toEqual({ value: 0, bits: 1 });
+    expect(getEntropy(5, 6)).toEqual({ value: 1, bits: 1 });
   });
 
   it('handles 20 sides dice', () => {
-    assert.deepEqual(getEntropy(0, 20), { value: 0, bits: 4 });
-    assert.deepEqual(getEntropy(15, 20), { value: 15, bits: 4 });
+    expect(getEntropy(0, 20)).toEqual({ value: 0, bits: 4 });
+    expect(getEntropy(15, 20)).toEqual({ value: 15, bits: 4 });
 
-    assert.deepEqual(getEntropy(16, 20), { value: 0, bits: 2 });
-    assert.deepEqual(getEntropy(17, 20), { value: 1, bits: 2 });
-    assert.deepEqual(getEntropy(18, 20), { value: 2, bits: 2 });
-    assert.deepEqual(getEntropy(19, 20), { value: 3, bits: 2 });
+    expect(getEntropy(16, 20)).toEqual({ value: 0, bits: 2 });
+    expect(getEntropy(17, 20)).toEqual({ value: 1, bits: 2 });
+    expect(getEntropy(18, 20)).toEqual({ value: 2, bits: 2 });
+    expect(getEntropy(19, 20)).toEqual({ value: 3, bits: 2 });
   });
 
   it('handles odd numbers', () => {
-    assert.deepEqual(getEntropy(0, 3), { value: 0, bits: 1 });
-    assert.deepEqual(getEntropy(1, 3), { value: 1, bits: 1 });
-    assert.deepEqual(getEntropy(2, 3), null);
+    expect(getEntropy(0, 3)).toEqual({ value: 0, bits: 1 });
+    expect(getEntropy(1, 3)).toEqual({ value: 1, bits: 1 });
+    expect(getEntropy(2, 3)).toEqual(null);
   });
 });
 
 describe('convertToBuffer function', () => {
   it('zero bits', () => {
     const state = eReducer(undefined, { type: null });
-    assert.deepEqual(convertToBuffer(state), Buffer.from([]));
+    expect(convertToBuffer(state)).toEqual(Buffer.from([]));
   });
 
   it('8 zero bits', () => {
     const state = eReducer(undefined, { type: 'push', value: 0, bits: 8 });
-    assert.deepEqual(convertToBuffer(state), Buffer.from([0]));
+    expect(convertToBuffer(state)).toEqual(Buffer.from([0]));
   });
 
   it('8 filled bits', () => {
     const state = eReducer(undefined, { type: 'push', value: 0b11111111, bits: 8 });
-    assert.deepEqual(convertToBuffer(state), Buffer.from([0b11111111]));
+    expect(convertToBuffer(state)).toEqual(Buffer.from([0b11111111]));
   });
 
   it('9 zero bits', () => {
     const state = eReducer(undefined, { type: 'push', value: 0, bits: 9 });
-    assert.deepEqual(convertToBuffer(state), Buffer.from([0]));
+    expect(convertToBuffer(state)).toEqual(Buffer.from([0]));
   });
 
   it('9 filled bits', () => {
     const state = eReducer(undefined, { type: 'push', value: 0b111111111, bits: 9 });
-    assert.deepEqual(convertToBuffer(state), Buffer.from([0b11111111]));
+    expect(convertToBuffer(state)).toEqual(Buffer.from([0b11111111]));
   });
 
   it('9 bits', () => {
     const state = eReducer(undefined, { type: 'push', value: 0b111100111, bits: 9 });
-    assert.deepEqual(convertToBuffer(state), Buffer.from([0b11100111]));
+    expect(convertToBuffer(state)).toEqual(Buffer.from([0b11100111]));
   });
 
   it('3 bytes', () => {
     let state = eReducer(undefined, { type: 'push', value: 1, bits: 8 });
     state = eReducer(state, { type: 'push', value: 2, bits: 8 });
     state = eReducer(state, { type: 'push', value: 3, bits: 8 });
-    assert.deepEqual(convertToBuffer(state), Buffer.from([1, 2, 3]));
+    expect(convertToBuffer(state)).toEqual(Buffer.from([1, 2, 3]));
   });
 
   it('256 bits or 32bytes', () => {
@@ -150,6 +148,6 @@ describe('convertToBuffer function', () => {
 
     const bytes = [...Array(32)].map(() => 255);
 
-    assert.deepEqual(convertToBuffer(state), Buffer.from(bytes));
+    expect(convertToBuffer(state)).toEqual(Buffer.from(bytes));
   });
 });

--- a/tests/unit/segwit-bech32-wallet.test.js
+++ b/tests/unit/segwit-bech32-wallet.test.js
@@ -1,14 +1,13 @@
+import * as bitcoin from 'bitcoinjs-lib';
 import { SegwitBech32Wallet } from '../../class';
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
 
 describe('Segwit P2SH wallet', () => {
   it('can create transaction', async () => {
     const wallet = new SegwitBech32Wallet();
     wallet.setSecret('L4vn2KxgMLrEVpxjfLwxfjnPPQMnx42DCjZJ2H7nN4mdHDyEUWXd');
-    assert.strictEqual(wallet.getAddress(), 'bc1q3rl0mkyk0zrtxfmqn9wpcd3gnaz00yv9yp0hxe');
-    assert.deepStrictEqual(wallet.getAllExternalAddresses(), ['bc1q3rl0mkyk0zrtxfmqn9wpcd3gnaz00yv9yp0hxe']);
-    assert.strictEqual(await wallet.getChangeAddressAsync(), wallet.getAddress());
+    expect(wallet.getAddress()).toBe('bc1q3rl0mkyk0zrtxfmqn9wpcd3gnaz00yv9yp0hxe');
+    expect(wallet.getAllExternalAddresses()).toEqual(['bc1q3rl0mkyk0zrtxfmqn9wpcd3gnaz00yv9yp0hxe']);
+    expect(await wallet.getChangeAddressAsync()).toBe(wallet.getAddress());
 
     const utxos = [
       {
@@ -20,21 +19,20 @@ describe('Segwit P2SH wallet', () => {
 
     let txNew = wallet.createTransaction(utxos, [{ value: 90000, address: '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB' }], 1, wallet.getAddress());
     let tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-    assert.strictEqual(
-      txNew.tx.toHex(),
+    expect(txNew.tx.toHex()).toBe(
       '02000000000101ebff950f972e51ea4791f635fef777d5ed0162bacf74f03f5819b976c08bd1570000000000ffffffff02905f0100000000001976a914aa381cd428a4e91327fd4434aa0a08ff131f1a5a88ac2e2600000000000016001488fefdd8967886b32760995c1c36289f44f791850247304402206272d7ba35177bbcccbf52a49a9466e7692252ebbb36753c50ea99c6de8ddb6402204975c76d894b6811b86bab9f2544e7ade7d4f4f7e6a543a60d0af1b854c493a601210314cf2bf53f221e58c5adc1dd95adba9239b248f39b09eb2c550aadc1926fe7aa00000000',
     );
-    assert.strictEqual(tx.ins.length, 1);
-    assert.strictEqual(tx.outs.length, 2);
-    assert.strictEqual('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB', bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
-    assert.strictEqual(bitcoin.address.fromOutputScript(tx.outs[1].script), wallet.getAddress()); // change address
+    expect(tx.ins.length).toBe(1);
+    expect(tx.outs.length).toBe(2);
+    expect('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB').toBe(bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
+    expect(bitcoin.address.fromOutputScript(tx.outs[1].script)).toBe(wallet.getAddress()); // change address
 
     // sendMax
     txNew = wallet.createTransaction(utxos, [{ address: '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB' }], 1, wallet.getAddress());
     tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-    assert.strictEqual(tx.ins.length, 1);
-    assert.strictEqual(tx.outs.length, 1);
-    assert.strictEqual('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB', bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
+    expect(tx.ins.length).toBe(1);
+    expect(tx.outs.length).toBe(1);
+    expect('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB').toBe(bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
 
     // batch send + send max
     txNew = wallet.createTransaction(
@@ -44,10 +42,10 @@ describe('Segwit P2SH wallet', () => {
       wallet.getAddress(),
     );
     tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-    assert.strictEqual(tx.ins.length, 1);
-    assert.strictEqual(tx.outs.length, 2);
-    assert.strictEqual('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB', bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
-    assert.strictEqual('14YZ6iymQtBVQJk6gKnLCk49UScJK7SH4M', bitcoin.address.fromOutputScript(tx.outs[1].script)); // to address
+    expect(tx.ins.length).toBe(1);
+    expect(tx.outs.length).toBe(2);
+    expect('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB').toBe(bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
+    expect('14YZ6iymQtBVQJk6gKnLCk49UScJK7SH4M').toBe(bitcoin.address.fromOutputScript(tx.outs[1].script)); // to address
   });
 
   it('can sign and verify messages', async () => {
@@ -55,7 +53,7 @@ describe('Segwit P2SH wallet', () => {
     l.setSecret('L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1'); // from bitcoinjs-message examples
 
     const signature = l.signMessage('This is an example of a signed message.', l.getAddress());
-    assert.strictEqual(signature, 'J9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk=');
-    assert.strictEqual(l.verifyMessage('This is an example of a signed message.', l.getAddress(), signature), true);
+    expect(signature).toBe('J9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk=');
+    expect(l.verifyMessage('This is an example of a signed message.', l.getAddress(), signature)).toBe(true);
   });
 });

--- a/tests/unit/segwit-p2sh-wallet.test.js
+++ b/tests/unit/segwit-p2sh-wallet.test.js
@@ -1,15 +1,14 @@
+import * as bitcoin from 'bitcoinjs-lib';
 import { SegwitP2SHWallet } from '../../class';
-const bitcoin = require('bitcoinjs-lib');
-const assert = require('assert');
 
 describe('Segwit P2SH wallet', () => {
   it('can create transaction', async () => {
     const wallet = new SegwitP2SHWallet();
     wallet.setSecret('Ky1vhqYGCiCbPd8nmbUeGfwLdXB1h5aGwxHwpXrzYRfY5cTZPDo4');
-    assert.strictEqual(wallet.getAddress(), '3CKN8HTCews4rYJYsyub5hjAVm5g5VFdQJ');
-    assert.deepStrictEqual(wallet.getAllExternalAddresses(), ['3CKN8HTCews4rYJYsyub5hjAVm5g5VFdQJ']);
-    assert.strictEqual(await wallet.getChangeAddressAsync(), wallet.getAddress());
-    assert.strictEqual(await wallet.getAddressAsync(), wallet.getAddress());
+    expect(wallet.getAddress()).toBe('3CKN8HTCews4rYJYsyub5hjAVm5g5VFdQJ');
+    expect(wallet.getAllExternalAddresses()).toEqual(['3CKN8HTCews4rYJYsyub5hjAVm5g5VFdQJ']);
+    expect(await wallet.getChangeAddressAsync()).toBe(wallet.getAddress());
+    expect(await wallet.getAddressAsync()).toBe(wallet.getAddress());
 
     const utxos = [
       {
@@ -21,21 +20,20 @@ describe('Segwit P2SH wallet', () => {
 
     let txNew = wallet.createTransaction(utxos, [{ value: 90000, address: '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB' }], 1, wallet.getAddress());
     let tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-    assert.strictEqual(
-      txNew.tx.toHex(),
+    expect(txNew.tx.toHex()).toBe(
       '020000000001010c86eb9013616e38b4752e56e5683e864cb34fcd7fe790bdc006b60c08446ba50000000017160014139dc70d73097f9d775f8a3280ba3e3435515641ffffffff02905f0100000000001976a914aa381cd428a4e91327fd4434aa0a08ff131f1a5a88ac6e3303000000000017a914749118baa93fb4b88c28909c8bf0a8202a0484f4870247304402205f0bcb0d9968b3c410e2a3699369bf4149bb56ade18b63356b45285a34d64600022043ac1271f3900ea1000a66b9a9d9ceb3e6e4a4ef45c4da0f55b691ad4b64fcb1012103a5de146762f84055db3202c1316cd9008f16047f4f408c1482fdb108217eda0800000000',
     );
-    assert.strictEqual(tx.ins.length, 1);
-    assert.strictEqual(tx.outs.length, 2);
-    assert.strictEqual('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB', bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
-    assert.strictEqual(bitcoin.address.fromOutputScript(tx.outs[1].script), wallet.getAddress()); // change address
+    expect(tx.ins.length).toBe(1);
+    expect(tx.outs.length).toBe(2);
+    expect('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB').toBe(bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
+    expect(bitcoin.address.fromOutputScript(tx.outs[1].script)).toBe(wallet.getAddress()); // change address
 
     // sendMax
     txNew = wallet.createTransaction(utxos, [{ address: '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB' }], 1, wallet.getAddress());
     tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
-    assert.strictEqual(tx.ins.length, 1);
-    assert.strictEqual(tx.outs.length, 1);
-    assert.strictEqual('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB', bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
+    expect(tx.ins.length).toBe(1);
+    expect(tx.outs.length).toBe(1);
+    expect('1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB').toBe(bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
   });
 
   it('can sign and verify messages', async () => {
@@ -43,7 +41,7 @@ describe('Segwit P2SH wallet', () => {
     l.setSecret('L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1'); // from bitcoinjs-message examples
 
     const signature = l.signMessage('This is an example of a signed message.', l.getAddress());
-    assert.strictEqual(signature, 'I9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk=');
-    assert.strictEqual(l.verifyMessage('This is an example of a signed message.', l.getAddress(), signature), true);
+    expect(signature).toBe('I9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk=');
+    expect(l.verifyMessage('This is an example of a signed message.', l.getAddress(), signature)).toBe(true);
   });
 });

--- a/tests/unit/slip39-wallets.test.js
+++ b/tests/unit/slip39-wallets.test.js
@@ -1,5 +1,3 @@
-import assert from 'assert';
-
 import { SLIP39LegacyP2PKHWallet, SLIP39SegwitP2SHWallet, SLIP39SegwitBech32Wallet } from '../../class';
 
 global.crypto = require('crypto');
@@ -11,11 +9,11 @@ describe('SLIP39 wallets tests', () => {
     w.setSecret(
       'shadow pistol academic always adequate wildlife fancy gross oasis cylinder mustang wrist rescue view short owner flip making coding armed',
     );
-    assert.strictEqual(w.validateMnemonic(), false);
+    expect(w.validateMnemonic()).toBe(false);
 
     // wrong words
     w.setSecret('qweasd ewqasd');
-    assert.strictEqual(w.validateMnemonic(), false);
+    expect(w.validateMnemonic()).toBe(false);
   });
 
   it('can generate ID', () => {
@@ -25,7 +23,7 @@ describe('SLIP39 wallets tests', () => {
       'shadow pistol academic always adequate wildlife fancy gross oasis cylinder mustang wrist rescue view short owner flip making coding armed',
     );
 
-    assert.ok(w.getID());
+    expect(w.getID()).toBeTruthy();
   });
 
   it('SLIP39LegacyP2PKHWallet can generate addresses', async () => {
@@ -36,11 +34,11 @@ describe('SLIP39 wallets tests', () => {
         'shadow pistol academic acid actress prayer class unknown daughter sweater depict flip twice unkind craft early superior advocate guest smoking',
     );
 
-    assert.ok(w.validateMnemonic());
-    assert.strictEqual(w._getExternalAddressByIndex(0), '18pvMjy7AJbCDtv4TLYbGPbR7SzGzjqUpj');
-    assert.strictEqual(w._getExternalAddressByIndex(1), '1LDm2yFgHesgVjENC4cEpvUnW5HdYp51gX');
-    assert.strictEqual(w._getInternalAddressByIndex(0), '1EeW2xsK52vqBpsFLYa1vL6hyxmWCsK3Nx');
-    assert.strictEqual(w._getInternalAddressByIndex(1), '1EM8ADickQ9WppVgSGGgjL8PGWhbbTqNpW');
+    expect(w.validateMnemonic()).toBeTruthy();
+    expect(w._getExternalAddressByIndex(0)).toBe('18pvMjy7AJbCDtv4TLYbGPbR7SzGzjqUpj');
+    expect(w._getExternalAddressByIndex(1)).toBe('1LDm2yFgHesgVjENC4cEpvUnW5HdYp51gX');
+    expect(w._getInternalAddressByIndex(0)).toBe('1EeW2xsK52vqBpsFLYa1vL6hyxmWCsK3Nx');
+    expect(w._getInternalAddressByIndex(1)).toBe('1EM8ADickQ9WppVgSGGgjL8PGWhbbTqNpW');
   });
 
   it('SLIP39SegwitP2SHWallet can generate addresses', async () => {
@@ -51,11 +49,11 @@ describe('SLIP39 wallets tests', () => {
         'humidity disease academic agency actress jacket gross physics cylinder solution fake mortgage benefit public busy prepare sharp friar change work slow purchase ruler again tricycle involve viral wireless mixture anatomy desert cargo upgrade',
     );
 
-    assert.ok(w.validateMnemonic());
-    assert.strictEqual(w._getExternalAddressByIndex(0), '3G3HrQ7DrNJLm8gMrLHTeeD5DdzgeoScRJ');
-    assert.strictEqual(w._getExternalAddressByIndex(1), '3HgGV4fhXz8GZYVMRT1tj9WoUdMQMDrGvw');
-    assert.strictEqual(w._getInternalAddressByIndex(0), '3BdrAbZCo9BCmzP1nmpEVyGXMB9JF4MJ1L');
-    assert.strictEqual(w._getInternalAddressByIndex(1), '3GFSjHbSRGZZavmY7YTm9UJfDbmJdpCeMA');
+    expect(w.validateMnemonic()).toBeTruthy();
+    expect(w._getExternalAddressByIndex(0)).toBe('3G3HrQ7DrNJLm8gMrLHTeeD5DdzgeoScRJ');
+    expect(w._getExternalAddressByIndex(1)).toBe('3HgGV4fhXz8GZYVMRT1tj9WoUdMQMDrGvw');
+    expect(w._getInternalAddressByIndex(0)).toBe('3BdrAbZCo9BCmzP1nmpEVyGXMB9JF4MJ1L');
+    expect(w._getInternalAddressByIndex(1)).toBe('3GFSjHbSRGZZavmY7YTm9UJfDbmJdpCeMA');
   });
 
   it('SLIP39SegwitBech32Wallet can generate addresses', async () => {
@@ -69,11 +67,11 @@ describe('SLIP39 wallets tests', () => {
         'wildlife deal decision shadow analysis adjust bulb skunk muscle mandate obesity total guitar coal gravity carve slim jacket ruin rebuild ancestor numerous hour mortgage require herd maiden public ceiling pecan pickup shadow club\n',
     );
 
-    assert.ok(w.validateMnemonic());
-    assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1qkchjws74hkuhamxk0qa280xc68643nu32pde20');
-    assert.strictEqual(w._getExternalAddressByIndex(1), 'bc1qrslzpjwl7ksdxvealdq0qulgspey62vr3acwnp');
-    assert.strictEqual(w._getInternalAddressByIndex(0), 'bc1qgx35amln8aryyr0lw6j2729l3gemzjftp5xrne');
-    assert.strictEqual(w._getInternalAddressByIndex(1), 'bc1q48v0hcuz2jjsls628wj8jtn7rqp8wsyz2gxdxm');
+    expect(w.validateMnemonic()).toBeTruthy();
+    expect(w._getExternalAddressByIndex(0)).toBe('bc1qkchjws74hkuhamxk0qa280xc68643nu32pde20');
+    expect(w._getExternalAddressByIndex(1)).toBe('bc1qrslzpjwl7ksdxvealdq0qulgspey62vr3acwnp');
+    expect(w._getInternalAddressByIndex(0)).toBe('bc1qgx35amln8aryyr0lw6j2729l3gemzjftp5xrne');
+    expect(w._getInternalAddressByIndex(1)).toBe('bc1q48v0hcuz2jjsls628wj8jtn7rqp8wsyz2gxdxm');
   });
 
   // tests below are from https://github.com/spesmilo/electrum/pull/6917/files#diff-2940d8023ed102277f9c8b91135a9d6fa90fd2752b7b6147c1b5911f26db6d7fR497
@@ -86,14 +84,13 @@ describe('SLIP39 wallets tests', () => {
     );
     w.setPassphrase('TREZOR');
 
-    assert.strictEqual(
-      w.getXpub(),
+    expect(w.getXpub()).toBe(
       'xpub6CDgeTHt97zmW24XoYdjH9PVFMUj6qcYAe9SZXMKRKJbvTNeZhutNkQqajLyZrQ9DCqdnGenKhBD6UTrT1nHnoLCfFHkdeX8hDsZx1je6b2',
     );
 
-    assert.strictEqual(w._getExternalAddressByIndex(0), '1NomKAUNnbASwbPuGHmkSVmnrJS5tZeVce');
-    assert.strictEqual(w._getInternalAddressByIndex(0), '1Aw4wpXsAyEHSgMZqPdyewoAtJqH9Jaso3');
-    assert.strictEqual(w._getExternalWIFByIndex(0), 'L55ZfXJgyXNPFrFtq2eqnwAkrjrarkKdmbkTEWxYXd2srXcfj3KF');
+    expect(w._getExternalAddressByIndex(0)).toBe('1NomKAUNnbASwbPuGHmkSVmnrJS5tZeVce');
+    expect(w._getInternalAddressByIndex(0)).toBe('1Aw4wpXsAyEHSgMZqPdyewoAtJqH9Jaso3');
+    expect(w._getExternalWIFByIndex(0)).toBe('L55ZfXJgyXNPFrFtq2eqnwAkrjrarkKdmbkTEWxYXd2srXcfj3KF');
   });
 
   it('SLIP39SegwitP2SHWallet can use passphrase', async () => {
@@ -104,13 +101,12 @@ describe('SLIP39 wallets tests', () => {
     );
     w.setPassphrase('TREZOR');
 
-    assert.strictEqual(
-      w.getXpub(),
+    expect(w.getXpub()).toBe(
       'ypub6Y6aCjkcjCP2y7jZStTevc8Tj3GjoXncqC4ReMzdVZWScB68vKZSZBZ88ENvuPUXXBBR58JXkuz1UrwLnCFvnFTUEpzu5yQabeYBRyd7Edf',
     );
 
-    assert.strictEqual(w._getExternalAddressByIndex(0), '3GCgNoWWVqVdhBxWxrnWQHgwLtffGSYn7D');
-    assert.strictEqual(w._getInternalAddressByIndex(0), '3FVvdRhR7racZhmcvrGAqX9eJoP8Sw3ypp');
+    expect(w._getExternalAddressByIndex(0)).toBe('3GCgNoWWVqVdhBxWxrnWQHgwLtffGSYn7D');
+    expect(w._getInternalAddressByIndex(0)).toBe('3FVvdRhR7racZhmcvrGAqX9eJoP8Sw3ypp');
   });
 
   it('SLIP39SegwitBech32Wallet can use passphrase', async () => {
@@ -123,12 +119,11 @@ describe('SLIP39 wallets tests', () => {
     );
     w.setPassphrase('TREZOR');
 
-    assert.strictEqual(
-      w.getXpub(),
+    expect(w.getXpub()).toBe(
       'zpub6rs6bFckxdWVHBucVX129aNAYqiwPwh1HgsWt6HEQBa9F9QBKRcYzsw7WZR7rPSCWKmRVTUaEgrGrHStx2LSTpbgAEerbnrh4XxkRXbUUZF',
     );
 
-    assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1qaggygkqgqjjpt58zrmhvjz5m9dj8mjshw0lpgu');
-    assert.strictEqual(w._getInternalAddressByIndex(0), 'bc1q8l6hcvlczu4mtjcnlwhczw7vdxnvwccpjl3cwz');
+    expect(w._getExternalAddressByIndex(0)).toBe('bc1qaggygkqgqjjpt58zrmhvjz5m9dj8mjshw0lpgu');
+    expect(w._getInternalAddressByIndex(0)).toBe('bc1q8l6hcvlczu4mtjcnlwhczw7vdxnvwccpjl3cwz');
   });
 });

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -1,6 +1,5 @@
 import { SegwitP2SHWallet, AppStorage } from '../../class';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-const assert = require('assert');
 
 it('Appstorage - loadFromDisk works', async () => {
   /** @type {AppStorage} */
@@ -15,10 +14,10 @@ it('Appstorage - loadFromDisk works', async () => {
 
   const Storage2 = new AppStorage();
   await Storage2.loadFromDisk();
-  assert.strictEqual(Storage2.wallets.length, 1);
-  assert.strictEqual(Storage2.wallets[0].getLabel(), 'testlabel');
+  expect(Storage2.wallets.length).toBe(1);
+  expect(Storage2.wallets[0].getLabel()).toBe('testlabel');
   let isEncrypted = await Storage2.storageIsEncrypted();
-  assert.ok(!isEncrypted);
+  expect(!isEncrypted).toBeTruthy();
 
   // emulating encrypted storage (and testing flag)
 
@@ -26,7 +25,7 @@ it('Appstorage - loadFromDisk works', async () => {
   await AsyncStorage.setItem(AppStorage.FLAG_ENCRYPTED, '1');
   const Storage3 = new AppStorage();
   isEncrypted = await Storage3.storageIsEncrypted();
-  assert.ok(isEncrypted);
+  expect(isEncrypted).toBeTruthy();
 });
 
 it('Appstorage - encryptStorage & load encrypted storage works', async () => {
@@ -38,63 +37,63 @@ it('Appstorage - encryptStorage & load encrypted storage works', async () => {
   Storage.wallets.push(w);
   await Storage.saveToDisk();
   let isEncrypted = await Storage.storageIsEncrypted();
-  assert.ok(!isEncrypted);
+  expect(!isEncrypted).toBeTruthy();
   await Storage.encryptStorage('password');
   isEncrypted = await Storage.storageIsEncrypted();
-  assert.strictEqual(Storage.cachedPassword, 'password');
-  assert.ok(isEncrypted);
+  expect(Storage.cachedPassword).toBe('password');
+  expect(isEncrypted).toBeTruthy();
 
   // saved, now trying to load, using good password
 
   let Storage2 = new AppStorage();
   isEncrypted = await Storage2.storageIsEncrypted();
-  assert.ok(isEncrypted);
+  expect(isEncrypted).toBeTruthy();
   let loadResult = await Storage2.loadFromDisk('password');
-  assert.ok(loadResult);
-  assert.strictEqual(Storage2.wallets.length, 1);
-  assert.strictEqual(Storage2.wallets[0].getLabel(), 'testlabel');
+  expect(loadResult).toBeTruthy();
+  expect(Storage2.wallets.length).toBe(1);
+  expect(Storage2.wallets[0].getLabel()).toBe('testlabel');
 
   // now trying to load, using bad password
 
   Storage2 = new AppStorage();
   isEncrypted = await Storage2.storageIsEncrypted();
-  assert.ok(isEncrypted);
+  expect(isEncrypted).toBeTruthy();
   loadResult = await Storage2.loadFromDisk('passwordBAD');
-  assert.ok(!loadResult);
-  assert.strictEqual(Storage2.wallets.length, 0);
+  expect(!loadResult).toBeTruthy();
+  expect(Storage2.wallets.length).toBe(0);
 
   // now, trying case with adding data after decrypt.
   // saveToDisk should be handled correctly
 
   Storage2 = new AppStorage();
   isEncrypted = await Storage2.storageIsEncrypted();
-  assert.ok(isEncrypted);
+  expect(isEncrypted).toBeTruthy();
   loadResult = await Storage2.loadFromDisk('password');
-  assert.ok(loadResult);
-  assert.strictEqual(Storage2.wallets.length, 1);
-  assert.strictEqual(Storage2.wallets[0].getLabel(), 'testlabel');
+  expect(loadResult).toBeTruthy();
+  expect(Storage2.wallets.length).toBe(1);
+  expect(Storage2.wallets[0].getLabel()).toBe('testlabel');
   w = new SegwitP2SHWallet();
   w.setLabel('testlabel2');
   await w.generate();
   Storage2.wallets.push(w);
-  assert.strictEqual(Storage2.wallets.length, 2);
-  assert.strictEqual(Storage2.wallets[1].getLabel(), 'testlabel2');
+  expect(Storage2.wallets.length).toBe(2);
+  expect(Storage2.wallets[1].getLabel()).toBe('testlabel2');
   await Storage2.saveToDisk();
   // saved to encrypted storage after load. next load should be successfull
   Storage2 = new AppStorage();
   isEncrypted = await Storage2.storageIsEncrypted();
-  assert.ok(isEncrypted);
+  expect(isEncrypted).toBeTruthy();
   loadResult = await Storage2.loadFromDisk('password');
-  assert.ok(loadResult);
-  assert.strictEqual(Storage2.wallets.length, 2);
-  assert.strictEqual(Storage2.wallets[0].getLabel(), 'testlabel');
-  assert.strictEqual(Storage2.wallets[1].getLabel(), 'testlabel2');
+  expect(loadResult).toBeTruthy();
+  expect(Storage2.wallets.length).toBe(2);
+  expect(Storage2.wallets[0].getLabel()).toBe('testlabel');
+  expect(Storage2.wallets[1].getLabel()).toBe('testlabel2');
 
   // next, adding new `fake` storage which should be unlocked with `fake` password
   const createFakeStorageResult = await Storage2.createFakeStorage('fakePassword');
-  assert.ok(createFakeStorageResult);
-  assert.strictEqual(Storage2.wallets.length, 0);
-  assert.strictEqual(Storage2.cachedPassword, 'fakePassword');
+  expect(createFakeStorageResult).toBeTruthy();
+  expect(Storage2.wallets.length).toBe(0);
+  expect(Storage2.cachedPassword).toBe('fakePassword');
   w = new SegwitP2SHWallet();
   w.setLabel('fakewallet');
   await w.generate();
@@ -104,15 +103,15 @@ it('Appstorage - encryptStorage & load encrypted storage works', async () => {
   // real:
   let Storage3 = new AppStorage();
   loadResult = await Storage3.loadFromDisk('password');
-  assert.ok(loadResult);
-  assert.strictEqual(Storage3.wallets.length, 2);
-  assert.strictEqual(Storage3.wallets[0].getLabel(), 'testlabel');
+  expect(loadResult).toBeTruthy();
+  expect(Storage3.wallets.length).toBe(2);
+  expect(Storage3.wallets[0].getLabel()).toBe('testlabel');
   // fake:
   Storage3 = new AppStorage();
   loadResult = await Storage3.loadFromDisk('fakePassword');
-  assert.ok(loadResult);
-  assert.strictEqual(Storage3.wallets.length, 1);
-  assert.strictEqual(Storage3.wallets[0].getLabel(), 'fakewallet');
+  expect(loadResult).toBeTruthy();
+  expect(Storage3.wallets.length).toBe(1);
+  expect(Storage3.wallets[0].getLabel()).toBe('fakewallet');
 });
 
 it('Appstorage - encryptStorage & load encrypted, then decryptStorage and load storage works', async () => {
@@ -124,63 +123,63 @@ it('Appstorage - encryptStorage & load encrypted, then decryptStorage and load s
   Storage.wallets.push(w);
   await Storage.saveToDisk();
   let isEncrypted = await Storage.storageIsEncrypted();
-  assert.ok(!isEncrypted);
+  expect(!isEncrypted).toBeTruthy();
   await Storage.encryptStorage('password');
   isEncrypted = await Storage.storageIsEncrypted();
-  assert.strictEqual(Storage.cachedPassword, 'password');
-  assert.ok(isEncrypted);
+  expect(Storage.cachedPassword).toBe('password');
+  expect(isEncrypted).toBeTruthy();
 
   // saved, now trying to load, using good password
 
   let Storage2 = new AppStorage();
   isEncrypted = await Storage2.storageIsEncrypted();
-  assert.ok(isEncrypted);
+  expect(isEncrypted).toBeTruthy();
   let loadResult = await Storage2.loadFromDisk('password');
-  assert.ok(loadResult);
-  assert.strictEqual(Storage2.wallets.length, 1);
-  assert.strictEqual(Storage2.wallets[0].getLabel(), 'testlabel');
+  expect(loadResult).toBeTruthy();
+  expect(Storage2.wallets.length).toBe(1);
+  expect(Storage2.wallets[0].getLabel()).toBe('testlabel');
 
   // now trying to load, using bad password
 
   Storage2 = new AppStorage();
   isEncrypted = await Storage2.storageIsEncrypted();
-  assert.ok(isEncrypted);
+  expect(isEncrypted).toBeTruthy();
   loadResult = await Storage2.loadFromDisk('passwordBAD');
-  assert.ok(!loadResult);
-  assert.strictEqual(Storage2.wallets.length, 0);
+  expect(!loadResult).toBeTruthy();
+  expect(Storage2.wallets.length).toBe(0);
 
   // now, trying case with adding data after decrypt.
   // saveToDisk should be handled correctly
 
   Storage2 = new AppStorage();
   isEncrypted = await Storage2.storageIsEncrypted();
-  assert.ok(isEncrypted);
+  expect(isEncrypted).toBeTruthy();
   loadResult = await Storage2.loadFromDisk('password');
-  assert.ok(loadResult);
-  assert.strictEqual(Storage2.wallets.length, 1);
-  assert.strictEqual(Storage2.wallets[0].getLabel(), 'testlabel');
+  expect(loadResult).toBeTruthy();
+  expect(Storage2.wallets.length).toBe(1);
+  expect(Storage2.wallets[0].getLabel()).toBe('testlabel');
   w = new SegwitP2SHWallet();
   w.setLabel('testlabel2');
   await w.generate();
   Storage2.wallets.push(w);
-  assert.strictEqual(Storage2.wallets.length, 2);
-  assert.strictEqual(Storage2.wallets[1].getLabel(), 'testlabel2');
+  expect(Storage2.wallets.length).toBe(2);
+  expect(Storage2.wallets[1].getLabel()).toBe('testlabel2');
   await Storage2.saveToDisk();
   // saved to encrypted storage after load. next load should be successfull
   Storage2 = new AppStorage();
   isEncrypted = await Storage2.storageIsEncrypted();
-  assert.ok(isEncrypted);
+  expect(isEncrypted).toBeTruthy();
   loadResult = await Storage2.loadFromDisk('password');
-  assert.ok(loadResult);
-  assert.strictEqual(Storage2.wallets.length, 2);
-  assert.strictEqual(Storage2.wallets[0].getLabel(), 'testlabel');
-  assert.strictEqual(Storage2.wallets[1].getLabel(), 'testlabel2');
+  expect(loadResult).toBeTruthy();
+  expect(Storage2.wallets.length).toBe(2);
+  expect(Storage2.wallets[0].getLabel()).toBe('testlabel');
+  expect(Storage2.wallets[1].getLabel()).toBe('testlabel2');
 
   // next, adding new `fake` storage which should be unlocked with `fake` password
   const createFakeStorageResult = await Storage2.createFakeStorage('fakePassword');
-  assert.ok(createFakeStorageResult);
-  assert.strictEqual(Storage2.wallets.length, 0);
-  assert.strictEqual(Storage2.cachedPassword, 'fakePassword');
+  expect(createFakeStorageResult).toBeTruthy();
+  expect(Storage2.wallets.length).toBe(0);
+  expect(Storage2.cachedPassword).toBe('fakePassword');
   w = new SegwitP2SHWallet();
   w.setLabel('fakewallet');
   await w.generate();
@@ -190,34 +189,34 @@ it('Appstorage - encryptStorage & load encrypted, then decryptStorage and load s
   // real:
   let Storage3 = new AppStorage();
   loadResult = await Storage3.loadFromDisk('password');
-  assert.ok(loadResult);
-  assert.strictEqual(Storage3.wallets.length, 2);
-  assert.strictEqual(Storage3.wallets[0].getLabel(), 'testlabel');
+  expect(loadResult).toBeTruthy();
+  expect(Storage3.wallets.length).toBe(2);
+  expect(Storage3.wallets[0].getLabel()).toBe('testlabel');
   // fake:
   Storage3 = new AppStorage();
   loadResult = await Storage3.loadFromDisk('fakePassword');
-  assert.ok(loadResult);
-  assert.strictEqual(Storage3.wallets.length, 1);
-  assert.strictEqual(Storage3.wallets[0].getLabel(), 'fakewallet');
+  expect(loadResult).toBeTruthy();
+  expect(Storage3.wallets.length).toBe(1);
+  expect(Storage3.wallets[0].getLabel()).toBe('fakewallet');
 
   // now will decrypt storage. label of wallet should be testlabel
 
   const Storage4 = new AppStorage();
   isEncrypted = await Storage4.storageIsEncrypted();
-  assert.ok(isEncrypted);
+  expect(isEncrypted).toBeTruthy();
   loadResult = await Storage4.loadFromDisk('password');
-  assert.ok(loadResult);
+  expect(loadResult).toBeTruthy();
   const decryptStorageResult = await Storage4.decryptStorage('password');
-  assert.ok(decryptStorageResult);
+  expect(decryptStorageResult).toBeTruthy();
 
   const Storage5 = new AppStorage();
   isEncrypted = await Storage5.storageIsEncrypted();
-  assert.strictEqual(isEncrypted, false);
+  expect(isEncrypted).toBe(false);
   const storage5loadResult = await Storage5.loadFromDisk();
-  assert.ok(storage5loadResult);
-  assert.strictEqual(Storage5.wallets.length, 2);
-  assert.strictEqual(Storage5.wallets[0].getLabel(), 'testlabel');
-  assert.strictEqual(Storage5.wallets[1].getLabel(), 'testlabel2');
+  expect(storage5loadResult).toBeTruthy();
+  expect(Storage5.wallets.length).toBe(2);
+  expect(Storage5.wallets[0].getLabel()).toBe('testlabel');
+  expect(Storage5.wallets[1].getLabel()).toBe('testlabel2');
 });
 
 it('can decrypt storage that is second in a list of buckets; and isPasswordInUse() works', async () => {
@@ -229,17 +228,17 @@ it('can decrypt storage that is second in a list of buckets; and isPasswordInUse
   Storage.wallets.push(w);
   await Storage.saveToDisk();
   let isEncrypted = await Storage.storageIsEncrypted();
-  assert.ok(!isEncrypted);
+  expect(!isEncrypted).toBeTruthy();
   await Storage.encryptStorage('password');
   isEncrypted = await Storage.storageIsEncrypted();
-  assert.strictEqual(Storage.cachedPassword, 'password');
-  assert.ok(isEncrypted);
+  expect(Storage.cachedPassword).toBe('password');
+  expect(isEncrypted).toBeTruthy();
 
   // next, adding new `fake` storage which should be unlocked with `fake` password
   const createFakeStorageResult = await Storage.createFakeStorage('fakePassword');
-  assert.ok(createFakeStorageResult);
-  assert.strictEqual(Storage.wallets.length, 0);
-  assert.strictEqual(Storage.cachedPassword, 'fakePassword');
+  expect(createFakeStorageResult).toBeTruthy();
+  expect(Storage.wallets.length).toBe(0);
+  expect(Storage.cachedPassword).toBe('fakePassword');
   w = new SegwitP2SHWallet();
   w.setLabel('fakewallet');
   await w.generate();
@@ -251,9 +250,9 @@ it('can decrypt storage that is second in a list of buckets; and isPasswordInUse
 
   const Storage4 = new AppStorage();
   isEncrypted = await Storage4.storageIsEncrypted();
-  assert.ok(isEncrypted);
+  expect(isEncrypted).toBeTruthy();
   let loadResult = await Storage4.loadFromDisk('password');
-  assert.ok(loadResult);
+  expect(loadResult).toBeTruthy();
 
   let wasException = false;
   try {
@@ -262,7 +261,7 @@ it('can decrypt storage that is second in a list of buckets; and isPasswordInUse
     wasException = true;
   }
 
-  assert.ok(wasException);
+  expect(wasException).toBeTruthy();
 
   // now we will load fake storage, and we will decrypt it, which efficiently makes it main
   // storage, purging other buckets. this should be possible since if user wants to shoot himsel in the foot
@@ -270,29 +269,29 @@ it('can decrypt storage that is second in a list of buckets; and isPasswordInUse
 
   const Storage5 = new AppStorage();
   isEncrypted = await Storage5.storageIsEncrypted();
-  assert.ok(isEncrypted);
+  expect(isEncrypted).toBeTruthy();
   loadResult = await Storage5.loadFromDisk('fakePassword');
-  assert.ok(loadResult);
+  expect(loadResult).toBeTruthy();
 
   // testing that isPasswordInUse() works:
-  assert.ok(await Storage5.isPasswordInUse('fakePassword'));
-  assert.ok(await Storage5.isPasswordInUse('password'));
-  assert.ok(!(await Storage5.isPasswordInUse('blablablabla')));
+  expect(await Storage5.isPasswordInUse('fakePassword')).toBeTruthy();
+  expect(await Storage5.isPasswordInUse('password')).toBeTruthy();
+  expect(!(await Storage5.isPasswordInUse('blablablabla'))).toBeTruthy();
 
   // now we will decrypt storage. label of wallet should be testlabel
 
   const Storage6 = new AppStorage();
   isEncrypted = await Storage6.storageIsEncrypted();
-  assert.ok(isEncrypted);
+  expect(isEncrypted).toBeTruthy();
   loadResult = await Storage6.loadFromDisk('fakePassword');
-  assert.ok(loadResult);
+  expect(loadResult).toBeTruthy();
   const decryptStorageResult = await Storage6.decryptStorage('fakePassword');
-  assert.ok(decryptStorageResult);
+  expect(decryptStorageResult).toBeTruthy();
 
   const Storage7 = new AppStorage();
   isEncrypted = await Storage7.storageIsEncrypted();
-  assert.strictEqual(isEncrypted, false);
+  expect(isEncrypted).toBe(false);
   const storage5loadResult = await Storage7.loadFromDisk();
-  assert.ok(storage5loadResult);
-  assert.strictEqual(Storage7.wallets[0].getLabel(), 'fakewallet');
+  expect(storage5loadResult).toBeTruthy();
+  expect(Storage7.wallets[0].getLabel()).toBe('fakewallet');
 });

--- a/tests/unit/watch-only-wallet.test.js
+++ b/tests/unit/watch-only-wallet.test.js
@@ -1,7 +1,6 @@
+import { Psbt } from 'bitcoinjs-lib';
 import { WatchOnlyWallet } from '../../class';
 import { decodeUR, encodeUR, setUseURv1, clearUseURv1, extractSingleWorkload, BlueURDecoder } from '../../blue_modules/ur';
-import { Psbt } from 'bitcoinjs-lib';
-const assert = require('assert');
 
 describe('Watch only wallet', () => {
   it('can validate address', async () => {
@@ -13,17 +12,14 @@ describe('Watch only wallet', () => {
       'BC1QUHNVE8Q4TK3UNHMJTS7YMXV8CD6W9XV8WY29UV',
     ]) {
       w.setSecret(secret);
-      assert.ok(w.valid());
-      assert.deepStrictEqual(
-        w.getAllExternalAddresses().map(elem => elem.toUpperCase()),
-        [secret.toUpperCase()],
-      );
-      assert.strictEqual(w.isHd(), false);
-      assert.ok(!w.useWithHardwareWalletEnabled());
+      expect(w.valid()).toBeTruthy();
+      expect(w.getAllExternalAddresses().map(elem => elem.toUpperCase())).toEqual([secret.toUpperCase()]);
+      expect(w.isHd()).toBe(false);
+      expect(!w.useWithHardwareWalletEnabled()).toBeTruthy();
     }
 
     w.setSecret('not valid');
-    assert.ok(!w.valid());
+    expect(!w.valid()).toBeTruthy();
 
     for (const secret of [
       'xpub6CQdfC3v9gU86eaSn7AhUFcBVxiGhdtYxdC5Cw2vLmFkfth2KXCMmYcPpvZviA89X6DXDs4PJDk5QVL2G2xaVjv7SM4roWHr1gR4xB3Z7Ps',
@@ -31,35 +27,35 @@ describe('Watch only wallet', () => {
       'zpub6r7jhKKm7BAVx3b3nSnuadY1WnshZYkhK8gKFoRLwK9rF3Mzv28BrGcCGA3ugGtawi1WLb2vyjQAX9ZTDGU5gNk2bLdTc3iEXr6tzR1ipNP',
     ]) {
       w.setSecret(secret);
-      assert.ok(w.valid());
-      assert.strictEqual(w.isHd(), true);
-      assert.strictEqual(w.getMasterFingerprint(), false);
-      assert.strictEqual(w.getMasterFingerprintHex(), '00000000');
-      assert.ok(w.isXpubValid(), w.secret);
-      assert.ok(!w.useWithHardwareWalletEnabled());
+      expect(w.valid()).toBeTruthy();
+      expect(w.isHd()).toBe(true);
+      expect(w.getMasterFingerprint()).toBe(false);
+      expect(w.getMasterFingerprintHex()).toBe('00000000');
+      expect(w.isXpubValid()).toBeTruthy();
+      expect(!w.useWithHardwareWalletEnabled()).toBeTruthy();
     }
   });
 
   it('can validate xpub', () => {
     const w = new WatchOnlyWallet();
     w.setSecret('xpub6CQdfC3v9gU86eaSn7AhUFcBVxiGhdtYxdC5Cw2vLmFkfth2KXCMmYcPpvZviA89X6DXDs4PJDk5QVL2G2xaVjv7SM4roWHr1gR4xB3Z7Ps');
-    assert.ok(w.isXpubValid());
-    assert.ok(w.valid());
+    expect(w.isXpubValid()).toBeTruthy();
+    expect(w.valid()).toBeTruthy();
     w.setSecret('ypub6XRzrn3HB1tjhhvrHbk1vnXCecZEdXohGzCk3GXwwbDoJ3VBzZ34jNGWbC6WrS7idXrYjjXEzcPDX5VqnHEnuNf5VAXgLfSaytMkJ2rwVqy');
-    assert.ok(w.isXpubValid());
-    assert.ok(w.valid());
+    expect(w.isXpubValid()).toBeTruthy();
+    expect(w.valid()).toBeTruthy();
     w.setSecret('zpub6r7jhKKm7BAVx3b3nSnuadY1WnshZYkhK8gKFoRLwK9rF3Mzv28BrGcCGA3ugGtawi1WLb2vyjQAX9ZTDGU5gNk2bLdTc3iEXr6tzR1ipNP');
-    assert.ok(w.isXpubValid());
-    assert.ok(w.valid());
+    expect(w.isXpubValid()).toBeTruthy();
+    expect(w.valid()).toBeTruthy();
     w.setSecret('xpub6CQdfC3v9gU86eaSn7AhUFcBVxiGhdtYxdC5Cw2vLmFkfth2KXCMmYcPpvZviA89X6D');
-    assert.ok(!w.isXpubValid());
-    assert.ok(!w.valid());
+    expect(!w.isXpubValid()).toBeTruthy();
+    expect(!w.valid()).toBeTruthy();
     w.setSecret('ypub6XRzrn3HB1tjhhvrHbk1vnXCecZEdXohGzCk3GXwwbDoJ3VBzZ34jNGWbC6WrS7idXr');
-    assert.ok(!w.isXpubValid());
-    assert.ok(!w.valid());
+    expect(!w.isXpubValid()).toBeTruthy();
+    expect(!w.valid()).toBeTruthy();
     w.setSecret('ypub6XRzrn3HB1tjhhvrHbk1vnXCecZEdXohGzCk3GXwwbDoJ3VBzZ34jNGWbC6WrS7idXr');
-    assert.ok(!w.isXpubValid());
-    assert.ok(!w.valid());
+    expect(!w.isXpubValid()).toBeTruthy();
+    expect(!w.valid()).toBeTruthy();
   });
 
   it('can create PSBT base64 without signature for HW wallet xpub', async () => {
@@ -83,8 +79,7 @@ describe('Watch only wallet', () => {
 
     const { psbt } = await w.createTransaction(utxos, [{ address: '1QDCFcpnrZ4yrAQxmbvSgeUC9iZZ8ehcR5' }], 1, changeAddress);
 
-    assert.strictEqual(
-      psbt.toBase64(),
+    expect(psbt.toBase64()).toBe(
       'cHNidP8BAFUCAAAAAZaLfDcOPs2Jk1UefwZZOzPCdTJF+ugLOsYZYagnIEPQAQAAAAAAAACAASgDAAAAAAAAGXapFP6ZRvxlaU5S/9HQFr1i2lsgp58AiKwAAAAAAAEA4gEAAAABtjCsNkoEuDVImU3tRwW5gxay0f4Yuf/6Jie+nu8Rv2AAAAAAa0gwRQIhAJbmjZTTdOOmiO0uZgUon4EXJUCrqrX2zEMcIxkZhgdGAiB17k5kyGftnTadAamzXYsWiaghvo1yn/9/s9/MddFvZAEhAoHS5AumQi/Je2H9VkO+6D3XSdg2kzntx5XXs/AOlsaB/f///wLvAgAAAAAAABl2qRTkJx756aA6ibmBxz09aTbS9vzMBois6AMAAAAAAAAZdqkUEgrXhUFSkB6+smmsts7yDnGzz1mIrOoZCAAiBgPGm5BfckKzaIEi8GlRM5oe4A2mUvbsxlJ+pmMhRsrOYhgAAAAALAAAgAAAAIAAAACAAAAAAAAAAAAAAA==',
     );
   });
@@ -108,8 +103,7 @@ describe('Watch only wallet', () => {
 
     const { psbt } = await w.createTransaction(utxos, [{ address: '398qz3BtNG8DABpEGa2VkHBcficxkgeKvX' }], 1, changeAddress);
 
-    assert.strictEqual(
-      psbt.toBase64(),
+    expect(psbt.toBase64()).toBe(
       'cHNidP8BAFMCAAAAAfTUAYKfU/lPbuIV0AsoBIURL2tAz7iaObvEMcXQBW94AAAAAAAAAACAAdDPAwAAAAAAF6kUUatl8TFvnlvB8H/KsqbnR6kpUluHAAAAAAABASCQ0AMAAAAAABepFDzN1E7LDjAMNARzCHsU4rXqBf55hwEEFgAUG3vPJhyWYtt/ikPpOCW6jCqkmxsiBgLHMhb0QhE8eyJBnE9syGAtMehGmHe1sxpm+TlxjgFXERgAAAAAMQAAgAAAAIAAAACAAAAAAAAAAAAAAA==',
     );
   });
@@ -139,8 +133,7 @@ describe('Watch only wallet', () => {
       changeAddress,
     );
 
-    assert.strictEqual(
-      psbt.toBase64(),
+    expect(psbt.toBase64()).toBe(
       'cHNidP8BAHECAAAAAYBbjCRXw4r66Ly1aI/SCvis+CDQsCdQej1BhCoDnjt/AAAAAAAAAACAAogTAAAAAAAAFgAUwM681sPTyox13F7GLr5VMw75EOK2OQAAAAAAABYAFOc6kh7rlKStRwwMvbaeu+oFvB4MAAAAAAABAR8gTgAAAAAAABYAFL8PIBBJ6JHVhwsE61MPwWtjtptAIgYDWOHbOE3D4KiuoR7kHtmTtFZ7KXQB+8zb51QALLJxTx8YAAAAAFQAAIAAAACAAAAAgAAAAAAAAAAAAAAiAgM005BVD8MgH5kiSGnwXSfzaxLeDSl3y17Vhrx3F/9XxBgAAAAAVAAAgAAAAIAAAACAAQAAAAAAAAAA',
     );
   });
@@ -149,15 +142,14 @@ describe('Watch only wallet', () => {
     const w = new WatchOnlyWallet();
     w.setSecret(require('fs').readFileSync('./tests/unit/fixtures/skeleton-coldcard.txt', 'ascii'));
     w.init();
-    assert.ok(w.valid());
-    assert.strictEqual(
-      w.getSecret(),
+    expect(w.valid()).toBeTruthy();
+    expect(w.getSecret()).toBe(
       'zpub6rFDtF1nuXZ9PUL4XzKURh3vJBW6Kj6TUrYL4qPtFNtDXtcTVfiqjQDyrZNwjwzt5HS14qdqo3Co2282Lv3Re6Y5wFZxAVuMEpeygnnDwfx',
     );
-    assert.strictEqual(w.getMasterFingerprint(), 64392470);
-    assert.strictEqual(w.getMasterFingerprintHex(), '168dd603');
-    assert.strictEqual(w.getDerivationPath(), "m/84'/0'/0'");
-    assert.ok(w.useWithHardwareWalletEnabled());
+    expect(w.getMasterFingerprint()).toBe(64392470);
+    expect(w.getMasterFingerprintHex()).toBe('168dd603');
+    expect(w.getDerivationPath()).toBe("m/84'/0'/0'");
+    expect(w.useWithHardwareWalletEnabled()).toBeTruthy();
 
     const utxos = [
       {
@@ -179,8 +171,7 @@ describe('Watch only wallet', () => {
       22,
       'bc1qtutssamysdkgd87df0afjct0mztx56qpze7wqe',
     );
-    assert.strictEqual(
-      psbt.toBase64(),
+    expect(psbt.toBase64()).toBe(
       'cHNidP8BAHECAAAAASJiwHJP3qYi80+cYjHn/n8TiJJR6jRbJFx67gnclfVdAAAAAAAAAACAAogTAAAAAAAAFgAUb3eWXdETtv7KGyXiUxyIS+Q3wJ003QAAAAAAABYAFF8XCHdkg2yGn81L+plhb9iWamgBAAAAAAABAR8oBAEAAAAAABYAFBAk4ma75DYqawitVrni8qlFzNykIgYDNK9TxoCjQ8P0+qI2Hu4hrnXnJuYAC3h2puZbgRORp+sYFo3WA1QAAIAAAACAAAAAgAAAAAAAAAAAAAAiAgL1DWeV+AfIP5RRB5zHv5vuXsIt8+rF9rrsji3FhQlhzBgWjdYDVAAAgAAAAIAAAACAAQAAAAAAAAAA',
     );
   });
@@ -189,15 +180,14 @@ describe('Watch only wallet', () => {
     const w = new WatchOnlyWallet();
     w.setSecret(require('fs').readFileSync('./tests/unit/fixtures/skeleton-electrum.txt', 'ascii'));
     w.init();
-    assert.ok(w.valid());
-    assert.strictEqual(
-      w.getSecret(),
+    expect(w.valid()).toBeTruthy();
+    expect(w.getSecret()).toBe(
       'zpub6rFDtF1nuXZ9PUL4XzKURh3vJBW6Kj6TUrYL4qPtFNtDXtcTVfiqjQDyrZNwjwzt5HS14qdqo3Co2282Lv3Re6Y5wFZxAVuMEpeygnnDwfx',
     );
-    assert.strictEqual(w.getMasterFingerprint(), 64392470);
-    assert.strictEqual(w.getMasterFingerprintHex(), '168dd603');
-    assert.strictEqual(w.getDerivationPath(), "m/84'/0'/1'");
-    assert.ok(w.useWithHardwareWalletEnabled());
+    expect(w.getMasterFingerprint()).toBe(64392470);
+    expect(w.getMasterFingerprintHex()).toBe('168dd603');
+    expect(w.getDerivationPath()).toBe("m/84'/0'/1'");
+    expect(w.useWithHardwareWalletEnabled()).toBeTruthy();
 
     const utxos = [
       {
@@ -219,8 +209,7 @@ describe('Watch only wallet', () => {
       22,
       'bc1qtutssamysdkgd87df0afjct0mztx56qpze7wqe',
     );
-    assert.strictEqual(
-      psbt.toBase64(),
+    expect(psbt.toBase64()).toBe(
       'cHNidP8BAHECAAAAASJiwHJP3qYi80+cYjHn/n8TiJJR6jRbJFx67gnclfVdAAAAAAAAAACAAogTAAAAAAAAFgAUb3eWXdETtv7KGyXiUxyIS+Q3wJ003QAAAAAAABYAFF8XCHdkg2yGn81L+plhb9iWamgBAAAAAAABAR8oBAEAAAAAABYAFBAk4ma75DYqawitVrni8qlFzNykIgYDNK9TxoCjQ8P0+qI2Hu4hrnXnJuYAC3h2puZbgRORp+sYFo3WA1QAAIAAAACAAAAAgAAAAAAAAAAAAAAiAgL1DWeV+AfIP5RRB5zHv5vuXsIt8+rF9rrsji3FhQlhzBgWjdYDVAAAgAAAAIAAAACAAQAAAAAAAAAA',
     );
   });
@@ -229,31 +218,29 @@ describe('Watch only wallet', () => {
     const w = new WatchOnlyWallet();
     w.setSecret(require('fs').readFileSync('./tests/unit/fixtures/skeleton-cobo.txt', 'ascii'));
     w.init();
-    assert.ok(w.valid());
-    assert.strictEqual(
-      w.getSecret(),
+    expect(w.valid()).toBeTruthy();
+    expect(w.getSecret()).toBe(
       'zpub6rcabYFcdr41zyUNRWRyHYs2Sm86E5XV8RjjRzTFYsiCngteeZnkwaF2xuhjmM6kpHjuNpFW42BMhzPmFwXt48e1FhddMB7xidZzN4SF24K',
     );
-    assert.strictEqual(w.getMasterFingerprint(), 1908437330);
-    assert.strictEqual(w.getMasterFingerprintHex(), '5271c071');
-    assert.strictEqual(w.getLabel(), 'Wallet');
-    assert.strictEqual(w.getDerivationPath(), "m/84'/0'/0'");
-    assert.ok(w.useWithHardwareWalletEnabled());
+    expect(w.getMasterFingerprint()).toBe(1908437330);
+    expect(w.getMasterFingerprintHex()).toBe('5271c071');
+    expect(w.getLabel()).toBe('Wallet');
+    expect(w.getDerivationPath()).toBe("m/84'/0'/0'");
+    expect(w.useWithHardwareWalletEnabled()).toBeTruthy();
   });
 
   it('can import zpub with master fingerprint and derivation path', async () => {
     const w = new WatchOnlyWallet();
     w.setSecret(require('fs').readFileSync('./tests/unit/fixtures/skeleton-walletdescriptor.txt', 'ascii'));
     w.init();
-    assert.ok(w.valid());
-    assert.strictEqual(
-      w.getSecret(),
+    expect(w.valid()).toBeTruthy();
+    expect(w.getSecret()).toBe(
       'zpub6s2RJ9qAEBW8Abhojs6LyDzF7gttcDr6EsR3Umu2aptZBb45e734rGtt4KqsCMmNyR1EEzUU2ugdVYez2VywQvAbBjUSKn8ho4Zk2c5otkk',
     );
-    assert.strictEqual(w.getMasterFingerprint(), 4167290508);
-    assert.strictEqual(w.getMasterFingerprintHex(), '8cce63f8');
-    assert.strictEqual(w.getDerivationPath(), "m/84'/0'/0'");
-    assert.ok(!w.useWithHardwareWalletEnabled());
+    expect(w.getMasterFingerprint()).toBe(4167290508);
+    expect(w.getMasterFingerprintHex()).toBe('8cce63f8');
+    expect(w.getDerivationPath()).toBe("m/84'/0'/0'");
+    expect(!w.useWithHardwareWalletEnabled()).toBeTruthy();
   });
 
   it('can combine signed PSBT and prepare it for broadcast', async () => {
@@ -267,39 +254,38 @@ describe('Watch only wallet', () => {
 
     const Tx = w.combinePsbt(unsignedPsbt, signedPsbt);
 
-    assert.strictEqual(
-      Tx.toHex(),
+    expect(Tx.toHex()).toBe(
       '02000000000101805b8c2457c38afae8bcb5688fd20af8acf820d0b027507a3d41842a039e3b7f000000000000000080028813000000000000160014c0cebcd6c3d3ca8c75dc5ec62ebe55330ef910e2b739000000000000160014e73a921eeb94a4ad470c0cbdb69ebbea05bc1e0c0247304402203d1f736733539df3ea64989fc94c1d3367165bc3d9a829d20ac7c278f959d9aa022056e1affe4ffdb4ba786419b57dfeeaafa750ee8a69229881a699ad4644345e8101210358e1db384dc3e0a8aea11ee41ed993b4567b297401fbccdbe754002cb2714f1f00000000',
     );
 
     // checking that combine can work with both base64 and pure Psbt objects
     const Tx2 = w.combinePsbt(Psbt.fromBase64(unsignedPsbt), Psbt.fromBase64(signedPsbt));
 
-    assert.strictEqual(Tx2.toHex(), Tx.toHex());
+    expect(Tx2.toHex()).toBe(Tx.toHex());
   });
 
   it('ypub watch-only can generate addresses', async () => {
     const w = new WatchOnlyWallet();
     w.setSecret('ypub6Y9u3QCRC1HkZv3stNxcQVwmw7vC7KX5Ldz38En5P88RQbesP2oy16hNyQocVCfYRQPxdHcd3pmu9AFhLv7NdChWmw5iNLryZ2U6EEHdnfo');
     w.init();
-    assert.ok((await w._getExternalAddressByIndex(0)).startsWith('3'));
-    assert.ok(w.getAllExternalAddresses().includes(await w._getExternalAddressByIndex(0)));
+    expect((await w._getExternalAddressByIndex(0)).startsWith('3')).toBeTruthy();
+    expect(w.getAllExternalAddresses().includes(await w._getExternalAddressByIndex(0))).toBeTruthy();
   });
 
   it('xpub watch-only can generate addresses', async () => {
     const w = new WatchOnlyWallet();
     w.setSecret('xpub6CQdfC3v9gU86eaSn7AhUFcBVxiGhdtYxdC5Cw2vLmFkfth2KXCMmYcPpvZviA89X6DXDs4PJDk5QVL2G2xaVjv7SM4roWHr1gR4xB3Z7Ps');
     w.init();
-    assert.ok((await w._getExternalAddressByIndex(0)).startsWith('1'));
-    assert.ok(w.getAllExternalAddresses().includes(await w._getExternalAddressByIndex(0)));
+    expect((await w._getExternalAddressByIndex(0)).startsWith('1')).toBeTruthy();
+    expect(w.getAllExternalAddresses().includes(await w._getExternalAddressByIndex(0))).toBeTruthy();
   });
 
   it('can determine change address for HD wallet', async () => {
     const w = new WatchOnlyWallet();
     w.setSecret('ypub6Y9u3QCRC1HkZv3stNxcQVwmw7vC7KX5Ldz38En5P88RQbesP2oy16hNyQocVCfYRQPxdHcd3pmu9AFhLv7NdChWmw5iNLryZ2U6EEHdnfo');
     w.init();
-    assert.ok(!w.addressIsChange(await w._getExternalAddressByIndex(0)));
-    assert.ok(w.addressIsChange(await w._getInternalAddressByIndex(0)));
+    expect(!w.addressIsChange(await w._getExternalAddressByIndex(0))).toBeTruthy();
+    expect(w.addressIsChange(await w._getInternalAddressByIndex(0))).toBeTruthy();
   });
 
   it('can craft correct psbt for HW wallet to sign', async () => {
@@ -334,32 +320,31 @@ describe('Watch only wallet', () => {
       changeAddress,
     );
 
-    assert.strictEqual(
-      psbt.data.outputs[1].bip32Derivation[0].pubkey.toString('hex'),
+    expect(psbt.data.outputs[1].bip32Derivation[0].pubkey.toString('hex')).toBe(
       '03e060c9b5bb85476caa53e3b8cd3d40c9dc2c36a8a5e8ed87e48bfc9bbe1760ad',
     );
-    assert.strictEqual(psbt.data.outputs[1].bip32Derivation[0].path, "m/49'/0'/0'/1/46");
+    expect(psbt.data.outputs[1].bip32Derivation[0].path).toBe("m/49'/0'/0'/1/46");
   });
 
   it('xpub watch only has derivation path set to BIP44 default', () => {
     const w = new WatchOnlyWallet();
     w.setSecret('xpub6CQdfC3v9gU86eaSn7AhUFcBVxiGhdtYxdC5Cw2vLmFkfth2KXCMmYcPpvZviA89X6DXDs4PJDk5QVL2G2xaVjv7SM4roWHr1gR4xB3Z7Ps');
 
-    assert.strictEqual(w.getDerivationPath(), "m/44'/0'/0'");
+    expect(w.getDerivationPath()).toBe("m/44'/0'/0'");
   });
 
   it('ypub watch only has derivation path set to BIP49 default', () => {
     const w = new WatchOnlyWallet();
     w.setSecret('ypub6Y9u3QCRC1HkZv3stNxcQVwmw7vC7KX5Ldz38En5P88RQbesP2oy16hNyQocVCfYRQPxdHcd3pmu9AFhLv7NdChWmw5iNLryZ2U6EEHdnfo');
 
-    assert.strictEqual(w.getDerivationPath(), "m/49'/0'/0'");
+    expect(w.getDerivationPath()).toBe("m/49'/0'/0'");
   });
 
   it('zpub watch only has derivation path set to BIP84 default', () => {
     const w = new WatchOnlyWallet();
     w.setSecret('zpub6rjLjQVqVnj7crz9E4QWj4WgczmEseJq22u2B6k2HZr6NE2PQx3ZYg8BnbjN9kCfHymSeMd2EpwpM5iiz5Nrb3TzvddxW2RMcE3VXdVaXHk');
 
-    assert.strictEqual(w.getDerivationPath(), "m/84'/0'/0'");
+    expect(w.getDerivationPath()).toBe("m/84'/0'/0'");
   });
 });
 
@@ -380,8 +365,7 @@ describe('BC-UR', () => {
     w.init();
 
     const tx = w.combinePsbt(uPsbtB64, sPsbtB64);
-    assert.strictEqual(
-      tx.toHex(),
+    expect(tx.toHex()).toBe(
       '0200000000010179a8cb95eb6982c48fa79d31cd6c557b9382d56b6ec5bea8baed300b0625e6ea0100000000feffffff02fc630000000000001600142526fbd63288672766d4aeaa1b3957054483e89e204e000000000000160014c1ad3414335a36d1b1e89ba7214151b211163ec602473044022077ad33068b4a8da130ac8a64a3efbbaabaf18fa20d705adc86d53cbb69c18258022035eea4daadf9ba51080f57a7a3476d9f300414e82c544d58a24e682161e4be700121026757c3ea5b1d39f584ef358ac7c7f0eb99b290c625642529e0b4cc6472401c3f00000000',
     );
   });
@@ -391,8 +375,7 @@ describe('BC-UR', () => {
       'UR:BYTES/TYQHKGEQGDHKYM6KV96KCAPQF46KCARFWD5KWGRNV4682UPQVE5KCEFQ9P3HYETPW3JKGGR0DCSYGVEHG4Q5GWPC9Y9ZXZJWV9KK2W3QGDT97VENGG65YWF3G90NYTFJPFGX7MRFVDUN5GPJYPHKVGPJPFZX2UNFWESHG6T0DCAZQMF0XSUZWTESYUHNQFE0XGNS53N0WFKKZAP6YPGRY46NFQ9Q53PNXAZ5Z3PC8QAZQKNSW43RWDRFDFCXV6Z92F9YU6NGGD94S5NNWP2XGNZ22C6K2M69D4F4YKNYFPC5GANS8944VARY2EZHJ62CDVMHQKRC2F3XVKN629M8X3ZXWPNYGJZ9FPT8G4NS0Q6YG73EG3R42468DCE9S6E40FRN2AF5X4G4GNTNT9FNYAN2DA5YU5G2XYMRS3ZYXCCRXW3QTFC82C3HX4K5Z3FCG448J7ZN0FHHJ5RDGAHXGD29XEXHJ3PHG9XYWNNWV3E824MKX5E8SUR6D9K4552TW44HWAJ9VEV9GJR3D4YRSMNZVF3NVCMR2Q6HGVNPF5EK6AMNXDCYKK2NDE9HQJ6DF4UHGERZFEZ453J40P9H57N5T9RY6WZSDC9QWZ5LU2';
     const rez = decodeUR([txtFileFormatMultisigNativeSegwit]);
     const b = Buffer.from(rez, 'hex');
-    assert.strictEqual(
-      b.toString('ascii'),
+    expect(b.toString('ascii')).toBe(
       "# CoboVault Multisig setup file (created on D37EAD88)\n#\nName: CV_33B5B91A_2-2\nPolicy: 2 of 2\nDerivation: m/48'/0'/0'/2'\nFormat: P2WSH\n\nD37EAD88: Zpub74ijpfhERJNjhCKXRspTdLJV5eoEmSRZdHqDvp9kVtdVEyiXk7pXxRbfZzQvsDFpfDHEHVtVpx4Dz9DGUWGn2Xk5zG5u45QTMsYS2vjohNQ\n168DD603: Zpub75mAE8EjyxSzoyPmGnd5E6MyD7ALGNndruWv52xpzimZQKukwvEfXTHqmH8nbbc6ccP5t2aM3mws3pKYSnKpKMMytdbNEZFUxKzztYFM8Pn\n",
     );
   });
@@ -402,13 +385,12 @@ describe('BC-UR', () => {
       'UR:CRYPTO-ACCOUNT/OEADCYADWMTNKIAOLYTAADMWTAADDLOSAOWKAXHDCLAXMDRPFXWKHPTPNEWEVAWKYNFPJEDEMNJKAEGHCFQZLKUOTPLRIHMEFRTECWGRVWWDAAHDCXMHIODYPYLEAXZOGRPKEYPTBGBWGWDWHPZEIMVDBAAOIEVEWLZEGRBKRNFTHFAMMOAHTAADEHOEADADAOAEAMTAADDYOTADLNCSGHYKAEYKAEYKAOCYADWMTNKIAXAXATTAADDYOEADLRAEWKLAWKAXAEAYCYBGHFLOPACMIOWZLB';
 
     const [index, total] = extractSingleWorkload(payload);
-    assert.strictEqual(index, 1);
-    assert.strictEqual(total, 1);
+    expect(index).toBe(1);
+    expect(total).toBe(1);
 
     const decoded = decodeUR([payload]);
 
-    assert.strictEqual(
-      Buffer.from(decoded, 'hex').toString('ascii'),
+    expect(Buffer.from(decoded, 'hex').toString('ascii')).toBe(
       '{"ExtPubKey":"zpub6qT7amLcp2exr4mU4AhXZMjD9CFkopECVhUxc9LHW8pNsJG2B9ogs5sFbGZpxEeT5TBjLmc7EFYgZA9EeWEM1xkJMFLefzZc8eigRFhKB8Q","MasterFingerprint":"01EBDA7D","AccountKeyPath":"m/84\'/0\'/0\'"}',
     );
   });
@@ -421,8 +403,7 @@ describe('BC-UR', () => {
     const uPsbtB64 = Buffer.from(payload, 'hex').toString('base64');
 
     const psbtTx = Psbt.fromBase64(uPsbtB64);
-    assert.strictEqual(
-      psbtTx.extractTransaction().toHex(),
+    expect(psbtTx.extractTransaction().toHex()).toBe(
       '02000000000101f4964f72b0521e6f759b9b13051003233faab9ddad4d0e3ced0d7f357c9e0b730100000000ffffffff02a0860100000000001976a91419129d53e6319baf19dba059bead166df90ab8f588ace25a010000000000160014ededd9f510d1d268e751d15231832e0944acab2a024730440220513cbb75e1f3ed4e40d489ccf19f461f6aaf3feb1b9e96175a8f4bc93b8826000220777e589b1c479111a2c1d167041703ffe52bba5f685938061726334366282257012102615cd496b1f48644391ba078eae79ef68e19883cd1f09a449d5fb8bb24b3ed4f00000000',
     );
 
@@ -440,9 +421,9 @@ describe('BC-UR', () => {
     decoder.receivePart(
       'UR:CRYPTO-PSBT/75-2/LPCSGRAOCFAOIOCYCSKEMSHLHKADEECFZTYKOEFDAMJYZTFZTALNNEMTTKGRAEADADCTCYWMAOAEAEAEAEAECMAEBBTYKNASSBGUVSCFDYOEUOWYDRKPSEJOUYMORPISJPADAYJEAOFLDYFYAOCXBYYKBYFMMTSPFYFZFYWESNHNEYSWGDWSIOBNHYBTGETNSBJOEYLNOSGUGOVOPYTAAOCXCPRKIOLELEVETPTPIENDRDREAOPECHTBDPZSPEFPWYSEADHKDMAAZEDIMUHPOYZOADCLAOJSZOEMSTFYFDTSENRSHNNSVTLNFGWDOTUYHLFMGWRSGOFMUYVLGOADVLMEUEPFNYAEADADCTLNZMAOAEAEAEAEAECMAEBBJYLSWNATMWIOEMHTPMFXCWMTGLZSTPVSCMWDLBKKADAYJEAOFLDYFYAOCXIYQZMEGUDAAXSOKNWMGOAAZSLYSGFMWPFDNBDPBDJEFSMSDLPFJSWMHLAXKNTDGEAOCXDKHEPTGMZMYACWCEDEJEEORHOYCAHYSRJTFYDSMHROFTDYPEFGZMRSRLJZBDAMONADCLAOHSHHTYMTPAWKLNFYESCWNBKSWDVDNNYNMNCFLOFNTTWTNYFYNTHERORKDKQDWEGWAEAEAEPDBAJSAH',
     );
-    assert.strictEqual(decoder.estimatedPercentComplete(), 1);
+    expect(decoder.estimatedPercentComplete()).toBe(1);
     const psbt = Psbt.fromBase64(decoder.toString());
-    assert.ok(psbt);
+    expect(psbt).toBeTruthy();
   });
 
   it('v2: can decodeUR() multipart bytes', () => {
@@ -465,11 +446,11 @@ describe('BC-UR', () => {
     decoder.receivePart(
       'UR:BYTES/224-2/LPCSVTAOCFADKECYCEBTIDBGHDRNBGINGTCMFLKKDIFMESECFTCSDIHDBAETCWBTEOAHHPGUKPCEGDBAATFYJEDPBKECFNCFCEGDEHCLDNDSDLASCSBAAXISIHGHECDAAHCHGUEHKEHEBYIAENEECAEEAXFGCEBSHLKBHKFWDWDAIECHHFEHHFGHGDCXCYBAHYHFGWGLJOGEHDCSDMGAJEHSCABNDSHDFYDSFGFMFTDRAYFXCAJTKEFPJSKSHDGTHKKGKTGTIMFDGUJKAHENEMEYBTGOCHHSGRBEIYBDFRFMASKTEOFLDWFRGMIYJTHSCXCHCLEMGHIHCNDRCKCHJTCTATDKFRHKGYASENDRGWCFAYGHAABGAXFHFRCHFMADDYDYKPDNCWBKHPCEBDAODIJTSAPMYNHK',
     );
-    assert.strictEqual(decoder.estimatedPercentComplete(), 1);
+    expect(decoder.estimatedPercentComplete()).toBe(1);
     const str = decoder.toString();
 
-    assert.ok(str.includes('E4F0DB12'));
-    assert.ok(str.includes('Keystone Multisig setup file'));
+    expect(str.includes('E4F0DB12')).toBeTruthy();
+    expect(str.includes('Keystone Multisig setup file')).toBeTruthy();
   });
 
   it('v1: decodeUR() works', async () => {
@@ -479,23 +460,23 @@ describe('BC-UR', () => {
     const txt = 'hello world';
     const b = Buffer.from(txt, 'ascii');
     let fragments = encodeUR(b.toString('hex'), 666);
-    assert.deepStrictEqual(fragments, ['ur:bytes/fd5x2mrvdus8wmmjd3jqugwtl9']);
-    assert.strictEqual(Buffer.from(decodeUR(fragments), 'hex').toString('ascii'), txt);
+    expect(fragments).toEqual(['ur:bytes/fd5x2mrvdus8wmmjd3jqugwtl9']);
+    expect(Buffer.from(decodeUR(fragments), 'hex').toString('ascii')).toBe(txt);
 
     fragments = encodeUR(b.toString('hex'), 10);
-    assert.deepStrictEqual(fragments, [
+    expect(fragments).toEqual([
       'ur:bytes/1of3/fc38n9ue84vu8ra8ue6cdnrghws0dwep4f46q4rlrgdncwsg49lsw38e6m/fd5x2mrvdu',
       'ur:bytes/2of3/fc38n9ue84vu8ra8ue6cdnrghws0dwep4f46q4rlrgdncwsg49lsw38e6m/s8wmmjd3jq',
       'ur:bytes/3of3/fc38n9ue84vu8ra8ue6cdnrghws0dwep4f46q4rlrgdncwsg49lsw38e6m/ugwtl9',
     ]);
-    assert.strictEqual(Buffer.from(decodeUR(fragments), 'hex').toString('ascii'), txt);
+    expect(Buffer.from(decodeUR(fragments), 'hex').toString('ascii')).toBe(txt);
   });
 
   it('v2: decodeUR() bytes works', () => {
     const payload =
       'UR:BYTES/HKADKNCNCXGRIHKKJKJYJLJTIHCXGTKPJZJYINJKINIOCXJKIHJYKPJOCXIYINJZIHCXDEIAJPIHHSJYIHIECXJLJTCXDYEHFEFWFYFPEMFYDTBKCNBKGLHSJNIHFTCXGRGHHEFGFPFPESDYFEFWENHEEYDPEYBKGDJLJZINIAKKFTCXEYCXJLIYCXEYBKFYIHJPINKOHSJYINJLJTFTCXJNDLEEETDIDLDYDIDLDYDIDLEYDIBKFGJLJPJNHSJYFTCXGDEYHGGUFDBKBKDYEHFEFWFYFPEMFYFTCXHTJOKPIDEMECENJYGDKSKSKTFDINHKJEHKINGHEHEYFLEYHGGOFYEYIAJOFPFDKKHFHGISIMKOGRGDIDHDJLHKECIMFYHTGUKKJLEMEHKKFLECFXEHEEGSFXKPKTISKKIAGHGHFPKNIOGHGOIAGYIYIEIEGMETFGFGGHGYEHIDGUHGGMENJEKNJNGLIDGTFEHSHFKNGOJPIMEEGSISKSIDJLJTIMJLBKESEMFXFWEHECEEEYFTCXHTJOKPIDEMECHFKPHKIYKTJPFXIMEYGLHDKTFGGSGMIEIDKKKOGDGDJNGDKOEMGMJYIHGYKTFGGTHDFDGEGTGDJKFYKPFXEMKOISKOIDHGJSJLJNFEIEEMETHKJOJLGRIEEMJEGRJEIAIAGHGHFXFPJNJNIDECHFJNHDFPEHESHSISEMIMHDGYINIOGRGOIHKSJEIHGSIHKPGRIMKTJYFDKKENECJLBKYLYAHNRS';
     const result = Buffer.from(decodeUR([payload]), 'hex').toString();
-    assert.ok(result.includes('Keystone Multisig setup file'));
+    expect(result.includes('Keystone Multisig setup file')).toBeTruthy();
   });
 
   it('v2: encodeUR() psbt works', async () => {
@@ -504,8 +485,8 @@ describe('BC-UR', () => {
       '70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f000000000000000000';
 
     const fragments = encodeUR(psbtHex, 100);
-    assert.strictEqual(fragments.length, 2);
-    assert.deepStrictEqual(fragments, [
+    expect(fragments.length).toBe(2);
+    expect(fragments).toEqual([
       'ur:crypto-psbt/1-2/lpadaocsptcybkgdcarhhdgohdosjojkidjyzmadaenyaoaeaeaeaohdvsknclrejnpebncnrnmnjojofejzeojlkerdonspkpkkdkykfelokgprpyutkpaeaeaeaeaezmzmzmzmlslgaaditiwpihbkispkfgrkbdaslewdfycprtjsprsgksecdratkkhktimndacnch',
       'ur:crypto-psbt/2-2/lpaoaocsptcybkgdcarhhdgokewdcaadaeaeaeaezmzmzmzmaojopkwtayaeaeaeaecmaebbtphhdnjstiambdassoloimwmlyhygdnlcatnbggtaevyykahaeaeaeaecmaebbaeplptoevwwtyakoonlourgofgvsjydpcaltaemyaeaeaeaeaeaeaeaeaeaeswhhtptt',
     ]);
@@ -513,7 +494,7 @@ describe('BC-UR', () => {
 
   it('v1: extractSingleWorkload() works', () => {
     const [index, total] = extractSingleWorkload('ur:bytes/2of3/fc38n9ue84vu8ra8ue6cdnrghws0dwep4f46q4rlrgdncwsg49lsw38e6m/s8wmmjd3jq');
-    assert.strictEqual(index, 2);
-    assert.strictEqual(total, 3);
+    expect(index).toBe(2);
+    expect(total).toBe(3);
   });
 });


### PR DESCRIPTION
Looks like assert is still should be in package.json, because blue_modules/bip38 is still using it.