### PR TITLE
REF: Reformulate helping text

### DIFF
--- a/loc/en.json
+++ b/loc/en.json
@@ -303,7 +303,7 @@
     "lightning_saved": "Your changes have been saved successfully.",
     "lightning_settings": "Lightning Settings",
     "tor_settings": "Tor Settings",
-    "lightning_settings_explain": "To connect to your own LND node, please install LNDHub and put its URL here in settings. Leave blank to use BlueWallet’s LNDHub (lndhub.io). Wallets created after saving changes will connect to the specified LNDHub.",
+    "lightning_settings_explain": "To connect to your own LND node, please install LNDHub and put its URL here in settings. Leave blank to use BlueWallet’s LNDHub (lndhub.io). Please note that only wallets created after saving changes will connect to the specified LNDHub.",
     "network": "Network",
     "network_broadcast": "Broadcast Transaction",
     "network_electrum": "Electrum Server",


### PR DESCRIPTION
 Make this message more explicit and in particular that the wallets already created are not impacted by the change of the parameter (and that a new wallet must therefore be created if we want to use these new parameters).  Keyword: **only**.
 
Found this out after updating this parameter and wondering why I could still receive payments while my node hadn't got any active channel yet =)

