### PR TITLE
[WIP] BIP-47 feature implementation

### DIFF
--- a/bip-47-init.txt
+++ b/bip-47-init.txt
@@ -1,0 +1,22 @@
+According to the BIP47 document, the following core functionality is required:
+
+Generate payment code from seed
+Initialize a payment code from base58 payment code
+Derive notification addresses
+Derive public keys from a payment code and a notification private key
+Derive public keys from a payment code and a notification public key
+Derive P2PKH addresses from a payment code and notification private key
+Derive P2Pkh addresses from a payment code and notification public key
+
+Fortunately, Dojo full node source code has implemented all the above functionally. Specifically in these projects bip-47-tool and bip47-js.
+We could directly make use of bip47-js functions and use the bip47-tool project to double-check our implementation. We may implement any other behavioral functionality that we may need independently.
+
+We will be able to derive BIP-47 compatible addresses from BIP-39 Mnemonic Seeds which should be enough to enable portability among other wallets like SamuraiWallet.
+
+Paynyms which are implemented by SamuraiWallet will not be implemented here. Instead, users will be able to simply share their unique “Payment Code”. If paynym-like behavior is desired, a separate public directory needs to be developed.
+
+
+We are a team of 3, working together for around 4 years and doing research and contribution to blockchain projects for around a year
+Our team consists of an experienced designer (https://dribbble.com/Beigi) an experienced Frontend and React Native developer (https://github.com/alimahdiyar) and a backend developer(https://github.com/spsina/)
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "bip32": "3.0.1",
         "bip38": "github:BlueWallet/bip38",
         "bip39": "3.0.4",
+        "bip47": "github:spsina/bip47",
         "bitcoinjs-lib": "6.0.1",
         "bitcoinjs-message": "2.2.0",
         "bolt11": "1.3.4",
@@ -8251,6 +8252,34 @@
       "version": "11.11.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
       "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+    },
+    "node_modules/bip47": {
+      "version": "0.0.1",
+      "resolved": "git+ssh://git@github.com/spsina/bip47.git#65fa98a7ac9bedd0ea39825ea67638ec0188dd08",
+      "license": "MIT",
+      "dependencies": {
+        "bip32": "^3.0.1",
+        "bip39": "^3.0.4",
+        "bitcoinjs-lib": "^6.0.1",
+        "bs58check": "^2.1.1",
+        "create-hmac": "^1.1.7",
+        "ecpair": "^2.0.1",
+        "tiny-secp256k1": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bip47/node_modules/tiny-secp256k1": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-2.2.1.tgz",
+      "integrity": "sha512-/U4xfVqnVxJXN4YVsru0E6t5wVncu2uunB8+RVR40fYUxkKYUPS10f+ePQZgFBoE/Jbf9H1NBveupF2VmB58Ng==",
+      "dependencies": {
+        "uint8array-tools": "0.0.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/bip66": {
       "version": "1.1.5",
@@ -27648,6 +27677,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/uint8array-tools": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.7.tgz",
+      "integrity": "sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/ultron": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
@@ -34725,6 +34762,29 @@
           "version": "11.11.6",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
           "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+        }
+      }
+    },
+    "bip47": {
+      "version": "git+ssh://git@github.com/spsina/bip47.git#65fa98a7ac9bedd0ea39825ea67638ec0188dd08",
+      "from": "bip47@git+ssh://git@github.com:spsina/bip47.git",
+      "requires": {
+        "bip32": "^3.0.1",
+        "bip39": "^3.0.4",
+        "bitcoinjs-lib": "^6.0.1",
+        "bs58check": "^2.1.1",
+        "create-hmac": "^1.1.7",
+        "ecpair": "^2.0.1",
+        "tiny-secp256k1": "^2.2.1"
+      },
+      "dependencies": {
+        "tiny-secp256k1": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-2.2.1.tgz",
+          "integrity": "sha512-/U4xfVqnVxJXN4YVsru0E6t5wVncu2uunB8+RVR40fYUxkKYUPS10f+ePQZgFBoE/Jbf9H1NBveupF2VmB58Ng==",
+          "requires": {
+            "uint8array-tools": "0.0.7"
+          }
         }
       }
     },
@@ -49880,6 +49940,11 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
+    },
+    "uint8array-tools": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.7.tgz",
+      "integrity": "sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ=="
     },
     "ultron": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "bip32": "3.0.1",
     "bip38": "github:BlueWallet/bip38",
     "bip39": "3.0.4",
+    "bip47": "github:spsina/bip47",
     "bitcoinjs-lib": "6.0.1",
     "bitcoinjs-message": "2.2.0",
     "bolt11": "1.3.4",


### PR DESCRIPTION
According to the [BIP47 document](https://github.com/OpenBitcoinPrivacyProject/rfc/blob/master/obpp-05.mediawiki), the following core functionality is required:

- Generate payment code from seed
- Initialize a payment code from base58 payment code
- Derive notification addresses
- Derive public keys from a payment code and a notification private key
- Derive public keys from a payment code and a notification public key
- Derive P2PKH addresses from a payment code and notification private key
- Derive P2Pkh addresses from a payment code and notification public key

Fortunately,[ Dojo full node source code ](https://code.samourai.io/dojo)has implemented all the above functionally. Specifically in these projects [bip-47-tool](https://code.samourai.io/dojo/bip47-tool) and [bip47-js](https://code.samourai.io/dojo/bip47-js).
We could directly make use of bip47-js functions and use the bip47-tool project to double-check our implementation. We may implement any other behavioral functionality that we may need independently.

We will be able to derive BIP-47 compatible addresses from BIP-39 Mnemonic Seeds which should be enough to enable portability among other wallets like SamuraiWallet.

Paynyms which are implemented by SamuraiWallet will not be implemented here. Instead, users will be able to simply share their unique “Payment Code”. If paynym-like behavior is desired, a separate public directory needs to be developed.


We are a team of 3, working together for around 4 years and doing research and contribution to blockchain projects for around a year
Our team consists of an experienced designer (https://dribbble.com/Beigi) an experienced Frontend and React Native developer (https://github.com/alimahdiyar) and a backend developer(https://github.com/spsina/)

fixes #2883