### PR TITLE
ADD: Fiat Unit - Uganda Shilling UGX

### DIFF
--- a/models/fiatUnits.json
+++ b/models/fiatUnits.json
@@ -293,6 +293,12 @@
       "locale": "uk-UA",
       "source": "CoinDesk"
     },
+    "UGX": {
+      "endPointKey": "UGX",
+      "symbol": "USh",
+      "locale": "en-UG",
+      "source": "CoinDesk"
+    },
     "UYU": {
       "endPointKey": "UYU",
       "symbol": "$",


### PR DESCRIPTION
Added Ugandan Shilling UGX. 