### PR TITLE
allow tailscale to connect using "MagicDNS" over HTTP

### DIFF
--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -4,5 +4,6 @@
         <domain includeSubdomains="true">10.0.2.2</domain>
         <domain includeSubdomains="true">localhost</domain>
         <domain includeSubdomains="true">onion</domain>
+        <domain includeSubdomains="true">tailscale.net</domain>
     </domain-config>
 </network-security-config>

--- a/ios/BlueWallet/Info.plist
+++ b/ios/BlueWallet/Info.plist
@@ -154,6 +154,13 @@
 				<key>NSIncludesSubdomains</key>
 				<true/>
 			</dict>
+			<key>tailscale.net</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
 		</dict>
 	</dict>
 	<key>NSAppleMusicUsageDescription</key>


### PR DESCRIPTION
#4852 

Would allow [Tailscale](https://community.getumbrel.com/t/how-to-use-umbrel-with-tailscale/6782) users to use ["MagicDNS"](https://tailscale.com/kb/1081/magicdns/) URIs as their LNDHub connection URI.  Tailscale is just a zero-config fireguard VPN, so these connections are already encrypted and require authentication and authorization.