### PR TITLE
FIX: do not check secret when adding new wallet

### DIFF
--- a/class/wallet-import.js
+++ b/class/wallet-import.js
@@ -57,7 +57,7 @@ function WalletImport() {
   };
 
   WalletImport.isWalletImported = w => {
-    const wallet = wallets.some(wallet => wallet.getSecret() === w.secret || wallet.getID() === w.getID());
+    const wallet = wallets.some(wallet => wallet.getID() === w.getID());
     return !!wallet;
   };
 


### PR DESCRIPTION
wallet.getID() is enought, because it is already contains hash of secret + passphrase

closes #3848

@mcsaeid please test it