### PR TITLE
Bip47 improvements

### DIFF
--- a/class/wallets/hd-legacy-electrum-seed-p2pkh-wallet.js
+++ b/class/wallets/hd-legacy-electrum-seed-p2pkh-wallet.js
@@ -23,6 +23,10 @@ export class HDLegacyElectrumSeedP2PKHWallet extends HDLegacyP2PKHWallet {
     return mn.validateMnemonic(this.secret, PREFIX);
   }
 
+  allowBIP47() {
+    return false;
+  }
+
   async generate() {
     throw new Error('Not implemented');
   }

--- a/class/wallets/hd-segwit-electrum-seed-p2wpkh-wallet.js
+++ b/class/wallets/hd-segwit-electrum-seed-p2wpkh-wallet.js
@@ -24,6 +24,10 @@ export class HDSegwitElectrumSeedP2WPKHWallet extends HDSegwitBech32Wallet {
     return mn.validateMnemonic(this.secret, PREFIX);
   }
 
+  allowBIP47() {
+    return false;
+  }
+
   async generate() {
     throw new Error('Not implemented');
   }

--- a/class/wallets/slip39-wallets.js
+++ b/class/wallets/slip39-wallets.js
@@ -67,6 +67,10 @@ export class SLIP39LegacyP2PKHWallet extends HDLegacyP2PKHWallet {
   static type = 'SLIP39legacyP2PKH';
   static typeReadable = 'SLIP39 Legacy (P2PKH)';
 
+  allowBIP47() {
+    return false;
+  }
+
   _getSeed = SLIP39Mixin._getSeed;
   validateMnemonic = SLIP39Mixin.validateMnemonic;
   setSecret = SLIP39Mixin.setSecret;
@@ -86,6 +90,10 @@ export class SLIP39SegwitP2SHWallet extends HDSegwitP2SHWallet {
 export class SLIP39SegwitBech32Wallet extends HDSegwitBech32Wallet {
   static type = 'SLIP39segwitBech32';
   static typeReadable = 'SLIP39 SegWit (Bech32)';
+
+  allowBIP47() {
+    return false;
+  }
 
   _getSeed = SLIP39Mixin._getSeed;
   validateMnemonic = SLIP39Mixin.validateMnemonic;

--- a/loc/en.json
+++ b/loc/en.json
@@ -595,6 +595,7 @@
     "payment_code": "Payment Code",
     "payment_codes_list": "Payment Codes List",
     "who_can_pay_me": "Who can pay me:",
-    "purpose": "Reusable and shareable code (BIP47)"
+    "purpose": "Reusable and shareable code (BIP47)",
+    "not_found": "Payment code not found"
   }
 }

--- a/screen/wallets/paymentCode.tsx
+++ b/screen/wallets/paymentCode.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet } from 'react-native';
 import { NativeStackScreenProps } from 'react-native-screens/lib/typescript/native-stack';
 import { BlueCopyTextToClipboard } from '../../BlueComponents';
 import QRCodeComponent from '../../components/QRCodeComponent';
+import loc from '../../loc';
 
 type PaymentCodeStackParamList = {
   PaymentCode: { paymentCode: string };
@@ -13,7 +14,7 @@ export default function PaymentCode({ route }: NativeStackScreenProps<PaymentCod
 
   return (
     <View style={styles.container}>
-      {!paymentCode && <Text>Payment code not found</Text>}
+      {!paymentCode && <Text>{loc.bip47.not_found}</Text>}
       {paymentCode && (
         <>
           <QRCodeComponent value={paymentCode} />

--- a/tests/integration/import.test.js
+++ b/tests/integration/import.test.js
@@ -455,4 +455,18 @@ describe('import procedure', () => {
       'receive own flight sentence tide hood silent bunker derive manage wink belt loud apology monster pill raw gate hurdle match night wish toddler achieve',
     );
   });
+
+  it('can import BIP47 wallet that only has notification transaction', async () => {
+    if (!process.env.BIP47_HD_MNEMONIC) {
+      console.error('process.env.BIP47_HD_MNEMONIC not set, skipped');
+      return;
+    }
+
+    const store = createStore('1');
+    const { promise } = startImport(process.env.BIP47_HD_MNEMONIC.split(':')[0], true, false, ...store.callbacks);
+    await promise;
+    assert.strictEqual(store.state.wallets[0].type, HDLegacyP2PKHWallet.type);
+    assert.strictEqual(store.state.wallets[1].type, HDSegwitBech32Wallet.type);
+    assert.strictEqual(store.state.wallets.length, 2);
+  });
 });


### PR DESCRIPTION
- add missing localization
- disable bip47 for SLIP39 and Electrum Seed wallets, until proper tested
- when importing seed from the BIP47 wallet 
- both BIP84 and BIP44 wallets will be offered for import, if transactions for notification address is discovered