### PR TITLE
FIX: Placeholder would intercept carrot due to default 0 value

### DIFF
--- a/components/AmountInput.js
+++ b/components/AmountInput.js
@@ -222,7 +222,7 @@ class AmountInput extends Component {
                 maxLength={this.maxLength()}
                 ref={textInput => (this.textInput = textInput)}
                 editable={!this.props.isLoading && !disabled}
-                value={amount === BitcoinUnit.MAX ? loc.units.MAX : parseFloat(amount) >= 0 ? String(amount) : undefined}
+                value={amount === BitcoinUnit.MAX ? loc.units.MAX : parseFloat(amount) > 0 ? String(amount) : undefined}
                 placeholderTextColor={disabled ? colors.buttonDisabledTextColor : colors.alternativeTextColor2}
                 style={[styles.input, stylesHook.input]}
               />


### PR DESCRIPTION
If you tapped at the very left of the amount input, it would go from 0 to 10. if u tapped at the very right, it would correctly be set to 1. 