### PR TITLE
FIX: lnurl-withdrawal bug when it says 'Maximum amount is X  sats'

### DIFF
--- a/screen/lnd/lndCreateInvoice.js
+++ b/screen/lnd/lndCreateInvoice.js
@@ -165,7 +165,7 @@ const LNDCreateInvoice = () => {
 
       if (lnurlParams) {
         const { min, max } = lnurlParams;
-        if (invoiceAmount < min || invoiceAmount > min) {
+        if (invoiceAmount < min || invoiceAmount > max) {
           let text;
           if (invoiceAmount < min) {
             text =


### PR DESCRIPTION
feels like a dumb typo