### PR TITLE
FIX: Dark Mode on Android 11 prevents other Apps (including BlueWalle…

### DIFF
--- a/components/QRCodeComponent.js
+++ b/components/QRCodeComponent.js
@@ -85,7 +85,7 @@ const QRCodeComponent = ({
 export default QRCodeComponent;
 
 const styles = StyleSheet.create({
-  qrCodeContainer: { borderWidth: 6, borderRadius: 8, borderColor: '#FFFFFF', backgroundColor: '#FFFFFF' },
+  qrCodeContainer: { borderWidth: 6, borderRadius: 8, borderColor: '#FFFFFF', borderStyle: 'solid' },
 });
 
 QRCodeComponent.actionKeys = {

--- a/components/QRCodeComponent.js
+++ b/components/QRCodeComponent.js
@@ -85,7 +85,7 @@ const QRCodeComponent = ({
 export default QRCodeComponent;
 
 const styles = StyleSheet.create({
-  qrCodeContainer: { borderWidth: 6, borderRadius: 8, borderColor: '#FFFFFF' },
+  qrCodeContainer: { borderWidth: 6, borderRadius: 8, borderColor: '#FFFFFF', backgroundColor: '#FFFFFF' },
 });
 
 QRCodeComponent.actionKeys = {


### PR DESCRIPTION
…t) to read the QR-Codes! #4458