### PR TITLE
Fix 3357 txs in realm

### DIFF
--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -296,3 +296,8 @@ it('can decrypt storage that is second in a list of buckets; and isPasswordInUse
   assert.ok(storage5loadResult);
   assert.strictEqual(Storage7.wallets[0].getLabel(), 'fakewallet');
 });
+
+it('Appstorage - hashIt() works', async () => {
+  const storage = new AppStorage();
+  assert.strictEqual(storage.hashIt('hello'), '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824');
+});


### PR DESCRIPTION
a bit risky change. we change format of storing HD wallets transactions in realm. before, we json encoded all txs in a single json blob and wrote it in a single realm row.
that started failing when some users transactions exceeded 30 mb.

after that change we store 1 tx per row, so we now practically can store unlimited amount of transactions (again HD wallets only).

after the update, users will notice transactions disappearing and then re-fetching.

also, if user updated to this build its impossible to go back, as realm doesn't allow schema downgrade.

cc @ncoelho 