### PR TITLE
FIX: scan BC-UR Crypto-Account animated

### DIFF
--- a/blue_modules/ur/index.js
+++ b/blue_modules/ur/index.js
@@ -97,11 +97,7 @@ function encodeURv2(str, len) {
             isMaster: false,
             key: Buffer.from(cosigner.getKeyHex(), 'hex'),
             chainCode: Buffer.from(cosigner.getChainCodeHex(), 'hex'),
-            origin: new CryptoKeypath(
-              cryptoKeyPathComponents,
-              Buffer.from(cosigner.getFp(), 'hex'),
-              cosigner.getDepthNumber(),
-            ),
+            origin: new CryptoKeypath(cryptoKeyPathComponents, Buffer.from(cosigner.getFp(), 'hex'), cosigner.getDepthNumber()),
             parentFingerprint: Buffer.from(cosigner.getParentFingerprintHex(), 'hex'),
           }),
         ),
@@ -155,6 +151,10 @@ function decodeUR(arg) {
 
   for (const part of arg) {
     decoder.receivePart(part);
+  }
+
+  if (!decoder.isComplete()) {
+    throw new Error("decodeUR func can't work with multimart BC-UR data. Prease use BlueURDecoder instead.");
   }
 
   if (!decoder.isSuccess()) {
@@ -218,10 +218,54 @@ class BlueURDecoder extends URDecoder {
     if (decoded.type === 'crypto-psbt') {
       const cryptoPsbt = CryptoPSBT.fromCBOR(decoded.cbor);
       return cryptoPsbt.getPSBT().toString('base64');
-    } else if (decoded.type === 'bytes') {
+    }
+
+    if (decoded.type === 'bytes') {
       const bytes = Bytes.fromCBOR(decoded.cbor);
       return Buffer.from(bytes.getData(), 'hex').toString('ascii');
     }
+
+    if (decoded.type === 'crypto-account') {
+      const cryptoAccount = CryptoAccount.fromCBOR(decoded.cbor);
+
+      // now, crafting zpub out of data we have
+      const hdKey = cryptoAccount.outputDescriptors[0].getCryptoKey();
+      const derivationPath = 'm/' + hdKey.getOrigin().getPath();
+      const script = cryptoAccount.outputDescriptors[0].getScriptExpressions()[0].getExpression();
+      const isMultisig =
+        script === ScriptExpressions.WITNESS_SCRIPT_HASH.getExpression() ||
+        // fallback to paths (unreliable).
+        // dont know how to add ms p2sh (legacy) or p2sh-p2wsh (wrapped segwit) atm
+        derivationPath === MultisigHDWallet.PATH_LEGACY ||
+        derivationPath === MultisigHDWallet.PATH_WRAPPED_SEGWIT ||
+        derivationPath === MultisigHDWallet.PATH_NATIVE_SEGWIT;
+      const version = Buffer.from(isMultisig ? '02aa7ed3' : '04b24746', 'hex');
+      const parentFingerprint = hdKey.getParentFingerprint();
+      const depth = hdKey.getOrigin().getDepth();
+      const depthBuf = Buffer.alloc(1);
+      depthBuf.writeUInt8(depth);
+      const components = hdKey.getOrigin().getComponents();
+      const lastComponents = components[components.length - 1];
+      const index = lastComponents.isHardened() ? lastComponents.getIndex() + 0x80000000 : lastComponents.getIndex();
+      const indexBuf = Buffer.alloc(4);
+      indexBuf.writeUInt32BE(index);
+      const chainCode = hdKey.getChainCode();
+      const key = hdKey.getKey();
+      const data = Buffer.concat([version, depthBuf, parentFingerprint, indexBuf, chainCode, key]);
+
+      const zpub = b58.encode(data);
+
+      const result = {};
+      result.ExtPubKey = zpub;
+      result.MasterFingerprint = cryptoAccount.getMasterFingerprint().toString('hex').toUpperCase();
+      result.AccountKeyPath = derivationPath;
+
+      const str = JSON.stringify(result);
+      return str;
+      // return Buffer.from(str, 'ascii').toString('hex'); // we are expected to return hex-encoded string
+    }
+
+    throw new Error('unsupported data format');
   }
 }
 

--- a/screen/send/ScanQRCode.js
+++ b/screen/send/ScanQRCode.js
@@ -196,6 +196,10 @@ const ScanQRCode = () => {
     }
     scannedCache[h] = +new Date();
 
+    if (ret.data.toUpperCase().startsWith('UR:CRYPTO-ACCOUNT')) {
+      return _onReadUniformResourceV2(ret.data);
+    }
+
     if (ret.data.toUpperCase().startsWith('UR:CRYPTO-PSBT')) {
       return _onReadUniformResourceV2(ret.data);
     }


### PR DESCRIPTION
In this case AirGap shows BC-UR CRYPTO-ACCOUNT animated Qr-code. But blue_modules/ur/index.js decodeUR func can't handle multipart qr-code. Instead of waiting for more data it raises empty error. That is why I've changed handler for `UR:CRYPTO-ACCOUNT` from old `_onReadUniformResource` to new `_onReadUniformResourceV2` which uses `BlueURDecoder` class. 

Also I've extended `BlueURDecoder` to be able to work with CRYPTO-ACCOUNT. 

Looks like BC-UR handling in BW needs to be refactored.

closes #4229