### PR TITLE
FIX: If derivation path returns empty string, return null instead of …

### DIFF
--- a/screen/wallets/details.js
+++ b/screen/wallets/details.js
@@ -130,7 +130,8 @@ const WalletDetails = () => {
   const [masterFingerprint, setMasterFingerprint] = useState();
   const derivationPath = useMemo(() => {
     try {
-      return wallet.getDerivationPath();
+      const path = wallet.getDerivationPath();
+      return path.length > 0 ? path : null;
     } catch (e) {
       return null;
     }


### PR DESCRIPTION
…crash