### PR TITLE
REF: dont load address txs if > 1000

### DIFF
--- a/class/wallets/legacy-wallet.ts
+++ b/class/wallets/legacy-wallet.ts
@@ -275,6 +275,11 @@ export class LegacyWallet extends AbstractWallet {
       }
     }
 
+    if (this.getTransactions().length === 0 && Object.values(txs).length > 1000)
+      throw new Error('Addresses with history of > 1000 transactions are not supported');
+    // we check existing transactions, so if there are any then user is just using his wallet and gradually reaching the theshold, which
+    // is safe because in that case our cache is filled
+
     // next, batch fetching each txid we got
     const txdatas = await BlueElectrum.multiGetTransactionByTxid(Object.keys(txs));
     const transactions = Object.values(txdatas);


### PR DESCRIPTION
```
im looking into that  huge address from user
it has 4k transactions
no way its gona fetch transactions in adequate time
im thinking about throwing an exception in case single address has more that, i dunno, 1k transactions..?
the rest should work fine - balance will update, and txs can be created (given that user uses normal electrum server, that suppots listUtxo call, unlike EPS that doesnt support that and we rely on deriving utxo from existing stored transactions)
```