### PR TITLE
FIX: vByte in loc

### DIFF
--- a/BlueComponents.js
+++ b/BlueComponents.js
@@ -1129,7 +1129,7 @@ export class BlueReplaceFeeSuggestions extends Component {
           </View>
         </TouchableOpacity>
         <BlueText style={{ color: BlueCurrentTheme.colors.alternativeTextColor }}>
-          {loc.formatString(loc.send.fee_replace_min, { min: this.props.transactionMinimum })}
+          {loc.formatString(loc.send.fee_replace_minvb, { min: this.props.transactionMinimum })}
         </BlueText>
       </View>
     );

--- a/loc/en.json
+++ b/loc/en.json
@@ -231,7 +231,7 @@
     "fee_custom": "Custom",
     "fee_fast": "Fast",
     "fee_medium": "Medium",
-    "fee_replace_min": "The total fee rate (satoshi per vbyte) you want to pay should be higher than {min} sat/vbyte.",
+    "fee_replace_minvb": "The total fee rate (satoshi per vbyte) you want to pay should be higher than {min} sat/vbyte.",
     "fee_satvbyte": "in sat/vByte",
     "fee_slow": "Slow",
     "header": "Send",


### PR DESCRIPTION
if you drastically change loc string in en.json and it now has different meaning, it is better to create new key for it. Otherwise it should be deleted from all other loc files.

related to #3810