### PR TITLE
FIX: refresh lndhub wallet balance after paying for invoice by scanning qrcode on main screen

### DIFF
--- a/screen/lnd/scanLndInvoice.js
+++ b/screen/lnd/scanLndInvoice.js
@@ -217,7 +217,7 @@ const ScanLndInvoice = () => {
       amountUnit: BitcoinUnit.SATS,
       invoiceDescription: decoded.description,
     });
-    fetchAndSaveWalletTransactions(walletID);
+    fetchAndSaveWalletTransactions(wallet.getID());
   };
 
   const processTextForInvoice = text => {


### PR DESCRIPTION
`walletID` is not set when user scans code on main screen

closes #3679