### PR TITLE
FIX: iOS: If you create a lightning wallet and have a bad URL (enter …

### DIFF
--- a/screen/wallets/add.js
+++ b/screen/wallets/add.js
@@ -211,7 +211,11 @@ const WalletsAdd = () => {
     } catch (Err) {
       setIsLoading(false);
       console.warn('lnd create failure', Err);
-      return alert(Err);
+      if (Err.message) {
+        return alert(Err.message);
+      } else {
+        return alert(loc.wallets.add_lndhub_error);
+      }
       // giving app, not adding anything
     }
     A(A.ENUM.CREATED_LIGHTNING_WALLET);


### PR DESCRIPTION
…"x") the app crashes. #4449