### PR TITLE
FIX: Pull-to-refresh on main screen

### DIFF
--- a/screen/wallets/list.js
+++ b/screen/wallets/list.js
@@ -139,7 +139,7 @@ const WalletsList = () => {
   const refreshTransactions = async (showLoadingIndicator = true, showUpdateStatusIndicator = false) => {
     if (isElectrumDisabled) return setIsLoading(false);
     setIsLoading(showLoadingIndicator);
-    refreshAllWalletTransactions(showLoadingIndicator, showUpdateStatusIndicator).finally(() => setIsLoading(false));
+    refreshAllWalletTransactions(false, showUpdateStatusIndicator).finally(() => setIsLoading(false));
   };
 
   useEffect(() => {


### PR DESCRIPTION
Right now pull-to-refresh is broken on main screen, because instead of calling `refreshAllWalletTransactions(` with index of wallet to refresh it was called with `true`