### PR TITLE
fix(styles): adjust spaces on the success view

### DIFF
--- a/screen/lnd/lnurlPaySuccess.js
+++ b/screen/lnd/lnurlPaySuccess.js
@@ -82,14 +82,12 @@ export default class LnurlPaySuccess extends Component {
 
     return (
       <SafeBlueArea style={styles.root}>
-        <ScrollView>
+        <ScrollView style={styles.container}>
           {justPaid && <SuccessView />}
 
           <BlueSpacing40 />
-
-          <BlueSpacing40 />
           <BlueText style={styles.alignSelfCenter}>{domain}</BlueText>
-          <BlueText style={styles.alignSelfCenter}>{description}</BlueText>
+          <BlueText style={[styles.alignSelfCenter, styles.description]}>{description}</BlueText>
           {image && <Image style={styles.img} source={{ uri: image }} />}
           <BlueSpacing20 />
 
@@ -125,7 +123,7 @@ export default class LnurlPaySuccess extends Component {
                     },
                   });
                 }}
-                title="repeat"
+                title="repeat" // TODO: translate this
                 icon={{ name: 'refresh', type: 'font-awesome', color: '#9aa0aa' }}
               />
             ) : (
@@ -167,6 +165,9 @@ const styles = StyleSheet.create({
   root: {
     padding: 0,
   },
+  container: {
+    paddingHorizontal: 16,
+  },
   successContainer: {
     marginTop: 10,
   },
@@ -176,6 +177,9 @@ const styles = StyleSheet.create({
   },
   successValue: {
     fontWeight: 'bold',
+  },
+  description: {
+    marginTop: 20,
   },
 });
 

--- a/screen/send/success.js
+++ b/screen/send/success.js
@@ -79,24 +79,27 @@ export const SuccessView = ({ amount, amountUnit, fee, invoiceDescription, shoul
 
   return (
     <View style={styles.root}>
-      <BlueCard style={styles.amount}>
-        <View style={styles.view}>
-          {amount ? (
-            <>
-              <Text style={[styles.amountValue, stylesHook.amountValue]}>{amount}</Text>
-              <Text style={[styles.amountUnit, stylesHook.amountUnit]}>{' ' + loc.units[amountUnit]}</Text>
-            </>
-          ) : null}
-        </View>
-        {fee > 0 && (
-          <Text style={styles.feeText}>
-            {loc.send.create_fee}: {new BigNumber(fee).toFixed()} {loc.units[BitcoinUnit.BTC]}
+      {amount || fee > 0 ? (
+        <BlueCard style={styles.amount}>
+          <View style={styles.view}>
+            {amount ? (
+              <>
+                <Text style={[styles.amountValue, stylesHook.amountValue]}>{amount}</Text>
+                <Text style={[styles.amountUnit, stylesHook.amountUnit]}>{' ' + loc.units[amountUnit]}</Text>
+              </>
+            ) : null}
+          </View>
+          {fee > 0 && (
+            <Text style={styles.feeText}>
+              {loc.send.create_fee}: {new BigNumber(fee).toFixed()} {loc.units[BitcoinUnit.BTC]}
+            </Text>
+          )}
+          <Text numberOfLines={0} style={styles.feeText}>
+            {invoiceDescription}
           </Text>
-        )}
-        <Text numberOfLines={0} style={styles.feeText}>
-          {invoiceDescription}
-        </Text>
-      </BlueCard>
+        </BlueCard>
+      ) : null}
+
       <View style={styles.ready}>
         <LottieView
           style={styles.lottie}
@@ -119,6 +122,7 @@ export const SuccessView = ({ amount, amountUnit, fee, invoiceDescription, shoul
               color: colors.successCheck,
             },
           ]}
+          resizeMode="center"
         />
       </View>
     </View>
@@ -177,7 +181,7 @@ const styles = StyleSheet.create({
     marginBottom: 53,
   },
   lottie: {
-    width: 400,
-    height: 400,
+    width: 200,
+    height: 200,
   },
 });


### PR DESCRIPTION
Resolves #2893

## Problem
The text after making a payment extends across the screen.

## Solution
Add a new style to the container and set horizontal padding.

I also checked that the `SuccessView` was introducing some unwanted spaces, I have refactored it so that it only takes up the necessary space.

### Screenshots
### Before/After with a short message
<div>
<img width=300 src=https://user-images.githubusercontent.com/28598593/221180200-dc6de2db-1f48-4b1b-a785-e4771057c3e5.png />
<img width=300 src=https://user-images.githubusercontent.com/28598593/221180496-e80f441b-bde1-4534-ae64-ab17a428faab.png />
</div>

### Before/After with a long message
<div>
<img width=300 src=https://user-images.githubusercontent.com/28598593/221180604-d594a646-790c-4e03-8146-23039f2c4729.png />
<img width=300 src=https://user-images.githubusercontent.com/28598593/221180597-a5706534-48c9-4ba2-a073-c8b54f0822a6.png />
</div>

### Before/After of a different screen which also uses the `SuccessView` component
I have checked that the other screens which use the `SuccessView` component are not broken after the change.
<div>
<img width=300 src=https://user-images.githubusercontent.com/28598593/221181411-83823440-8705-45bd-b493-58f9e476c429.png />
<img width=300 src=https://user-images.githubusercontent.com/28598593/221181414-b1f78718-108c-492a-84e7-7870399da987.png />
</div>
