### PR TITLE
REF: hide bip47 behind backdoor; refactor

### DIFF
--- a/class/app-storage.js
+++ b/class/app-storage.js
@@ -602,6 +602,11 @@ export class AppStorage {
           keyCloned._hdWalletInstance._txs_by_external_index = {};
           keyCloned._hdWalletInstance._txs_by_internal_index = {};
         }
+
+        if (keyCloned._bip47_instance) {
+          delete keyCloned._bip47_instance; // since it wont be restored into a proper class instance
+        }
+
         walletsToSave.push(JSON.stringify({ ...keyCloned, type: keyCloned.type }));
       }
       if (realm) realm.close();
@@ -730,7 +735,7 @@ export class AppStorage {
     console.log('fetchSenderPaymentCodes for wallet#', typeof index === 'undefined' ? '(all)' : index);
     if (index || index === 0) {
       try {
-        if (!this.wallets[index].allowBIP47()) return;
+        if (!(this.wallets[index].allowBIP47() && this.wallets[index].isBIP47Enabled())) return;
         await this.wallets[index].fetchBIP47SenderPaymentCodes();
       } catch (error) {
         console.error('Failed to fetch sender payment codes for wallet', index, error);
@@ -738,7 +743,7 @@ export class AppStorage {
     } else {
       for (const wallet of this.wallets) {
         try {
-          if (!wallet.allowBIP47()) continue;
+          if (!(wallet.allowBIP47() && wallet.isBIP47Enabled())) continue;
           await wallet.fetchBIP47SenderPaymentCodes();
         } catch (error) {
           console.error('Failed to fetch sender payment codes for wallet', wallet.label, error);

--- a/class/wallets/abstract-hd-electrum-wallet.ts
+++ b/class/wallets/abstract-hd-electrum-wallet.ts
@@ -1447,11 +1447,6 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     return AbstractHDElectrumWallet.seedToFingerprint(seed);
   }
 
-  prepareForSerialization() {
-    super.prepareForSerialization();
-    delete this._bip47_instance;
-  }
-
   /**
    * Whether BIP47 is enabled. This is per-wallet setting that can be changed, NOT a feature-flag
    * @returns boolean
@@ -1465,7 +1460,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
   }
 
   getBIP47FromSeed(): BIP47Interface {
-    if (!this._bip47_instance) {
+    if (!this._bip47_instance || !this._bip47_instance.getNotificationAddress) {
       this._bip47_instance = bip47.fromBip39Seed(this.secret, undefined, this.passphrase);
     }
 
@@ -1481,7 +1476,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
   }
 
   async fetchBIP47SenderPaymentCodes(): Promise<void> {
-    const bip47_instance = BIP47Factory(ecc).fromBip39Seed(this.secret, undefined, this.passphrase);
+    const bip47_instance = this.getBIP47FromSeed();
 
     const address = bip47_instance.getNotificationAddress();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@react-navigation/drawer": "5.12.9",
         "@react-navigation/native": "5.9.8",
         "@remobile/react-native-qrcode-local-image": "https://github.com/BlueWallet/react-native-qrcode-local-image",
-        "@spsina/bip47": "1.0.1",
+        "@spsina/bip47": "github:BlueWallet/bip47#0a2f02c90350802f2ec93afa4e6c8843be2d687c",
         "aez": "1.0.1",
         "assert": "2.0.0",
         "base-x": "3.0.9",
@@ -5904,7 +5904,7 @@
     },
     "node_modules/@spsina/bip47": {
       "version": "1.0.1",
-      "resolved": "git+ssh://git@github.com/abhishandy/bip47.git#1abcd4c20a387e43ed55bacc52726690bf417559",
+      "resolved": "git+ssh://git@github.com/BlueWallet/bip47.git#0a2f02c90350802f2ec93afa4e6c8843be2d687c",
       "integrity": "sha512-lsgEpiEMDgpiYOA2kizOwiSS3vjTeLe2VnkOTIGnJ7Eu7Mkgl9dLES7oSLAjY64aQXr0VolqCRciRDc2nAC++w==",
       "license": "MIT",
       "dependencies": {
@@ -28559,9 +28559,9 @@
       }
     },
     "@spsina/bip47": {
-      "version": "git+ssh://git@github.com/abhishandy/bip47.git#1abcd4c20a387e43ed55bacc52726690bf417559",
+      "version": "git+ssh://git@github.com/BlueWallet/bip47.git#0a2f02c90350802f2ec93afa4e6c8843be2d687c",
       "integrity": "sha512-lsgEpiEMDgpiYOA2kizOwiSS3vjTeLe2VnkOTIGnJ7Eu7Mkgl9dLES7oSLAjY64aQXr0VolqCRciRDc2nAC++w==",
-      "from": "@spsina/bip47@1.0.1",
+      "from": "@spsina/bip47@https://github.com/BlueWallet/bip47#0a2f02c90350802f2ec93afa4e6c8843be2d687c",
       "requires": {
         "bip32": "^3.0.1",
         "bip39": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@react-navigation/drawer": "5.12.9",
     "@react-navigation/native": "5.9.8",
     "@remobile/react-native-qrcode-local-image": "https://github.com/BlueWallet/react-native-qrcode-local-image",
-    "@spsina/bip47": "1.0.1",
+    "@spsina/bip47": "github:BlueWallet/bip47#0a2f02c90350802f2ec93afa4e6c8843be2d687c",
     "aez": "1.0.1",
     "assert": "2.0.0",
     "base-x": "3.0.9",

--- a/screen/wallets/details.js
+++ b/screen/wallets/details.js
@@ -123,6 +123,7 @@ const WalletDetails = () => {
   const { walletID } = useRoute().params;
   const [isLoading, setIsLoading] = useState(false);
   const [backdoorPressed, setBackdoorPressed] = useState(0);
+  const [backdoorBip47Pressed, setBackdoorBip47Pressed] = useState(0);
   const wallet = useRef(wallets.find(w => w.getID() === walletID)).current;
   const [walletName, setWalletName] = useState(wallet.getLabel());
   const [useWithHardwareWallet, setUseWithHardwareWallet] = useState(wallet.useWithHardwareWalletEnabled());
@@ -565,7 +566,7 @@ const WalletDetails = () => {
                   {loc.transactions.list_title.toLowerCase()}
                 </Text>
                 <View style={styles.hardware}>
-                  <BlueText>{loc.wallets.details_display}</BlueText>
+                  <BlueText onPress={() => setBackdoorBip47Pressed(prevState => prevState + 1)}>{loc.wallets.details_display}</BlueText>
                   <Switch value={hideTransactionsInWalletsList} onValueChange={setHideTransactionsInWalletsList} />
                 </View>
               </>
@@ -576,7 +577,7 @@ const WalletDetails = () => {
                 <BlueText>{wallet.getTransactions().length}</BlueText>
               </>
 
-              {wallet.allowBIP47() ? (
+              {backdoorBip47Pressed >= 10 && wallet.allowBIP47() ? (
                 <>
                   <Text style={[styles.textLabel2, stylesHook.textLabel2]}>{loc.bip47.payment_code}</Text>
                   <View style={styles.hardware}>

--- a/screen/wallets/transactions.js
+++ b/screen/wallets/transactions.js
@@ -178,7 +178,7 @@ const WalletTransactions = ({ navigation }) => {
       refreshLnNodeInfo();
       // await BlueElectrum.ping();
       await BlueElectrum.waitTillConnected();
-      if (wallet.allowBIP47()) {
+      if (wallet.allowBIP47() && wallet.isBIP47Enabled()) {
         const pcStart = +new Date();
         await wallet.fetchBIP47SenderPaymentCodes();
         const pcEnd = +new Date();


### PR DESCRIPTION
* forked bip47 dep under our org
* refactored a bit to speed it up
* if payment codes are disabled, wallets wont even try to fetch their balance from network