### PR TITLE
REF: Pass item rather than index

### DIFF
--- a/components/WalletsCarousel.js
+++ b/components/WalletsCarousel.js
@@ -329,7 +329,7 @@ const WalletsCarousel = forwardRef((props, ref) => {
     <View style={cStyles.contentLargeScreen}>
       {props.data.map((item, index) => (
         <WalletCarouselItem
-          isSelectedWallet={!props.horizontal && props.selectedWallet && item ? props.selectedWallet === item.getID() : undefined}
+          isSelectedWallet={!props.horizontal && props.selectedWallet ? props.selectedWallet === item.getID() : undefined}
           item={item}
           index={index}
           handleLongPress={props.handleLongPress}

--- a/components/WalletsCarousel.js
+++ b/components/WalletsCarousel.js
@@ -8,11 +8,11 @@ import {
   StyleSheet,
   Text,
   TouchableOpacity,
-  TouchableWithoutFeedback,
   useWindowDimensions,
   View,
   Dimensions,
   FlatList,
+  Pressable,
 } from 'react-native';
 import { useTheme } from '@react-navigation/native';
 import LinearGradient from 'react-native-linear-gradient';
@@ -157,16 +157,6 @@ const WalletCarouselItem = ({ item, index, onPress, handleLongPress, isSelectedW
     Animated.spring(scaleValue, props).start();
   };
 
-  if (!item)
-    return (
-      <NewWalletPanel
-        onPress={() => {
-          onPressedOut();
-          onPress(index);
-        }}
-      />
-    );
-
   const opacity = isSelectedWallet === false ? 0.5 : 1.0;
   let image;
   switch (item.type) {
@@ -202,7 +192,7 @@ const WalletCarouselItem = ({ item, index, onPress, handleLongPress, isSelectedW
       shadowOffset={{ width: 0, height: 3 }}
       shadowRadius={8}
     >
-      <TouchableWithoutFeedback
+      <Pressable
         accessibilityRole="button"
         testID={item.getLabel()}
         onPressIn={onPressedIn}
@@ -210,7 +200,7 @@ const WalletCarouselItem = ({ item, index, onPress, handleLongPress, isSelectedW
         onLongPress={handleLongPress}
         onPress={() => {
           onPressedOut();
-          onPress(index);
+          onPress(item);
           onPressedOut();
         }}
       >
@@ -241,7 +231,7 @@ const WalletCarouselItem = ({ item, index, onPress, handleLongPress, isSelectedW
             {latestTransactionText}
           </Text>
         </LinearGradient>
-      </TouchableWithoutFeedback>
+      </Pressable>
     </Animated.View>
   );
 };
@@ -270,15 +260,18 @@ const cStyles = StyleSheet.create({
 const WalletsCarousel = forwardRef((props, ref) => {
   const { preferredFiatCurrency, language } = useContext(BlueStorageContext);
   const renderItem = useCallback(
-    ({ item, index }) => (
-      <WalletCarouselItem
-        isSelectedWallet={!props.horizontal && props.selectedWallet && item ? props.selectedWallet === item.getID() : undefined}
-        item={item}
-        index={index}
-        handleLongPress={props.handleLongPress}
-        onPress={props.onPress}
-      />
-    ),
+    ({ item, index }) =>
+      item ? (
+        <WalletCarouselItem
+          isSelectedWallet={!props.horizontal && props.selectedWallet && item ? props.selectedWallet === item.getID() : undefined}
+          item={item}
+          index={index}
+          handleLongPress={props.handleLongPress}
+          onPress={props.onPress}
+        />
+      ) : (
+        <NewWalletPanel onPress={props.onPress} />
+      ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [props.horizontal, props.selectedWallet, props.handleLongPress, props.onPress, preferredFiatCurrency, language],
   );

--- a/components/WalletsCarousel.js
+++ b/components/WalletsCarousel.js
@@ -263,7 +263,7 @@ const WalletsCarousel = forwardRef((props, ref) => {
     ({ item, index }) =>
       item ? (
         <WalletCarouselItem
-          isSelectedWallet={!props.horizontal && props.selectedWallet && item ? props.selectedWallet === item.getID() : undefined}
+          isSelectedWallet={!props.horizontal && props.selectedWallet ? props.selectedWallet === item.getID() : undefined}
           item={item}
           index={index}
           handleLongPress={props.handleLongPress}

--- a/screen/wallets/drawerList.js
+++ b/screen/wallets/drawerList.js
@@ -29,14 +29,13 @@ const DrawerList = props => {
     walletsCount.current = wallets.length;
   }, [wallets]);
 
-  const handleClick = index => {
-    console.log('click', index);
-    if (index <= wallets.length - 1) {
-      const wallet = wallets[index];
-      const walletID = wallet.getID();
+  const handleClick = item => {
+    console.log('handleClick', item);
+    if (item?.getID) {
+      const walletID = item.getID();
       props.navigation.navigate('WalletTransactions', {
-        walletID: wallet.getID(),
-        walletType: wallet.type,
+        walletID: item.getID(),
+        walletType: item.type,
         key: `WalletTransactions-${walletID}`,
       });
     } else {

--- a/screen/wallets/drawerList.js
+++ b/screen/wallets/drawerList.js
@@ -30,7 +30,6 @@ const DrawerList = props => {
   }, [wallets]);
 
   const handleClick = item => {
-    console.log('handleClick', item);
     if (item?.getID) {
       const walletID = item.getID();
       props.navigation.navigate('WalletTransactions', {

--- a/screen/wallets/list.js
+++ b/screen/wallets/list.js
@@ -148,17 +148,16 @@ const WalletsList = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // call refreshTransactions() only once, when screen mounts
 
-  const handleClick = index => {
-    console.log('click', index);
-    if (index <= wallets.length - 1) {
-      const wallet = wallets[index];
-      const walletID = wallet.getID();
+  const handleClick = item => {
+    console.log('handleClick', item);
+    if (item?.getID) {
+      const walletID = item.getID();
       navigate('WalletTransactions', {
         walletID,
-        walletType: wallet.type,
+        walletType: item.type,
         key: `WalletTransactions-${walletID}`,
       });
-    } else if (index >= wallets.length) {
+    } else {
       navigate('AddWalletRoot');
     }
   };

--- a/screen/wallets/list.js
+++ b/screen/wallets/list.js
@@ -149,7 +149,6 @@ const WalletsList = () => {
   }, []); // call refreshTransactions() only once, when screen mounts
 
   const handleClick = item => {
-    console.log('handleClick', item);
     if (item?.getID) {
       const walletID = item.getID();
       navigate('WalletTransactions', {


### PR DESCRIPTION
This will open the door to future features that will prefer the item instead of index. Such as search.

Don't decide when to render NewWallet or CarouseItem before return.