### PR TITLE
FIX: use getID to compare wallets during delete and loadFromDisk

### DIFF
--- a/class/app-storage.js
+++ b/class/app-storage.js
@@ -426,7 +426,8 @@ export class AppStorage {
         }
 
         // done
-        if (!this.wallets.some(wallet => wallet.getSecret() === unserializedWallet.secret)) {
+        const ID = unserializedWallet.getID();
+        if (!this.wallets.some(wallet => wallet.getID() === ID)) {
           this.wallets.push(unserializedWallet);
           this.tx_metadata = data.tx_metadata;
         }
@@ -445,7 +446,7 @@ export class AppStorage {
    * @param wallet {AbstractWallet}
    */
   deleteWallet = wallet => {
-    const secret = wallet.getSecret();
+    const ID = wallet.getID();
     const tempWallets = [];
 
     if (wallet.type === LightningLdkWallet.type) {
@@ -457,7 +458,7 @@ export class AppStorage {
     for (const value of this.wallets) {
       if (value.type === PlaceholderWallet.type) {
         continue;
-      } else if (value.getSecret() === secret) {
+      } else if (value.getID() === ID) {
         // the one we should delete
         // nop
       } else {


### PR DESCRIPTION
Basically same as #3849
- If you add 2 wallets with same seed, but different passphrase, and try to remove one wallet, both wallets will be removed
- same for loading from disk. one wallet will be removed if they both have same seed

PS
We use getID() quite often in the app. And it always calculates sha256, for it. How fast is it? Should we optimize it? Switch to constant id's, for example. Of cache it.