### PR TITLE
ADD: Arab countries

### DIFF
--- a/models/fiatUnits.json
+++ b/models/fiatUnits.json
@@ -37,7 +37,7 @@
     },
     "BHD": {
       "endPointKey": "BHD",
-      "symbol": "د.ب",
+      "symbol": "د.ب.",
       "locale": "ar-BH",
       "source": "CoinDesk"
     },


### PR DESCRIPTION
Adoption for Bitcoin in Arab countries is taking place now.
Added GCC Arab countries (all supported by CoinDesk):
Saudi riyal, Emirati dirham, Bahraini dinar, Omani rial, Kuwaiti dinar, Qatari riyal.

Exchange rate is accurate since all of GCC countries are linked to a fixed exchange rate to the Dollar since 1986.