### PR TITLE
FIX: Sign/Verify uncompressed

### DIFF
--- a/class/wallets/legacy-wallet.ts
+++ b/class/wallets/legacy-wallet.ts
@@ -601,8 +601,18 @@ export class LegacyWallet extends AbstractWallet {
    * @returns {boolean} base64 encoded signature
    */
   verifyMessage(message: string, address: string, signature: string): boolean {
-    // null, true so it can verify Electrum signatores without errors
-    return bitcoinMessage.verify(message, address, signature, undefined, true);
+    // undefined, true so it can verify Electrum signatures without errors
+    try {
+      return bitcoinMessage.verify(message, address, signature, undefined, true);
+    } catch (e) {
+      if (e.message === 'checkSegwitAlways can only be used with a compressed pubkey signature flagbyte') {
+        // If message created with uncompressed private key, it will throw this error
+        // in this case we should re-try with checkSegwitAlways flag off
+        // node_modules/bitcoinjs-message/index.js:187
+        return bitcoinMessage.verify(message, address, signature);
+      }
+      throw e;
+    }
   }
 
   /**

--- a/tests/unit/legacy-wallet.test.js
+++ b/tests/unit/legacy-wallet.test.js
@@ -133,4 +133,13 @@ describe('Legacy wallet', () => {
     assert.strictEqual(signature, 'H9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk=');
     assert.strictEqual(l.verifyMessage('This is an example of a signed message.', l.getAddress(), signature), true);
   });
+
+  it('can sign and verify messages with uncompressed key', async () => {
+    const l = new LegacyWallet();
+    l.setSecret('5JqSfbkoVDrzM5i7PH7939G5fwWVDWmnFTSMbVctAmet3tYMq2S');
+
+    const signature = l.signMessage('This is an example of a signed message.', l.getAddress());
+    assert.strictEqual(signature, 'G19XLC0OYWN5ftv3N01s1PSt9Zpy0ZRKL2THZA46qGb0Jax29+SFmsdlsup0QKFeGJYN+m2HQTG1Na+YxcjU9ew=');
+    assert.strictEqual(l.verifyMessage('This is an example of a signed message.', l.getAddress(), signature), true);
+  });
 });


### PR DESCRIPTION
In case of message created of uncompressed key, it need to be verified without `checkSegwitAlways` key

<img width="200" alt="image" src="https://user-images.githubusercontent.com/155891/137143414-77865d7c-6a13-4fc8-910c-c86f6af46668.png">
