### PR TITLE
Satisfy PayjoinClient wallet param

### DIFF
--- a/screen/send/confirm.js
+++ b/screen/send/confirm.js
@@ -140,13 +140,13 @@ const Confirm = () => {
           };
           payjoinClient = new PayjoinClient({
             paymentScript,
-            payJoinWallet,
+            wallet: payJoinWallet,
             payjoinRequester: customPayjoinRequester,
           });
         } else {
           payjoinClient = new PayjoinClient({
             paymentScript,
-            payJoinWallet,
+            wallet: payJoinWallet,
             payjoinUrl,
           });
         }


### PR DESCRIPTION
fix #5313 

PayjoinClient requires named `opts.wallet`, we passed `opts.payJoinWallet` before
