### PR TITLE
FIX: ecctests failing wallet creation

### DIFF
--- a/blue_modules/noble_ecc.ts
+++ b/blue_modules/noble_ecc.ts
@@ -20,6 +20,8 @@ export interface TinySecp256k1InterfaceExtended {
   isXOnlyPoint(p: Uint8Array): boolean;
 
   xOnlyPointAddTweak(p: Uint8Array, tweak: Uint8Array): XOnlyPointAddTweakResult | null;
+
+  privateNegate(d: Uint8Array): Uint8Array;
 }
 
 necc.utils.sha256Sync = (...messages: Uint8Array[]): Uint8Array => {
@@ -119,7 +121,7 @@ const ecc: TinySecp256k1InterfaceExtended & TinySecp256k1Interface & TinySecp256
       return ret;
     }),
 
-  // privateNegate: (d: Uint8Array): Uint8Array => necc.utils.privateNegate(d),
+  privateNegate: (d: Uint8Array): Uint8Array => necc.utils.privateNegate(d),
 
   sign: (h: Uint8Array, d: Uint8Array, e?: Uint8Array): Uint8Array => {
     return necc.signSync(h, d, { der: false, extraEntropy: e });


### PR DESCRIPTION
Trying to import a wallet via seed phrase (and potentially other methods, I only tried with a phrase) fails due to an exception around `privateNegate` being undefined.

Adding the function back fixes this - let me know though if there's a better interface to throw this into than `TinySecp256k1InterfaceExtended`. I added it to this one because the other relevant types are imported from external libraries.