### PR TITLE
REF: switchet camera dependency (unfortunately still uses google libs)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
 
 import com.android.build.OutputFile
 
@@ -142,7 +144,6 @@ android {
         versionCode 1
         versionName "6.3.2"
         multiDexEnabled true
-        missingDimensionStrategy 'react-native-camera', 'general'
         testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         ndk {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,13 +5,14 @@ buildscript {
         minSdkVersion = 28
         supportLibVersion = "28.0.0"
         buildToolsVersion = "30.0.3"
-        compileSdkVersion = 30
+        compileSdkVersion = 31
         targetSdkVersion = 30
         googlePlayServicesVersion = "16.+"
         googlePlayServicesIidVersion = "16.0.1"
         firebaseVersion = "17.3.4"
         firebaseMessagingVersion = "20.2.1"
         ndkVersion = "23.0.7599858"
+        kotlin_version = '1.7.20'
     }
     repositories {
         google()
@@ -22,7 +23,7 @@ buildscript {
         classpath("com.bugsnag:bugsnag-android-gradle-plugin:5.+")
         classpath 'com.google.gms:google-services:4.3.14'  // Google Services plugin
 
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -73,9 +74,8 @@ subprojects {
     afterEvaluate {project ->
         if (project.hasProperty("android")) {
             android {
-                compileSdkVersion 30
                 buildToolsVersion '30.0.3'
-                compileSdkVersion 29
+                compileSdkVersion 31
                  defaultConfig {
                     minSdkVersion 28
                 }

--- a/loc/en.json
+++ b/loc/en.json
@@ -183,7 +183,6 @@
     "input_paste": "Paste",
     "input_total": "Total:",
     "permission_camera_message": "We need your permission to use your camera.",
-    "permission_camera_title": "Permission to use camera",
     "psbt_sign": "Sign a transaction",
     "open_settings": "Open Settings",
     "permission_storage_later": "Ask me later",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "react-localization": "1.0.19",
         "react-native": "0.67.4",
         "react-native-blue-crypto": "https://github.com/BlueWallet/react-native-blue-crypto#e9b60605dbdb24de720e923f740912a4930383ff",
-        "react-native-camera": "4.2.1",
+        "react-native-camera-kit": "13.0.0",
         "react-native-crypto": "2.2.0",
         "react-native-default-preference": "1.4.4",
         "react-native-device-info": "8.7.1",
@@ -21856,12 +21856,16 @@
         "react-native": "*"
       }
     },
-    "node_modules/react-native-camera": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/react-native-camera/-/react-native-camera-4.2.1.tgz",
-      "integrity": "sha512-+Vkql24PFYQfsPRznJCvPwJQfyzCnjlcww/iZ4Ej80bgivKjL9eU0IMQIXp4yi6XCrKi4voWXxIDPMupQZKeIQ==",
+    "node_modules/react-native-camera-kit": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-camera-kit/-/react-native-camera-kit-13.0.0.tgz",
+      "integrity": "sha512-fnkyivCG2xzS+14/doP8pCAYNafYaTyg5J0t+JJltJdgKSHf328OG44Rd+fnbbEOydZxgy/bcuLB24R0kCbynw==",
       "dependencies": {
-        "prop-types": "^15.6.2"
+        "lodash": "^4.14.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-codegen": {
@@ -44687,12 +44691,12 @@
       "integrity": "sha512-5f9g7ccMwasUn5n7lMpOjTEf14NbU81OsGREROXN5VV8g7KNV6pht/9lYzbICthK5q5eeClJONHcaWwuPGU0Mg==",
       "from": "react-native-blue-crypto@https://github.com/BlueWallet/react-native-blue-crypto#e9b60605dbdb24de720e923f740912a4930383ff"
     },
-    "react-native-camera": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/react-native-camera/-/react-native-camera-4.2.1.tgz",
-      "integrity": "sha512-+Vkql24PFYQfsPRznJCvPwJQfyzCnjlcww/iZ4Ej80bgivKjL9eU0IMQIXp4yi6XCrKi4voWXxIDPMupQZKeIQ==",
+    "react-native-camera-kit": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-camera-kit/-/react-native-camera-kit-13.0.0.tgz",
+      "integrity": "sha512-fnkyivCG2xzS+14/doP8pCAYNafYaTyg5J0t+JJltJdgKSHf328OG44Rd+fnbbEOydZxgy/bcuLB24R0kCbynw==",
       "requires": {
-        "prop-types": "^15.6.2"
+        "lodash": "^4.14.2"
       }
     },
     "react-native-codegen": {

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "react-localization": "1.0.19",
     "react-native": "0.67.4",
     "react-native-blue-crypto": "https://github.com/BlueWallet/react-native-blue-crypto#e9b60605dbdb24de720e923f740912a4930383ff",
-    "react-native-camera": "4.2.1",
+    "react-native-camera-kit": "13.0.0",
     "react-native-crypto": "2.2.0",
     "react-native-default-preference": "1.4.4",
     "react-native-device-info": "8.7.1",

--- a/screen/send/ScanQRCode.js
+++ b/screen/send/ScanQRCode.js
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Image, View, TouchableOpacity, StatusBar, Platform, StyleSheet, TextInput, Alert } from 'react-native';
-import { RNCamera } from 'react-native-camera';
+import { CameraScreen, Camera } from 'react-native-camera-kit';
 import { Icon } from 'react-native-elements';
 import { launchImageLibrary } from 'react-native-image-picker';
 import { decodeUR, extractSingleWorkload, BlueURDecoder } from '../../blue_modules/ur';
@@ -21,9 +21,6 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     backgroundColor: '#000000',
-  },
-  rnCamera: {
-    flex: 1,
   },
   closeTouch: {
     width: 40,
@@ -82,6 +79,12 @@ const styles = StyleSheet.create({
   },
 });
 
+const CameraAuthStatus = Object.freeze({
+  AUTHORIZED: 'AUTHORIZED',
+  NOT_AUTHORIZED: 'NOT_AUTHORIZED',
+  UNKNOWN: 'UNKNOWN',
+});
+
 const ScanQRCode = () => {
   const [isLoading, setIsLoading] = useState(false);
   const navigation = useNavigation();
@@ -91,7 +94,7 @@ const ScanQRCode = () => {
   const scannedCache = {};
   const { colors } = useTheme();
   const isFocused = useIsFocused();
-  const [cameraStatus, setCameraStatus] = useState(RNCamera.Constants.CameraStatus.PENDING_AUTHORIZATION);
+  const [cameraStatus, setCameraStatus] = useState(CameraAuthStatus.UNKNOWN);
   const [backdoorPressed, setBackdoorPressed] = useState(0);
   const [urTotal, setUrTotal] = useState(0);
   const [urHave, setUrHave] = useState(0);
@@ -113,6 +116,35 @@ const ScanQRCode = () => {
   const HashIt = function (s) {
     return createHash('sha256').update(s).digest().toString('hex');
   };
+
+  useEffect(() => {
+    (async () => {
+      if (Platform.OS !== 'ios' && Platform.OS !== 'macos') {
+        return;
+      }
+      let isUserAuthorizedCamera;
+      const isCameraAuthorized = await Camera.checkDeviceCameraAuthorizationStatus();
+      switch (isCameraAuthorized) {
+        case true:
+          setCameraStatus(CameraAuthStatus.AUTHORIZED);
+          break;
+        case false:
+          setCameraStatus(CameraAuthStatus.NOT_AUTHORIZED);
+          isUserAuthorizedCamera = await Camera.requestDeviceCameraAuthorization();
+          if (isUserAuthorizedCamera) {
+            setCameraStatus(CameraAuthStatus.AUTHORIZED);
+          }
+          break;
+        case -1:
+          setCameraStatus(CameraAuthStatus.UNKNOWN);
+          isUserAuthorizedCamera = await Camera.requestDeviceCameraAuthorization();
+          if (isUserAuthorizedCamera) {
+            setCameraStatus(CameraAuthStatus.AUTHORIZED);
+          }
+          break;
+      }
+    })();
+  }, []);
 
   const _onReadUniformResourceV2 = part => {
     if (!decoder) decoder = new BlueURDecoder();
@@ -295,10 +327,6 @@ const ScanQRCode = () => {
     if (onDismiss) onDismiss();
   };
 
-  const handleCameraStatusChange = event => {
-    setCameraStatus(event.cameraStatus);
-  };
-
   return isLoading ? (
     <View style={styles.root}>
       <BlueLoading />
@@ -306,23 +334,16 @@ const ScanQRCode = () => {
   ) : (
     <View style={styles.root}>
       <StatusBar hidden />
-      {isFocused && cameraStatus !== RNCamera.Constants.CameraStatus.NOT_AUTHORIZED && (
-        <RNCamera
-          autoFocus
-          captureAudio={false}
-          androidCameraPermissionOptions={{
-            title: loc.send.permission_camera_title,
-            message: loc.send.permission_camera_message,
-            buttonPositive: loc._.ok,
-            buttonNegative: loc._.cancel,
-          }}
-          style={styles.rnCamera}
-          onBarCodeRead={onBarCodeRead}
-          barCodeTypes={[RNCamera.Constants.BarCodeType.qr]}
-          onStatusChange={handleCameraStatusChange}
+      {isFocused && cameraStatus !== CameraAuthStatus.NOT_AUTHORIZED && (
+        <CameraScreen
+          scanBarcode
+          onReadCode={event => onBarCodeRead({ data: event?.nativeEvent?.codeStringValue })}
+          showFrame
+          laserColor="#6CD9FC" // (default red) optional, color of laser in scanner frame
+          frameColor="white" // (default white) optional, color of border of scanner frame
         />
       )}
-      {cameraStatus === RNCamera.Constants.CameraStatus.NOT_AUTHORIZED && (
+      {cameraStatus === CameraAuthStatus.NOT_AUTHORIZED && (
         <View style={[styles.openSettingsContainer, stylesHook.openSettingsContainer]}>
           <BlueText>{loc.send.permission_camera_message}</BlueText>
           <BlueSpacing40 />

--- a/screen/send/ScanQRCode.js
+++ b/screen/send/ScanQRCode.js
@@ -338,9 +338,7 @@ const ScanQRCode = () => {
         <CameraScreen
           scanBarcode
           onReadCode={event => onBarCodeRead({ data: event?.nativeEvent?.codeStringValue })}
-          showFrame
-          laserColor="#6CD9FC" // (default red) optional, color of laser in scanner frame
-          frameColor="white" // (default white) optional, color of border of scanner frame
+          showFrame={false}
         />
       )}
       {cameraStatus === CameraAuthStatus.NOT_AUTHORIZED && (


### PR DESCRIPTION
switched to new camera dep: https://github.com/teslamotors/react-native-camera-kit

unfortunately still uses google deps, but at least its maintained, so should not block upgrade to RN70.
also, code is pretty clear so I might be able to fork it and reimplement actual QR detection on the image.

also i like it way more than vision-camera which feels overengineered