### PR TITLE
FIX: styles on transactions/details screen

### DIFF
--- a/BlueComponents.js
+++ b/BlueComponents.js
@@ -382,17 +382,8 @@ export const BlueCard = props => {
 
 export const BlueText = props => {
   const { colors } = useTheme();
-  return (
-    <Text
-      {...props}
-      style={{
-        color: colors.foregroundColor,
-
-        ...props.style,
-        writingDirection: I18nManager.isRTL ? 'rtl' : 'ltr',
-      }}
-    />
-  );
+  const style = StyleSheet.compose({ color: colors.foregroundColor, writingDirection: I18nManager.isRTL ? 'rtl' : 'ltr' }, props.style);
+  return <Text {...props} style={style} />;
 };
 
 export const BlueTextCentered = props => {

--- a/screen/transactions/details.js
+++ b/screen/transactions/details.js
@@ -36,12 +36,6 @@ const TransactionsDetails = () => {
   const [memo, setMemo] = useState();
   const { colors } = useTheme();
   const stylesHooks = StyleSheet.create({
-    rowCaption: {
-      color: colors.foregroundColor,
-    },
-    txId: {
-      color: colors.foregroundColor,
-    },
     txLink: {
       color: colors.alternativeTextColor2,
     },
@@ -163,7 +157,7 @@ const TransactionsDetails = () => {
           {from && (
             <>
               <View style={styles.rowHeader}>
-                <BlueText style={[styles.rowCaption, stylesHooks.rowCaption]}>{loc.transactions.details_from}</BlueText>
+                <BlueText style={styles.rowCaption}>{loc.transactions.details_from}</BlueText>
                 <BlueCopyToClipboardButton stringToCopy={from.filter(onlyUnique).join(', ')} />
               </View>
               <BlueText style={styles.rowValue}>{from.filter(onlyUnique).join(', ')}</BlueText>
@@ -173,7 +167,7 @@ const TransactionsDetails = () => {
           {to && (
             <>
               <View style={styles.rowHeader}>
-                <BlueText style={[styles.rowCaption, stylesHooks.rowCaption]}>{loc.transactions.details_to}</BlueText>
+                <BlueText style={styles.rowCaption}>{loc.transactions.details_to}</BlueText>
                 <BlueCopyToClipboardButton stringToCopy={to.filter(onlyUnique).join(', ')} />
               </View>
               <BlueText style={styles.rowValue}>{arrDiff(from, to.filter(onlyUnique)).join(', ')}</BlueText>
@@ -182,7 +176,7 @@ const TransactionsDetails = () => {
 
           {tx.fee && (
             <>
-              <BlueText style={[styles.rowCaption, stylesHooks.rowCaption]}>{loc.send.create_fee}</BlueText>
+              <BlueText style={styles.rowCaption}>{loc.send.create_fee}</BlueText>
               <BlueText style={styles.rowValue}>{tx.fee + ' sats'}</BlueText>
             </>
           )}
@@ -199,28 +193,28 @@ const TransactionsDetails = () => {
 
           {tx.received && (
             <>
-              <BlueText style={[styles.rowCaption, stylesHooks.rowCaption]}>{loc.transactions.details_received}</BlueText>
+              <BlueText style={styles.rowCaption}>{loc.transactions.details_received}</BlueText>
               <BlueText style={styles.rowValue}>{dayjs(tx.received).format('LLL')}</BlueText>
             </>
           )}
 
           {tx.block_height > 0 && (
             <>
-              <BlueText style={[styles.rowCaption, stylesHooks.rowCaption]}>{loc.transactions.details_block}</BlueText>
+              <BlueText style={styles.rowCaption}>{loc.transactions.details_block}</BlueText>
               <BlueText style={styles.rowValue}>{tx.block_height}</BlueText>
             </>
           )}
 
           {tx.inputs && (
             <>
-              <BlueText style={[styles.rowCaption, stylesHooks.rowCaption]}>{loc.transactions.details_inputs}</BlueText>
+              <BlueText style={styles.rowCaption}>{loc.transactions.details_inputs}</BlueText>
               <BlueText style={styles.rowValue}>{tx.inputs.length}</BlueText>
             </>
           )}
 
           {tx.outputs?.length > 0 && (
             <>
-              <BlueText style={[styles.rowCaption, stylesHooks.rowCaption]}>{loc.transactions.details_outputs}</BlueText>
+              <BlueText style={styles.rowCaption}>{loc.transactions.details_outputs}</BlueText>
               <BlueText style={styles.rowValue}>{tx.outputs.length}</BlueText>
             </>
           )}


### PR DESCRIPTION
There were an error on transactions/details screen

Because styles where joining with object destruction. It doesn't work if your style is an array.
I switched to StyleSheet.compose and removed a couple of duplicate styles


```js 
Warning: Failed prop type: Invalid props.style key `0` supplied to `Text`.
Bad object: {
  "0": {
    "fontSize": 16,
    "fontWeight": "500"
  },
  "1": {
    "color": "#0c2550"
  },
  "color": "#0c2550",
  "writingDirection": "ltr"
}
Valid keys: [
  "display",
  "width",
  "height",
  "start",
   ...
]
    at Text
    in TextElement (at withTheme.js:44)
    in Themed.Text (at BlueComponents.js:386)
    in BlueText (at details.js:193)
    in RCTView (at View.js:34)
    in View (at details.js:192)
    in RCTView (at View.js:34)
    in View (at BlueComponents.js:380)
    in BlueCard (at details.js:151)
    in RCTScrollContentView (at ScrollView.js:1107)
    in RCTScrollView (at ScrollView.js:1238)
   ...
```