### PR TITLE
FIX: Cleanup the menu when the view is navigating away

### DIFF
--- a/components/TooltipMenu.ios.js
+++ b/components/TooltipMenu.ios.js
@@ -64,6 +64,7 @@ const ToolTipMenu = (props, ref) => {
   ) : (
     <ContextMenuView
       ref={ref}
+      internalCleanupMode="viewController"
       onPressMenuItem={({ nativeEvent }) => {
         props.onPressMenuItem(nativeEvent.actionKey);
       }}

--- a/components/TooltipMenu.ios.js
+++ b/components/TooltipMenu.ios.js
@@ -59,7 +59,7 @@ const ToolTipMenu = (props, ref) => {
       }}
       style={buttonStyle}
     >
-      {props.onPress ? <TouchableOpacity onPress={props.onPress}>{props.children}</TouchableOpacity> : props.children}
+      {props.onPress ? <TouchableOpacity onPressOut={props.onPress}>{props.children}</TouchableOpacity> : props.children}
     </ContextMenuButton>
   ) : (
     <ContextMenuView
@@ -82,7 +82,7 @@ const ToolTipMenu = (props, ref) => {
           }
         : {})}
     >
-      {props.onPress ? <TouchableOpacity onPress={props.onPress}>{props.children}</TouchableOpacity> : props.children}
+      {props.onPress ? <TouchableOpacity onPressOut={props.onPress}>{props.children}</TouchableOpacity> : props.children}
     </ContextMenuView>
   );
 };

--- a/components/TooltipMenu.ios.js
+++ b/components/TooltipMenu.ios.js
@@ -59,7 +59,7 @@ const ToolTipMenu = (props, ref) => {
       }}
       style={buttonStyle}
     >
-      {props.onPress ? <TouchableOpacity onPressOut={props.onPress}>{props.children}</TouchableOpacity> : props.children}
+      {props.onPress ? <TouchableOpacity onPress={props.onPress}>{props.children}</TouchableOpacity> : props.children}
     </ContextMenuButton>
   ) : (
     <ContextMenuView
@@ -82,7 +82,7 @@ const ToolTipMenu = (props, ref) => {
           }
         : {})}
     >
-      {props.onPress ? <TouchableOpacity onPressOut={props.onPress}>{props.children}</TouchableOpacity> : props.children}
+      {props.onPress ? <TouchableOpacity onPress={props.onPress}>{props.children}</TouchableOpacity> : props.children}
     </ContextMenuView>
   );
 };


### PR DESCRIPTION
If u pressed a tx list item really quickly after long press the onPress would trigger both the navigation and menu show which would lead to a crash