### PR TITLE
FIX: Iranian currency

### DIFF
--- a/models/fiatUnits.json
+++ b/models/fiatUnits.json
@@ -119,6 +119,12 @@
       "locale": "fa-IR",
       "source": "Exir"
     },
+    "IRR": {
+      "endPointKey": "IRR",
+      "symbol": "﷼",
+      "locale": "fa-IR",
+      "source": "Exir"
+    },
     "JPY": {
       "endPointKey": "JPY",
       "symbol": "¥",

--- a/models/fiatUnits.json
+++ b/models/fiatUnits.json
@@ -113,9 +113,9 @@
       "locale": "hi-HN",
       "source": "CoinDesk"
     },
-    "IRR": {
-      "endPointKey": "IRR",
-      "symbol": "﷼",
+    "IRT": {
+      "endPointKey": "IRT",
+      "symbol": "تومان",
       "locale": "fa-IR",
       "source": "Exir"
     },

--- a/tests/integration/Currency.test.js
+++ b/tests/integration/Currency.test.js
@@ -42,9 +42,9 @@ describe('currency', () => {
     // assert.ok(cur.BTC_LBP > 0);
 
     // test Exir rate source
-    await currency.setPrefferedCurrency(FiatUnit.IRR);
+    await currency.setPrefferedCurrency(FiatUnit.IRT);
     await currency.init(true);
     cur = JSON.parse(await AsyncStorage.getItem(currency.EXCHANGE_RATES));
-    assert.ok(cur.BTC_IRR > 0);
+    assert.ok(cur.BTC_IRT > 0);
   });
 });

--- a/tests/integration/Currency.test.js
+++ b/tests/integration/Currency.test.js
@@ -42,9 +42,9 @@ describe('currency', () => {
     // assert.ok(cur.BTC_LBP > 0);
 
     // test Exir rate source
-    await currency.setPrefferedCurrency(FiatUnit.IRT);
+    await currency.setPrefferedCurrency(FiatUnit.IRR);
     await currency.init(true);
     cur = JSON.parse(await AsyncStorage.getItem(currency.EXCHANGE_RATES));
-    assert.ok(cur.BTC_IRT > 0);
+    assert.ok(cur.BTC_IRR > 0);
   });
 });


### PR DESCRIPTION
The correct Iranian currency is IRT or Iranian Toman. Exir* also shows the amount in toman instead of rial (IRR).

Since IRR is one-tenth of an IRT, the amount shown in BlueWallet is incorrect. It should be ten times more†. People rarely use IRR in daily life, anyway.

![bkp09a4E jpg small](https://user-images.githubusercontent.com/63400670/133936419-274821f9-0e32-4966-99f0-a543ed02eb50.jpg)

![cY1HDdf2 jpg small](https://user-images.githubusercontent.com/63400670/133936422-887a5076-7bdc-4516-a13e-fece0dde4513.jpg)

*‌ https://github.com/BlueWallet/BlueWallet/blob/42be5c9b56f371ee2ce9109bdab6a98ecdd08f46/models/fiatUnit.ts#L62
† The correct amount shown in the screenshot should have been ۱۵۱٬۹۷۷٬۵۰۰٫۰۰ ﷼.

**Question**
How can we fix the thousands separators? They look off. For comparison, look at the Persian numbers above. I am also using the Arabic Thousands Separator (U+066C) instead of a comma.