### PR TITLE
Add Nobitex exchange for IRT currency

### DIFF
--- a/models/fiatUnit.ts
+++ b/models/fiatUnit.ts
@@ -5,6 +5,7 @@ export const FiatUnitSource = {
   Yadio: 'Yadio',
   BitcoinduLiban: 'BitcoinduLiban',
   Exir: 'Exir',
+  Nobitex: 'Nobitex',
   wazirx: 'wazirx',
 } as const;
 
@@ -73,6 +74,22 @@ const RateExtractors = {
     return rate;
   },
 
+  Nobitex: async (ticker: string): Promise<number> => {
+    let json;
+    try {
+      const res = await fetch('https://api.nobitex.ir/v2/orderbook/BTCIRT');
+      json = await res.json();
+    } catch (e: any) {
+      throw new Error(`Could not update rate for ${ticker}: ${e.message}`);
+    }
+    let rate = json?.lastTradePrice;
+    if (!rate) throw new Error(`Could not update rate for ${ticker}: data is wrong`);
+
+    rate = Number(rate);
+    if (!(rate >= 0)) throw new Error(`Could not update rate for ${ticker}: data is wrong`);
+    return rate;
+  },
+
   wazirx: async (ticker: string): Promise<number> => {
     let json;
     try {
@@ -95,7 +112,7 @@ type FiatUnit = {
     endPointKey: string;
     symbol: string;
     locale: string;
-    source: 'CoinDesk' | 'Yadio' | 'Exir' | 'BitcoinduLiban' | 'wazirx';
+    source: 'CoinDesk' | 'Yadio' | 'Exir' | 'Nobitex' | 'BitcoinduLiban' | 'wazirx';
   };
 };
 export const FiatUnit = untypedFiatUnit as FiatUnit;

--- a/models/fiatUnits.json
+++ b/models/fiatUnits.json
@@ -135,13 +135,13 @@
       "endPointKey": "IRT",
       "symbol": "تومان",
       "locale": "fa-IR",
-      "source": "Exir"
+      "source": "Nobitex"
     },
     "IRR": {
       "endPointKey": "IRR",
       "symbol": "﷼",
       "locale": "fa-IR",
-      "source": "Exir"
+      "source": "Nobitex"
     },
     "ISK": {
       "endPointKey": "ISK",


### PR DESCRIPTION
Please add Nobitex exchange, because many Iranians use this exchange and it is almost a price reference for digital currencies of this exchange in Iran and The volume of exchanges is more than Exir exchange.