### PR TITLE
ADD: Tailscale's new Tailnet naming scheme to list of exceptions

### DIFF
--- a/ios/BlueWallet/Info.plist
+++ b/ios/BlueWallet/Info.plist
@@ -133,6 +133,13 @@
 				<key>NSIncludesSubdomains</key>
 				<true/>
 			</dict>
+			<key>ts.net</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
 		</dict>
 	</dict>
 	<key>NSAppleMusicUsageDescription</key>


### PR DESCRIPTION
Howdy!

Tailscale's [MagicDNS](https://tailscale.com/kb/1081/magicdns/) service now utilises a new [Tailnet](https://tailscale.com/kb/1217/tailnet-name/) naming scheme which ends in `ts.net`

Tailscale's MagicDNS was whitelisted previously in #4854 - `beta.tailscale.net` remains supported until Nov 1, 2023 after which all users will need to migrate to the new Tailnet naming scheme.
