### PR TITLE
Be able to send exact amount in BTC

### DIFF
--- a/components/AmountInput.js
+++ b/components/AmountInput.js
@@ -126,7 +126,7 @@ class AmountInput extends Component {
   maxLength = () => {
     switch (this.props.unit) {
       case BitcoinUnit.BTC:
-        return 10;
+        return 11;
       case BitcoinUnit.SATS:
         return 15;
       default:


### PR DESCRIPTION
I regularly use BlueWallet to reserve hotels/flights using Bitcoin transactions (0.0.....1231 BTC), and I had problems with 1-9 satoshis missing because of the too short text editor input size. It's very frustrating, but this change will probably fix the bug.