### PR TITLE
fix: use SafeAreaView from react-native-safe-area-context

### DIFF
--- a/BlueComponents.js
+++ b/BlueComponents.js
@@ -327,13 +327,6 @@ const styleCopyTextToClipboard = StyleSheet.create({
   },
 });
 
-export const SafeBlueArea = props => {
-  const { style, ...nonStyleProps } = props;
-  const { colors } = useTheme();
-  const baseStyle = { flex: 1, backgroundColor: colors.background };
-  return <SafeAreaView forceInset={{ horizontal: 'always' }} style={[baseStyle, style]} {...nonStyleProps} />;
-};
-
 export const BlueCard = props => {
   return <View {...props} style={{ padding: 20 }} />;
 };

--- a/components/SafeArea.tsx
+++ b/components/SafeArea.tsx
@@ -1,0 +1,18 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, ViewProps } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { useTheme } from './themes';
+
+const SafeArea = (props: ViewProps) => {
+  const { style, ...otherProps } = props;
+  const { colors } = useTheme();
+
+  const componentStyle = useMemo(() => {
+    return StyleSheet.compose({ flex: 1, backgroundColor: colors.background }, style);
+  }, [colors.background, style]);
+
+  return <SafeAreaView style={componentStyle} {...otherProps} />;
+};
+
+export default SafeArea;

--- a/screen/lnd/browser.js
+++ b/screen/lnd/browser.js
@@ -4,12 +4,12 @@ import Ionicons from 'react-native-vector-icons/Ionicons';
 import { ActivityIndicator, Alert, BackHandler, Keyboard, Platform, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 
-import { SafeBlueArea } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import Notifications from '../../blue_modules/notifications';
 import loc from '../../loc';
 import { Button } from 'react-native-elements';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
+import SafeArea from '../../components/SafeArea';
 
 let processedInvoices = {};
 let lastTimeTriedToPay = 0;
@@ -427,7 +427,7 @@ export default class Browser extends Component {
 
   render() {
     return (
-      <SafeBlueArea>
+      <SafeArea>
         <View style={styles.safeRoot}>
           <Button
             icon={{
@@ -500,7 +500,7 @@ export default class Browser extends Component {
           </View>
         </View>
         {this.renderWebView()}
-      </SafeBlueArea>
+      </SafeArea>
     );
   }
 }

--- a/screen/lnd/ldkInfo.tsx
+++ b/screen/lnd/ldkInfo.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { View, StyleSheet, Text, Keyboard, TouchableOpacity, SectionList } from 'react-native';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
-import { SafeBlueArea, BlueSpacing20, BlueSpacing10, BlueLoading, BlueTextCentered } from '../../BlueComponents';
+import { BlueSpacing20, BlueSpacing10, BlueLoading, BlueTextCentered } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import { Chain } from '../../models/bitcoinUnits';
@@ -14,6 +14,7 @@ import { AbstractWallet, LightningLdkWallet } from '../../class';
 import alert from '../../components/Alert';
 import { useTheme } from '../../components/themes';
 import StyledButton, { StyledButtonType } from '../../components/StyledButton';
+import SafeArea from '../../components/SafeArea';
 const selectWallet = require('../../helpers/select-wallet');
 const confirm = require('../../helpers/confirm');
 const LdkNodeInfoChannelStatus = { ACTIVE: 'Active', INACTIVE: 'Inactive', PENDING: 'PENDING', STATUS: 'status' };
@@ -378,9 +379,8 @@ const LdkInfo = () => {
     return sectionForList;
   };
 
-  // @ts-ignore This kind of magic is not allowed in typescript, we should try and be more specific
   return (
-    <SafeBlueArea styles={[styles.root, stylesHook.root]}>
+    <SafeArea style={[styles.root, stylesHook.root]}>
       <SectionList
         ref={(ref: SectionList) => {
           sectionList.current = ref;
@@ -421,7 +421,7 @@ const LdkInfo = () => {
         <Button title={loc.lnd.new_channel} onPress={navigateToOpenPrivateChannel} disabled={isLoading} />
         <BlueSpacing20 />
       </View>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/lnd/ldkOpenChannel.tsx
+++ b/screen/lnd/ldkOpenChannel.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
-import { BlueLoading, SafeBlueArea, BlueDismissKeyboardInputAccessory, BlueSpacing20, BlueText } from '../../BlueComponents';
+import { BlueLoading, BlueDismissKeyboardInputAccessory, BlueSpacing20, BlueText } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import BigNumber from 'bignumber.js';
@@ -17,6 +17,7 @@ import alert from '../../components/Alert';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
+import SafeArea from '../../components/SafeArea';
 const currency = require('../../blue_modules/currency');
 
 type LdkOpenChannelProps = RouteProp<
@@ -283,7 +284,7 @@ const LdkOpenChannel = (props: any) => {
     );
   };
 
-  return <SafeBlueArea styles={[styles.root, stylesHook.root]}>{render()}</SafeBlueArea>;
+  return <SafeArea style={[styles.root, stylesHook.root]}>{render()}</SafeArea>;
 };
 
 const styles = StyleSheet.create({

--- a/screen/lnd/lndViewAdditionalInvoiceInformation.js
+++ b/screen/lnd/lndViewAdditionalInvoiceInformation.js
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { View, Share, StyleSheet } from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
-import { BlueCopyTextToClipboard, BlueLoading, BlueSpacing20, BlueText, SafeBlueArea } from '../../BlueComponents';
+import { BlueCopyTextToClipboard, BlueLoading, BlueSpacing20, BlueText } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
@@ -9,6 +9,7 @@ import QRCodeComponent from '../../components/QRCodeComponent';
 import alert from '../../components/Alert';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
+import SafeArea from '../../components/SafeArea';
 
 const LNDViewAdditionalInvoiceInformation = () => {
   const { walletID } = useRoute().params;
@@ -45,14 +46,14 @@ const LNDViewAdditionalInvoiceInformation = () => {
 
   if (walletInfo === undefined) {
     return (
-      <SafeBlueArea style={[styles.loading, stylesHook.loading]}>
+      <SafeArea style={[styles.loading, stylesHook.loading]}>
         <BlueLoading />
-      </SafeBlueArea>
+      </SafeArea>
     );
   }
 
   return (
-    <SafeBlueArea style={stylesHook.root}>
+    <SafeArea style={stylesHook.root}>
       <View style={styles.wrapper}>
         <View style={styles.qrcode}>
           <QRCodeComponent value={walletInfo.uris[0]} size={300} />
@@ -76,7 +77,7 @@ const LNDViewAdditionalInvoiceInformation = () => {
           />
         </View>
       </View>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/lnd/lndViewAdditionalInvoicePreImage.js
+++ b/screen/lnd/lndViewAdditionalInvoicePreImage.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useRoute } from '@react-navigation/native';
-import { BlueCopyTextToClipboard, SafeBlueArea, BlueSpacing20, BlueTextCentered } from '../../BlueComponents';
+import { BlueCopyTextToClipboard, BlueSpacing20, BlueTextCentered } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import loc from '../../loc';
 import QRCodeComponent from '../../components/QRCodeComponent';
 import { useTheme } from '../../components/themes';
+import SafeArea from '../../components/SafeArea';
 
 const LNDViewAdditionalInvoicePreImage = () => {
   // state = { walletInfo: undefined };
@@ -18,7 +19,7 @@ const LNDViewAdditionalInvoicePreImage = () => {
   });
 
   return (
-    <SafeBlueArea style={stylesHook.root}>
+    <SafeArea style={stylesHook.root}>
       <View style={styles.wrapper}>
         <BlueTextCentered>{loc.lndViewInvoice.preimage}:</BlueTextCentered>
         <BlueSpacing20 />
@@ -28,7 +29,7 @@ const LNDViewAdditionalInvoicePreImage = () => {
         <BlueSpacing20 />
         <BlueCopyTextToClipboard text={preImageData} />
       </View>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/lnd/lndViewInvoice.js
+++ b/screen/lnd/lndViewInvoice.js
@@ -4,7 +4,7 @@ import Share from 'react-native-share';
 import { Icon } from 'react-native-elements';
 import QRCodeComponent from '../../components/QRCodeComponent';
 import { useNavigation, useNavigationState, useRoute } from '@react-navigation/native';
-import { BlueLoading, BlueText, SafeBlueArea, BlueCopyTextToClipboard, BlueSpacing20, BlueTextCentered } from '../../BlueComponents';
+import { BlueLoading, BlueText, BlueCopyTextToClipboard, BlueSpacing20, BlueTextCentered } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
@@ -14,6 +14,7 @@ import LNDCreateInvoice from './lndCreateInvoice';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
+import SafeArea from '../../components/SafeArea';
 
 const LNDViewInvoice = () => {
   const { invoice, walletID } = useRoute().params;
@@ -276,7 +277,7 @@ const LNDViewInvoice = () => {
     }
   };
 
-  return <SafeBlueArea onLayout={onLayout}>{render()}</SafeBlueArea>;
+  return <SafeArea onLayout={onLayout}>{render()}</SafeArea>;
 };
 
 const styles = StyleSheet.create({

--- a/screen/lnd/lnurlAuth.js
+++ b/screen/lnd/lnurlAuth.js
@@ -2,7 +2,7 @@ import React, { useState, useContext, useCallback, useMemo } from 'react';
 import { I18nManager, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Icon } from 'react-native-elements';
 
-import { BlueCard, BlueLoading, BlueSpacing20, BlueSpacing40, BlueText, SafeBlueArea } from '../../BlueComponents';
+import { BlueCard, BlueLoading, BlueSpacing20, BlueSpacing40, BlueText } from '../../BlueComponents';
 
 import navigationStyle from '../../components/navigationStyle';
 import Lnurl from '../../class/lnurl';
@@ -15,6 +15,7 @@ import URL from 'url';
 import { SuccessView } from '../send/success';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
+import SafeArea from '../../components/SafeArea';
 
 const AuthState = {
   USER_PROMPT: 0,
@@ -87,7 +88,7 @@ const LnurlAuth = () => {
   );
 
   return (
-    <SafeBlueArea style={styles.root}>
+    <SafeArea style={styles.root}>
       {authState === AuthState.USER_PROMPT && (
         <>
           <ScrollView>
@@ -125,7 +126,7 @@ const LnurlAuth = () => {
           <BlueSpacing20 />
         </BlueCard>
       )}
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/lnd/lnurlPay.js
+++ b/screen/lnd/lnurlPay.js
@@ -4,7 +4,7 @@ import { I18nManager, Image, ScrollView, StyleSheet, Text, TouchableOpacity, Vie
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { Icon } from 'react-native-elements';
 
-import { BlueCard, BlueDismissKeyboardInputAccessory, BlueLoading, BlueSpacing20, BlueText, SafeBlueArea } from '../../BlueComponents';
+import { BlueCard, BlueDismissKeyboardInputAccessory, BlueLoading, BlueSpacing20, BlueText } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import AmountInput from '../../components/AmountInput';
 import Lnurl from '../../class/lnurl';
@@ -16,6 +16,7 @@ import alert from '../../components/Alert';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
+import SafeArea from '../../components/SafeArea';
 const prompt = require('../../helpers/prompt');
 const currency = require('../../blue_modules/currency');
 
@@ -196,7 +197,7 @@ const LnurlPay = () => {
 
   const renderGotPayload = () => {
     return (
-      <SafeBlueArea>
+      <SafeArea>
         <ScrollView contentContainertyle={{ justifyContent: 'space-around' }}>
           <BlueCard>
             <AmountInput
@@ -229,7 +230,7 @@ const LnurlPay = () => {
           </BlueCard>
         </ScrollView>
         {renderWalletSelectionButton}
-      </SafeBlueArea>
+      </SafeArea>
     );
   };
 

--- a/screen/lnd/lnurlPaySuccess.js
+++ b/screen/lnd/lnurlPaySuccess.js
@@ -2,12 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { View, Text, Linking, StyleSheet, Image, ScrollView } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { BlueButtonLink, BlueCard, BlueLoading, BlueSpacing20, BlueSpacing40, BlueText, SafeBlueArea } from '../../BlueComponents';
+import { BlueButtonLink, BlueCard, BlueLoading, BlueSpacing20, BlueSpacing40, BlueText } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import Lnurl from '../../class/lnurl';
 import loc from '../../loc';
 import { SuccessView } from '../send/success';
 import Button from '../../components/Button';
+import SafeArea from '../../components/SafeArea';
 
 export default class LnurlPaySuccess extends Component {
   constructor(props) {
@@ -72,7 +73,7 @@ export default class LnurlPaySuccess extends Component {
     const { preamble, message, url, justPaid } = this.state;
 
     return (
-      <SafeBlueArea style={styles.root}>
+      <SafeArea style={styles.root}>
         <ScrollView style={styles.container}>
           {justPaid && <SuccessView />}
 
@@ -127,7 +128,7 @@ export default class LnurlPaySuccess extends Component {
             )}
           </BlueCard>
         </ScrollView>
-      </SafeBlueArea>
+      </SafeArea>
     );
   }
 }

--- a/screen/lnd/scanLndInvoice.js
+++ b/screen/lnd/scanLndInvoice.js
@@ -13,7 +13,7 @@ import {
 import { Icon } from 'react-native-elements';
 import { useFocusEffect, useNavigation, useRoute } from '@react-navigation/native';
 
-import { BlueCard, BlueDismissKeyboardInputAccessory, BlueLoading, SafeBlueArea } from '../../BlueComponents';
+import { BlueCard, BlueDismissKeyboardInputAccessory, BlueLoading } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import AddressInput from '../../components/AddressInput';
 import AmountInput from '../../components/AmountInput';
@@ -26,6 +26,7 @@ import alert from '../../components/Alert';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
+import SafeArea from '../../components/SafeArea';
 const currency = require('../../blue_modules/currency');
 
 const ScanLndInvoice = () => {
@@ -299,7 +300,7 @@ const ScanLndInvoice = () => {
   }
 
   return (
-    <SafeBlueArea style={stylesHook.root}>
+    <SafeArea style={stylesHook.root}>
       <View style={[styles.root, stylesHook.root]}>
         <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
           <KeyboardAvoidingView enabled behavior="position" keyboardVerticalOffset={20}>
@@ -361,7 +362,7 @@ const ScanLndInvoice = () => {
         </ScrollView>
       </View>
       <BlueDismissKeyboardInputAccessory />
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/plausibledeniability.js
+++ b/screen/plausibledeniability.js
@@ -3,12 +3,13 @@ import { ScrollView } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
 import navigationStyle from '../components/navigationStyle';
-import { BlueLoading, SafeBlueArea, BlueCard, BlueText, BlueSpacing20 } from '../BlueComponents';
+import { BlueLoading, BlueCard, BlueText, BlueSpacing20 } from '../BlueComponents';
 import loc from '../loc';
 import { BlueStorageContext } from '../blue_modules/storage-context';
 import alert from '../components/Alert';
 import Button from '../components/Button';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../blue_modules/hapticFeedback';
+import SafeArea from '../components/SafeArea';
 const prompt = require('../helpers/prompt');
 
 const PlausibleDeniability = () => {
@@ -48,11 +49,11 @@ const PlausibleDeniability = () => {
   };
 
   return isLoading ? (
-    <SafeBlueArea>
+    <SafeArea>
       <BlueLoading />
-    </SafeBlueArea>
+    </SafeArea>
   ) : (
-    <SafeBlueArea>
+    <SafeArea>
       <BlueCard>
         <ScrollView maxHeight={450}>
           <BlueText>{loc.plausibledeniability.help}</BlueText>
@@ -70,7 +71,7 @@ const PlausibleDeniability = () => {
           />
         </ScrollView>
       </BlueCard>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/selftest.js
+++ b/screen/selftest.js
@@ -6,7 +6,7 @@ import bip38 from 'bip38';
 import BIP32Factory from 'bip32';
 
 import loc from '../loc';
-import { BlueSpacing20, SafeBlueArea, BlueCard, BlueText, BlueLoading } from '../BlueComponents';
+import { BlueSpacing20, BlueCard, BlueText, BlueLoading } from '../BlueComponents';
 import navigationStyle from '../components/navigationStyle';
 import {
   SegwitP2SHWallet,
@@ -18,6 +18,7 @@ import {
 } from '../class';
 import ecc from '../blue_modules/noble_ecc';
 import Button from '../components/Button';
+import SafeArea from '../components/SafeArea';
 const bitcoin = require('bitcoinjs-lib');
 const BlueCrypto = require('react-native-blue-crypto');
 const encryption = require('../blue_modules/encryption');
@@ -273,7 +274,7 @@ export default class Selftest extends Component {
     }
 
     return (
-      <SafeBlueArea>
+      <SafeArea>
         <BlueCard>
           <ScrollView>
             <BlueSpacing20 />
@@ -307,7 +308,7 @@ export default class Selftest extends Component {
             )}
           </ScrollView>
         </BlueCard>
-      </SafeBlueArea>
+      </SafeArea>
     );
   }
 }

--- a/screen/send/broadcast.js
+++ b/screen/send/broadcast.js
@@ -15,13 +15,13 @@ import {
   BlueSpacing10,
   BlueSpacing20,
   BlueTextCentered,
-  SafeBlueArea,
 } from '../../BlueComponents';
 import BlueElectrum from '../../blue_modules/BlueElectrum';
 import Notifications from '../../blue_modules/notifications';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
+import SafeArea from '../../components/SafeArea';
 
 const scanqr = require('../../helpers/scan-qr');
 
@@ -111,7 +111,7 @@ const Broadcast = () => {
   }
 
   return (
-    <SafeBlueArea>
+    <SafeArea>
       <KeyboardAvoidingView
         enabled={!Platform.isPad}
         behavior={Platform.OS === 'ios' ? 'position' : null}
@@ -158,7 +158,7 @@ const Broadcast = () => {
           {BROADCAST_RESULT.success === broadcastResult && <SuccessScreen tx={tx} />}
         </View>
       </KeyboardAvoidingView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/send/coinControl.js
+++ b/screen/send/coinControl.js
@@ -20,7 +20,7 @@ import { useRoute, useNavigation } from '@react-navigation/native';
 import * as RNLocalize from 'react-native-localize';
 import loc, { formatBalance } from '../../loc';
 import { BitcoinUnit } from '../../models/bitcoinUnits';
-import { SafeBlueArea, BlueSpacing10, BlueSpacing20 } from '../../BlueComponents';
+import { BlueSpacing10, BlueSpacing20 } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import BottomModal from '../../components/BottomModal';
 import { FContainer, FButton } from '../../components/FloatButtons';
@@ -29,6 +29,7 @@ import { BlueStorageContext } from '../../blue_modules/storage-context';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
 import ListItem from '../../components/ListItem';
+import SafeArea from '../../components/SafeArea';
 
 const FrozenBadge = () => {
   const { colors } = useTheme();
@@ -386,9 +387,9 @@ const CoinControl = () => {
 
   if (loading) {
     return (
-      <SafeBlueArea style={[styles.center, { backgroundColor: colors.elevated }]}>
+      <SafeArea style={[styles.center, { backgroundColor: colors.elevated }]}>
         <ActivityIndicator testID="Loading" />
-      </SafeBlueArea>
+      </SafeArea>
     );
   }
 

--- a/screen/send/confirm.js
+++ b/screen/send/confirm.js
@@ -4,7 +4,7 @@ import { Text } from 'react-native-elements';
 import { PayjoinClient } from 'payjoin-client';
 import PropTypes from 'prop-types';
 import PayjoinTransaction from '../../class/payjoin-transaction';
-import { BlueText, SafeBlueArea, BlueCard } from '../../BlueComponents';
+import { BlueText, BlueCard } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import { BitcoinUnit } from '../../models/bitcoinUnits';
 import Biometric from '../../class/biometrics';
@@ -16,6 +16,7 @@ import alert from '../../components/Alert';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
+import SafeArea from '../../components/SafeArea';
 const currency = require('../../blue_modules/currency');
 const BlueElectrum = require('../../blue_modules/BlueElectrum');
 const Bignumber = require('bignumber.js');
@@ -208,7 +209,7 @@ const Confirm = () => {
   };
 
   return (
-    <SafeBlueArea style={[styles.root, stylesHook.root]}>
+    <SafeArea style={[styles.root, stylesHook.root]}>
       <View style={styles.cardTop}>
         <FlatList
           scrollEnabled={recipients.length > 1}
@@ -237,7 +238,7 @@ const Confirm = () => {
           {isLoading ? <ActivityIndicator /> : <Button disabled={isElectrumDisabled} onPress={send} title={loc.send.confirm_sendNow} />}
         </BlueCard>
       </View>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/send/isItMyAddress.js
+++ b/screen/send/isItMyAddress.js
@@ -3,12 +3,13 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import { StyleSheet, View, KeyboardAvoidingView, Platform, TextInput, Keyboard } from 'react-native';
 
 import loc from '../../loc';
-import { BlueButtonLink, BlueCard, BlueSpacing10, BlueSpacing20, BlueText, SafeBlueArea } from '../../BlueComponents';
+import { BlueButtonLink, BlueCard, BlueSpacing10, BlueSpacing20, BlueText } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import { requestCameraAuthorization } from '../../helpers/scan-qr';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
+import SafeArea from '../../components/SafeArea';
 
 const IsItMyAddress = () => {
   /** @type {AbstractWallet[]} */
@@ -85,7 +86,7 @@ const IsItMyAddress = () => {
   };
 
   return (
-    <SafeBlueArea style={styles.blueArea}>
+    <SafeArea style={styles.blueArea}>
       <KeyboardAvoidingView
         enabled={!Platform.isPad}
         behavior={Platform.OS === 'ios' ? 'position' : null}
@@ -132,7 +133,7 @@ const IsItMyAddress = () => {
           </BlueCard>
         </View>
       </KeyboardAvoidingView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/send/psbtMultisig.js
+++ b/screen/send/psbtMultisig.js
@@ -3,7 +3,7 @@ import { FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native
 import { Icon } from 'react-native-elements';
 import { useNavigation, useRoute } from '@react-navigation/native';
 
-import { BlueCard, BlueText, SafeBlueArea } from '../../BlueComponents';
+import { BlueCard, BlueText } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import loc from '../../loc';
 import { BitcoinUnit } from '../../models/bitcoinUnits';
@@ -11,6 +11,7 @@ import { BlueStorageContext } from '../../blue_modules/storage-context';
 import alert from '../../components/Alert';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
+import SafeArea from '../../components/SafeArea';
 const bitcoin = require('bitcoinjs-lib');
 const BigNumber = require('bignumber.js');
 const currency = require('../../blue_modules/currency');
@@ -267,7 +268,7 @@ const PsbtMultisig = () => {
   };
 
   return (
-    <SafeBlueArea style={stylesHook.root}>
+    <SafeArea style={stylesHook.root}>
       <View style={styles.container}>
         <View style={styles.mstopcontainer}>
           <View style={styles.mscontainer}>
@@ -301,7 +302,7 @@ const PsbtMultisig = () => {
           </View>
         </View>
       </View>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/send/psbtMultisigQRCode.js
+++ b/screen/send/psbtMultisigQRCode.js
@@ -3,7 +3,7 @@ import { ActivityIndicator, findNodeHandle, ScrollView, StyleSheet, View } from 
 import { getSystemName } from 'react-native-device-info';
 import { useNavigation, useRoute, useIsFocused } from '@react-navigation/native';
 
-import { BlueSpacing20, SafeBlueArea } from '../../BlueComponents';
+import { BlueSpacing20 } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import { DynamicQRCode } from '../../components/DynamicQRCode';
 import { SquareButton } from '../../components/SquareButton';
@@ -12,6 +12,7 @@ import loc from '../../loc';
 import alert from '../../components/Alert';
 import { requestCameraAuthorization } from '../../helpers/scan-qr';
 import { useTheme } from '../../components/themes';
+import SafeArea from '../../components/SafeArea';
 const bitcoin = require('bitcoinjs-lib');
 const fs = require('../../blue_modules/fs');
 
@@ -92,7 +93,7 @@ const PsbtMultisigQRCode = () => {
   };
 
   return (
-    <SafeBlueArea style={stylesHook.root}>
+    <SafeArea style={stylesHook.root}>
       <ScrollView centerContent contentContainerStyle={styles.scrollViewContent}>
         <View style={[styles.modalContentShort, stylesHook.modalContentShort]}>
           <DynamicQRCode value={psbt.toHex()} ref={dynamicQRCode} />
@@ -116,7 +117,7 @@ const PsbtMultisigQRCode = () => {
           )}
         </View>
       </ScrollView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/send/psbtWithHardwareWallet.js
+++ b/screen/send/psbtWithHardwareWallet.js
@@ -6,7 +6,7 @@ import { useNavigation, useRoute, useIsFocused } from '@react-navigation/native'
 import RNFS from 'react-native-fs';
 import Biometric from '../../class/biometrics';
 
-import { SecondButton, BlueText, SafeBlueArea, BlueCard, BlueSpacing20, BlueCopyToClipboardButton } from '../../BlueComponents';
+import { SecondButton, BlueText, BlueCard, BlueSpacing20, BlueCopyToClipboardButton } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
@@ -16,6 +16,7 @@ import alert from '../../components/Alert';
 import { requestCameraAuthorization } from '../../helpers/scan-qr';
 import { useTheme } from '../../components/themes';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
+import SafeArea from '../../components/SafeArea';
 const BlueElectrum = require('../../blue_modules/BlueElectrum');
 const bitcoin = require('bitcoinjs-lib');
 const fs = require('../../blue_modules/fs');
@@ -229,7 +230,7 @@ const PsbtWithHardwareWallet = () => {
       <ActivityIndicator />
     </View>
   ) : (
-    <SafeBlueArea style={stylesHook.root}>
+    <SafeArea style={stylesHook.root}>
       <ScrollView centerContent contentContainerStyle={styles.scrollViewContent} testID="PsbtWithHardwareScrollView">
         <View style={styles.container}>
           <BlueCard>
@@ -281,7 +282,7 @@ const PsbtWithHardwareWallet = () => {
           </BlueCard>
         </View>
       </ScrollView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/settings/NetworkSettings.js
+++ b/screen/settings/NetworkSettings.js
@@ -3,9 +3,9 @@ import { ScrollView } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import Notifications from '../../blue_modules/notifications';
 import navigationStyle from '../../components/navigationStyle';
-import { SafeBlueArea } from '../../BlueComponents';
 import loc from '../../loc';
 import ListItem from '../../components/ListItem';
+import SafeArea from '../../components/SafeArea';
 
 const NetworkSettings = () => {
   const { navigate } = useNavigation();
@@ -19,7 +19,7 @@ const NetworkSettings = () => {
   };
 
   return (
-    <SafeBlueArea>
+    <SafeArea>
       <ScrollView>
         <ListItem title={loc.settings.network_electrum} onPress={navigateToElectrumSettings} testID="ElectrumSettings" chevron />
         <ListItem title={loc.settings.lightning_settings} onPress={navigateToLightningSettings} testID="LightningSettings" chevron />
@@ -32,7 +32,7 @@ const NetworkSettings = () => {
           />
         )}
       </ScrollView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/settings/currency.js
+++ b/screen/settings/currency.js
@@ -3,7 +3,7 @@ import { FlatList, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
 import navigationStyle from '../../components/navigationStyle';
-import { SafeBlueArea, BlueText, BlueCard, BlueSpacing10 } from '../../BlueComponents';
+import { BlueText, BlueCard, BlueSpacing10 } from '../../BlueComponents';
 import { FiatUnit, FiatUnitSource, getFiatRate } from '../../models/fiatUnit';
 import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
@@ -11,6 +11,7 @@ import dayjs from 'dayjs';
 import alert from '../../components/Alert';
 import { useTheme } from '../../components/themes';
 import ListItem from '../../components/ListItem';
+import SafeArea from '../../components/SafeArea';
 dayjs.extend(require('dayjs/plugin/calendar'));
 const currency = require('../../blue_modules/currency');
 
@@ -55,7 +56,7 @@ const Currency = () => {
   }, [setOptions]);
 
   return (
-    <SafeBlueArea>
+    <SafeArea>
       <FlatList
         style={styles.flex}
         keyExtractor={(_item, index) => `${index}`}
@@ -101,7 +102,7 @@ const Currency = () => {
           {loc.settings.last_updated}: {dayjs(currencyRate.LastUpdated).calendar() ?? loc._.never}
         </BlueText>
       </BlueCard>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/settings/defaultView.js
+++ b/screen/settings/defaultView.js
@@ -3,11 +3,12 @@ import { View, TouchableWithoutFeedback } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
 import navigationStyle from '../../components/navigationStyle';
-import { SafeBlueArea, BlueCard, BlueText } from '../../BlueComponents';
+import { BlueCard, BlueText } from '../../BlueComponents';
 import OnAppLaunch from '../../class/on-app-launch';
 import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import ListItem from '../../components/ListItem';
+import SafeArea from '../../components/SafeArea';
 
 const DefaultView = () => {
   const [defaultWalletLabel, setDefaultWalletLabel] = useState('');
@@ -53,7 +54,7 @@ const DefaultView = () => {
   };
 
   return (
-    <SafeBlueArea>
+    <SafeArea>
       <View>
         <ListItem
           title={loc.settings.default_wallets}
@@ -71,7 +72,7 @@ const DefaultView = () => {
           <ListItem title={loc.settings.default_info} onPress={selectWallet} rightTitle={defaultWalletLabel} chevron />
         )}
       </View>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/settings/electrumSettings.js
+++ b/screen/settings/electrumSettings.js
@@ -25,7 +25,6 @@ import {
   BlueLoading,
   BlueSpacing20,
   BlueText,
-  SafeBlueArea,
   BlueDoneAndDismissKeyboardInputAccessory,
   BlueDismissKeyboardInputAccessory,
 } from '../../BlueComponents';
@@ -37,6 +36,7 @@ import { requestCameraAuthorization } from '../../helpers/scan-qr';
 import Button from '../../components/Button';
 import ListItem from '../../components/ListItem';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
+import SafeArea from '../../components/SafeArea';
 
 const BlueElectrum = require('../../blue_modules/BlueElectrum');
 
@@ -422,7 +422,7 @@ export default class ElectrumSettings extends Component {
 
   render() {
     return (
-      <SafeBlueArea>
+      <SafeArea>
         <ScrollView keyboardShouldPersistTaps="always">
           <ListItem
             Component={Pressable}
@@ -438,7 +438,7 @@ export default class ElectrumSettings extends Component {
           </BlueCard>
           {!this.state.isOfflineMode && this.renderElectrumSettings()}
         </ScrollView>
-      </SafeBlueArea>
+      </SafeArea>
     );
   }
 }

--- a/screen/settings/encryptStorage.js
+++ b/screen/settings/encryptStorage.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useCallback, useContext } from 'react';
 import { ScrollView, Alert, TouchableOpacity, TouchableWithoutFeedback, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import navigationStyle from '../../components/navigationStyle';
-import { BlueLoading, SafeBlueArea, BlueSpacing20, BlueCard, BlueHeaderDefaultSub, BlueText } from '../../BlueComponents';
+import { BlueLoading, BlueSpacing20, BlueCard, BlueHeaderDefaultSub, BlueText } from '../../BlueComponents';
 import Biometric from '../../class/biometrics';
 import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
@@ -10,6 +10,7 @@ import alert from '../../components/Alert';
 import ListItem from '../../components/ListItem';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
 import { useTheme } from '../../components/themes';
+import SafeArea from '../../components/SafeArea';
 const prompt = require('../../helpers/prompt');
 
 const EncryptStorage = () => {
@@ -122,11 +123,11 @@ const EncryptStorage = () => {
   };
 
   return isLoading ? (
-    <SafeBlueArea>
+    <SafeArea>
       <BlueLoading />
-    </SafeBlueArea>
+    </SafeArea>
   ) : (
-    <SafeBlueArea>
+    <SafeArea>
       <ScrollView contentContainerStyle={styles.root}>
         {biometrics.isDeviceBiometricCapable && (
           <>
@@ -160,7 +161,7 @@ const EncryptStorage = () => {
           />
         )}
       </ScrollView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/settings/licensing.js
+++ b/screen/settings/licensing.js
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { ScrollView } from 'react-native';
 import navigationStyle from '../../components/navigationStyle';
-import { SafeBlueArea, BlueCard, BlueText, BlueSpacing20, BlueLoading } from '../../BlueComponents';
+import { BlueCard, BlueText, BlueSpacing20, BlueLoading } from '../../BlueComponents';
+import SafeArea from '../../components/SafeArea';
 
 const Licensing = () => {
   const [isLoading, setIsLoading] = useState(true);
@@ -13,7 +14,7 @@ const Licensing = () => {
   return isLoading ? (
     <BlueLoading />
   ) : (
-    <SafeBlueArea>
+    <SafeArea>
       <ScrollView>
         <BlueCard>
           <BlueText>MIT License</BlueText>
@@ -41,7 +42,7 @@ const Licensing = () => {
           </BlueText>
         </BlueCard>
       </ScrollView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/settings/lightningSettings.tsx
+++ b/screen/settings/lightningSettings.tsx
@@ -4,7 +4,7 @@ import { Button as ButtonRNElements } from 'react-native-elements';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import navigationStyle, { NavigationOptionsGetter } from '../../components/navigationStyle';
-import { BlueButtonLink, BlueCard, BlueLoading, BlueSpacing20, BlueText, SafeBlueArea } from '../../BlueComponents';
+import { BlueButtonLink, BlueCard, BlueLoading, BlueSpacing20, BlueText } from '../../BlueComponents';
 import { LightningCustodianWallet } from '../../class/wallets/lightning-custodian-wallet';
 import loc from '../../loc';
 import { useTheme } from '../../components/themes';
@@ -12,6 +12,7 @@ import DeeplinkSchemaMatch from '../../class/deeplink-schema-match';
 import alert from '../../components/Alert';
 import { requestCameraAuthorization } from '../../helpers/scan-qr';
 import { Button } from '../../components/Button';
+import SafeArea from '../../components/SafeArea';
 
 const BlueApp = require('../../BlueApp');
 const AppStorage = BlueApp.AppStorage;
@@ -130,7 +131,7 @@ const LightningSettings: React.FC & { navigationOptions: NavigationOptionsGetter
   };
 
   return (
-    <SafeBlueArea>
+    <SafeArea>
       <BlueCard>
         <BlueText>{loc.settings.lightning_settings_explain}</BlueText>
       </BlueCard>
@@ -171,7 +172,7 @@ const LightningSettings: React.FC & { navigationOptions: NavigationOptionsGetter
         <BlueSpacing20 />
         {isLoading ? <BlueLoading /> : <Button testID="Save" onPress={save} title={loc.settings.save} />}
       </BlueCard>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/settings/releasenotes.js
+++ b/screen/settings/releasenotes.js
@@ -1,20 +1,21 @@
 import React from 'react';
 import { ScrollView } from 'react-native';
 import navigationStyle from '../../components/navigationStyle';
-import { SafeBlueArea, BlueCard, BlueText } from '../../BlueComponents';
+import { BlueCard, BlueText } from '../../BlueComponents';
 import loc from '../../loc';
+import SafeArea from '../../components/SafeArea';
 
 const ReleaseNotes = () => {
   const notes = require('../../release-notes');
 
   return (
-    <SafeBlueArea>
+    <SafeArea>
       <ScrollView>
         <BlueCard>
           <BlueText>{notes}</BlueText>
         </BlueCard>
       </ScrollView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/settings/tools.js
+++ b/screen/settings/tools.js
@@ -3,9 +3,9 @@ import { ScrollView } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
 import navigationStyle from '../../components/navigationStyle';
-import { SafeBlueArea } from '../../BlueComponents';
 import loc from '../../loc';
 import ListItem from '../../components/ListItem';
+import SafeArea from '../../components/SafeArea';
 
 const NetworkSettings = () => {
   const { navigate } = useNavigation();
@@ -23,13 +23,13 @@ const NetworkSettings = () => {
   };
 
   return (
-    <SafeBlueArea>
+    <SafeArea>
       <ScrollView>
         <ListItem title={loc.is_it_my_address.title} onPress={navigateToIsItMyAddress} testID="IsItMyAddress" chevron />
         <ListItem title={loc.settings.network_broadcast} onPress={navigateToBroadcast} testID="Broadcast" chevron />
         <ListItem title={loc.autofill_word.title} onPress={navigateToGenerateWord} testID="GenerateWord" chevron />
       </ScrollView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/transactions/CPFP.js
+++ b/screen/transactions/CPFP.js
@@ -13,7 +13,8 @@ import {
 } from 'react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import { Text } from 'react-native-elements';
-import { BlueCard, BlueReplaceFeeSuggestions, BlueSpacing, BlueSpacing20, BlueText, SafeBlueArea } from '../../BlueComponents';
+
+import { BlueCard, BlueReplaceFeeSuggestions, BlueSpacing, BlueSpacing20, BlueText } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import { BlueCurrentTheme } from '../../components/themes';
 import { HDSegwitBech32Transaction, HDSegwitBech32Wallet } from '../../class';
@@ -23,6 +24,7 @@ import Notifications from '../../blue_modules/notifications';
 import alert from '../../components/Alert';
 import Button from '../../components/Button';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
+import SafeArea from '../../components/SafeArea';
 const BlueElectrum = require('../../blue_modules/BlueElectrum');
 
 const styles = StyleSheet.create({
@@ -160,7 +162,7 @@ export default class CPFP extends Component {
   renderStage1(text) {
     return (
       <KeyboardAvoidingView enabled={!Platform.isPad} behavior="position">
-        <SafeBlueArea style={styles.root}>
+        <SafeArea style={styles.root}>
           <BlueSpacing />
           <BlueCard style={styles.center}>
             <BlueText>{text}</BlueText>
@@ -173,7 +175,7 @@ export default class CPFP extends Component {
               title={loc.transactions.cpfp_create}
             />
           </BlueCard>
-        </SafeBlueArea>
+        </SafeArea>
       </KeyboardAvoidingView>
     );
   }
@@ -216,7 +218,7 @@ export default class CPFP extends Component {
 
     if (this.state.nonReplaceable) {
       return (
-        <SafeBlueArea style={styles.root}>
+        <SafeArea style={styles.root}>
           <BlueSpacing20 />
           <BlueSpacing20 />
           <BlueSpacing20 />
@@ -224,14 +226,14 @@ export default class CPFP extends Component {
           <BlueSpacing20 />
 
           <BlueText h4>{loc.transactions.cpfp_no_bump}</BlueText>
-        </SafeBlueArea>
+        </SafeArea>
       );
     }
 
     return (
-      <SafeBlueArea style={styles.explain}>
+      <SafeArea style={styles.explain}>
         <ScrollView>{this.renderStage1(loc.transactions.cpfp_exp)}</ScrollView>
-      </SafeBlueArea>
+      </SafeArea>
     );
   }
 }

--- a/screen/transactions/RBFBumpFee.js
+++ b/screen/transactions/RBFBumpFee.js
@@ -2,12 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ActivityIndicator, View, ScrollView, StyleSheet } from 'react-native';
 import navigationStyle from '../../components/navigationStyle';
-import { BlueSpacing20, SafeBlueArea, BlueText } from '../../BlueComponents';
+import { BlueSpacing20, BlueText } from '../../BlueComponents';
 import { HDSegwitBech32Transaction, HDSegwitBech32Wallet } from '../../class';
 import CPFP from './CPFP';
 import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import alert from '../../components/Alert';
+import SafeArea from '../../components/SafeArea';
 
 const styles = StyleSheet.create({
   root: {
@@ -85,7 +86,7 @@ export default class RBFBumpFee extends CPFP {
 
     if (this.state.nonReplaceable) {
       return (
-        <SafeBlueArea style={styles.root}>
+        <SafeArea style={styles.root}>
           <BlueSpacing20 />
           <BlueSpacing20 />
           <BlueSpacing20 />
@@ -93,14 +94,14 @@ export default class RBFBumpFee extends CPFP {
           <BlueSpacing20 />
 
           <BlueText h4>{loc.transactions.cpfp_no_bump}</BlueText>
-        </SafeBlueArea>
+        </SafeArea>
       );
     }
 
     return (
-      <SafeBlueArea style={styles.root}>
+      <SafeArea style={styles.root}>
         <ScrollView>{this.renderStage1(loc.transactions.rbf_explain)}</ScrollView>
-      </SafeBlueArea>
+      </SafeArea>
     );
   }
 }

--- a/screen/transactions/RBFCancel.js
+++ b/screen/transactions/RBFCancel.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ActivityIndicator, View, ScrollView } from 'react-native';
-import { BlueSpacing20, SafeBlueArea, BlueText } from '../../BlueComponents';
+import { BlueSpacing20, BlueText } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import { HDSegwitBech32Transaction, HDSegwitBech32Wallet } from '../../class';
 import CPFP from './CPFP';
 import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import alert from '../../components/Alert';
+import SafeArea from '../../components/SafeArea';
 
 export default class RBFCancel extends CPFP {
   static contextType = BlueStorageContext;
@@ -88,7 +89,7 @@ export default class RBFCancel extends CPFP {
 
     if (this.state.nonReplaceable) {
       return (
-        <SafeBlueArea>
+        <SafeArea>
           <BlueSpacing20 />
           <BlueSpacing20 />
           <BlueSpacing20 />
@@ -96,14 +97,14 @@ export default class RBFCancel extends CPFP {
           <BlueSpacing20 />
 
           <BlueText h4>{loc.transactions.cancel_no}</BlueText>
-        </SafeBlueArea>
+        </SafeArea>
       );
     }
 
     return (
-      <SafeBlueArea>
+      <SafeArea>
         <ScrollView>{this.renderStage1(loc.transactions.cancel_explain)}</ScrollView>
-      </SafeBlueArea>
+      </SafeArea>
     );
   }
 }

--- a/screen/transactions/transactionStatus.js
+++ b/screen/transactions/transactionStatus.js
@@ -2,7 +2,8 @@ import React, { useContext, useEffect, useLayoutEffect, useRef, useState } from 
 import { View, ActivityIndicator, Text, TouchableOpacity, StyleSheet, BackHandler } from 'react-native';
 import { Icon } from 'react-native-elements';
 import { useNavigation, useRoute } from '@react-navigation/native';
-import { BlueCard, BlueLoading, BlueSpacing10, BlueSpacing20, BlueText, SafeBlueArea } from '../../BlueComponents';
+
+import { BlueCard, BlueLoading, BlueSpacing10, BlueSpacing20, BlueText } from '../../BlueComponents';
 import TransactionIncomingIcon from '../../components/icons/TransactionIncomingIcon';
 import TransactionOutgoingIcon from '../../components/icons/TransactionOutgoingIcon';
 import TransactionPendingIcon from '../../components/icons/TransactionPendingIcon';
@@ -16,6 +17,7 @@ import * as BlueElectrum from '../../blue_modules/BlueElectrum';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
+import SafeArea from '../../components/SafeArea';
 
 const buttonStatus = Object.freeze({
   possible: 1,
@@ -349,13 +351,13 @@ const TransactionsStatus = () => {
 
   if (isLoading || !tx) {
     return (
-      <SafeBlueArea>
+      <SafeArea>
         <BlueLoading />
-      </SafeBlueArea>
+      </SafeArea>
     );
   }
   return (
-    <SafeBlueArea>
+    <SafeArea>
       <HandoffComponent
         title={loc.transactions.details_title}
         type={HandoffComponent.activityTypes.ViewInBlockExplorer}
@@ -434,7 +436,7 @@ const TransactionsStatus = () => {
           {renderRBFCancel()}
         </View>
       </View>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/wallets/addMultisigHelp.tsx
+++ b/screen/wallets/addMultisigHelp.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Image, View, Text, ScrollView, StyleSheet } from 'react-native';
-import { SafeBlueArea } from '../../BlueComponents';
+import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
+
 import loc from '../../loc';
 import { useTheme } from '../../components/themes';
-import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
+import SafeArea from '../../components/SafeArea';
 
 const WalletsAddMultisigHelp: React.FC = () => {
   const { colors } = useTheme();
@@ -31,7 +32,7 @@ const WalletsAddMultisigHelp: React.FC = () => {
   });
 
   return (
-    <SafeBlueArea style={stylesHook.root}>
+    <SafeArea style={stylesHook.root}>
       <ScrollView>
         <View style={[styles.intro, stylesHook.intro]}>
           <Text style={[styles.introTitle, stylesHook.introTitle]}>{loc.multisig.ms_help_title}</Text>
@@ -63,7 +64,7 @@ const WalletsAddMultisigHelp: React.FC = () => {
           <Text style={[styles.tipsText, stylesHook.tipsText]}>{loc.multisig.ms_help_5}</Text>
         </View>
       </ScrollView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/wallets/export.js
+++ b/screen/wallets/export.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useContext, useRef, useEffect } from 'rea
 import { InteractionManager, ScrollView, ActivityIndicator, View, StyleSheet, AppState } from 'react-native';
 import { useNavigation, useFocusEffect, useRoute } from '@react-navigation/native';
 
-import { BlueSpacing20, SafeBlueArea, BlueText, BlueCopyTextToClipboard, BlueCard } from '../../BlueComponents';
+import { BlueSpacing20, BlueText, BlueCopyTextToClipboard, BlueCard } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import Privacy from '../../blue_modules/Privacy';
 import Biometric from '../../class/biometrics';
@@ -12,6 +12,7 @@ import { BlueStorageContext } from '../../blue_modules/storage-context';
 import QRCodeComponent from '../../components/QRCodeComponent';
 import HandoffComponent from '../../components/handoff';
 import { useTheme } from '../../components/themes';
+import SafeArea from '../../components/SafeArea';
 
 const WalletExport = () => {
   const { wallets, saveToDisk } = useContext(BlueStorageContext);
@@ -94,7 +95,7 @@ const WalletExport = () => {
   };
 
   return (
-    <SafeBlueArea style={[styles.root, stylesHook.root]} onLayout={onLayout}>
+    <SafeArea style={[styles.root, stylesHook.root]} onLayout={onLayout}>
       <ScrollView contentContainerStyle={styles.scrollViewContent} testID="WalletExportScroll">
         <View>
           <BlueText style={[styles.type, stylesHook.type]}>{wallet.typeReadable}</BlueText>
@@ -130,7 +131,7 @@ const WalletExport = () => {
           </React.Fragment>
         ))}
       </ScrollView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/wallets/exportMultisigCoordinationSetup.js
+++ b/screen/wallets/exportMultisigCoordinationSetup.js
@@ -2,7 +2,7 @@ import React, { useCallback, useContext, useRef, useState } from 'react';
 import { ActivityIndicator, InteractionManager, ScrollView, StyleSheet, View } from 'react-native';
 import { useFocusEffect, useNavigation, useRoute } from '@react-navigation/native';
 
-import { BlueSpacing20, BlueText, SafeBlueArea } from '../../BlueComponents';
+import { BlueSpacing20, BlueText } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import { DynamicQRCode } from '../../components/DynamicQRCode';
 import Privacy from '../../blue_modules/Privacy';
@@ -11,6 +11,7 @@ import loc from '../../loc';
 import { SquareButton } from '../../components/SquareButton';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import { useTheme } from '../../components/themes';
+import SafeArea from '../../components/SafeArea';
 const fs = require('../../blue_modules/fs');
 
 const ExportMultisigCoordinationSetup = () => {
@@ -76,7 +77,7 @@ const ExportMultisigCoordinationSetup = () => {
       <ActivityIndicator />
     </View>
   ) : (
-    <SafeBlueArea style={stylesHook.root}>
+    <SafeArea style={stylesHook.root}>
       <ScrollView contentContainerStyle={styles.scrollViewContent}>
         <View>
           <BlueText style={[styles.type, stylesHook.type]}>{wallet.getLabel()}</BlueText>
@@ -92,7 +93,7 @@ const ExportMultisigCoordinationSetup = () => {
         <BlueSpacing20 />
         <BlueText style={[styles.secret, stylesHook.secret]}>{wallet.getXpub()}</BlueText>
       </ScrollView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/wallets/generateWord.js
+++ b/screen/wallets/generateWord.js
@@ -3,12 +3,13 @@ import { useTheme } from '@react-navigation/native';
 import { StyleSheet, View, KeyboardAvoidingView, Platform, TextInput, Keyboard } from 'react-native';
 
 import loc from '../../loc';
-import { BlueCard, BlueSpacing10, BlueSpacing20, BlueText, SafeBlueArea } from '../../BlueComponents';
+import { BlueCard, BlueSpacing10, BlueSpacing20, BlueText } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 
 import { randomBytes } from '../../class/rng';
 import { generateChecksumWords } from '../../blue_modules/checksumWords';
 import Button from '../../components/Button';
+import SafeArea from '../../components/SafeArea';
 
 const GenerateWord = () => {
   const { colors } = useTheme();
@@ -54,7 +55,7 @@ const GenerateWord = () => {
   };
 
   return (
-    <SafeBlueArea style={styles.blueArea}>
+    <SafeArea style={styles.blueArea}>
       <KeyboardAvoidingView
         enabled={!Platform.isPad}
         behavior={Platform.OS === 'ios' ? 'position' : null}
@@ -98,7 +99,7 @@ const GenerateWord = () => {
           </BlueCard>
         </View>
       </KeyboardAvoidingView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/wallets/import.js
+++ b/screen/wallets/import.js
@@ -8,7 +8,6 @@ import {
   BlueFormMultiInput,
   BlueSpacing20,
   BlueText,
-  SafeBlueArea,
 } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import Privacy from '../../blue_modules/Privacy';
@@ -17,6 +16,7 @@ import { BlueStorageContext } from '../../blue_modules/storage-context';
 import { requestCameraAuthorization } from '../../helpers/scan-qr';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
+import SafeArea from '../../components/SafeArea';
 
 const WalletsImport = () => {
   const navigation = useNavigation();
@@ -146,7 +146,7 @@ const WalletsImport = () => {
   );
 
   return (
-    <SafeBlueArea style={styles.root}>
+    <SafeArea style={styles.root}>
       <BlueSpacing20 />
       <TouchableWithoutFeedback accessibilityRole="button" onPress={speedBackdoorTap} testID="SpeedBackdoor">
         <BlueFormLabel>{loc.wallets.import_explanation}</BlueFormLabel>
@@ -186,7 +186,7 @@ const WalletsImport = () => {
           />
         ),
       })}
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/wallets/importCustomDerivationPath.js
+++ b/screen/wallets/importCustomDerivationPath.js
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState, useRef, useMemo } from 'react';
 import { FlatList, StyleSheet, TextInput, View } from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 
-import { BlueFormLabel, BlueSpacing20, BlueTextCentered, SafeBlueArea } from '../../BlueComponents';
+import { BlueFormLabel, BlueSpacing20, BlueTextCentered } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import WalletToImport from '../../components/WalletToImport';
 import loc from '../../loc';
@@ -12,6 +12,7 @@ import { validateBip32 } from '../../class/wallet-import';
 import debounce from '../../blue_modules/debounce';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
+import SafeArea from '../../components/SafeArea';
 
 const WRONG_PATH = 'WRONG_PATH';
 const WALLET_FOUND = 'WALLET_FOUND';
@@ -119,7 +120,7 @@ const ImportCustomDerivationPath = () => {
   };
 
   return (
-    <SafeBlueArea style={[styles.root, stylesHook.root]}>
+    <SafeArea style={[styles.root, stylesHook.root]}>
       <BlueSpacing20 />
       <BlueFormLabel>{loc.wallets.import_derivation_subtitle}</BlueFormLabel>
       <BlueSpacing20 />
@@ -149,7 +150,7 @@ const ImportCustomDerivationPath = () => {
           />
         </View>
       </View>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/wallets/importDiscovery.js
+++ b/screen/wallets/importDiscovery.js
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState, useRef, useMemo } from 'react';
 import { ActivityIndicator, Alert, FlatList, LayoutAnimation, StyleSheet, View } from 'react-native';
 import IdleTimerManager from 'react-native-idle-timer';
 import { useNavigation, useRoute } from '@react-navigation/native';
-import { BlueButtonLink, BlueFormLabel, BlueSpacing10, BlueSpacing20, SafeBlueArea } from '../../BlueComponents';
+import { BlueButtonLink, BlueFormLabel, BlueSpacing10, BlueSpacing20 } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import WalletToImport from '../../components/WalletToImport';
 import loc from '../../loc';
@@ -13,6 +13,7 @@ import prompt from '../../helpers/prompt';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
+import SafeArea from '../../components/SafeArea';
 
 const ImportWalletDiscovery = () => {
   const navigation = useNavigation();
@@ -122,7 +123,7 @@ const ImportWalletDiscovery = () => {
   const keyExtractor = w => w.id;
 
   return (
-    <SafeBlueArea style={[styles.root, stylesHook.root]}>
+    <SafeArea style={[styles.root, stylesHook.root]}>
       <BlueSpacing20 />
       <BlueFormLabel>{loc.wallets.import_discovery_subtitle}</BlueFormLabel>
       <BlueSpacing20 />
@@ -161,13 +162,14 @@ const ImportWalletDiscovery = () => {
           />
         </View>
       </View>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 
 const styles = StyleSheet.create({
   root: {
     paddingTop: 40,
+    flex: 1,
   },
   flatListContainer: {
     marginHorizontal: 16,

--- a/screen/wallets/importSpeed.js
+++ b/screen/wallets/importSpeed.js
@@ -3,11 +3,12 @@ import { Alert, View, StyleSheet, TextInput, ActivityIndicator } from 'react-nat
 import { useNavigation } from '@react-navigation/native';
 import { HDSegwitBech32Wallet, WatchOnlyWallet } from '../../class';
 import loc from '../../loc';
-import { BlueFormLabel, BlueFormMultiInput, BlueSpacing20, SafeBlueArea } from '../../BlueComponents';
+import { BlueFormLabel, BlueFormMultiInput, BlueSpacing20 } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
+import SafeArea from '../../components/SafeArea';
 
 const WalletsImportSpeed = () => {
   const navigation = useNavigation();
@@ -72,7 +73,7 @@ const WalletsImportSpeed = () => {
   };
 
   return (
-    <SafeBlueArea style={styles.root}>
+    <SafeArea style={styles.root}>
       <BlueSpacing20 />
       <BlueFormLabel>Mnemonic</BlueFormLabel>
       <BlueSpacing20 />
@@ -86,7 +87,7 @@ const WalletsImportSpeed = () => {
         <Button testID="SpeedDoImport" title="Import" onPress={importMnemonic} />
         {loading && <ActivityIndicator />}
       </View>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/wallets/ldkViewLogs.js
+++ b/screen/wallets/ldkViewLogs.js
@@ -1,14 +1,16 @@
 import React, { useEffect, useState, useContext, useRef } from 'react';
 import { StyleSheet, View, ScrollView, TouchableOpacity } from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
-import { BlueLoading, BlueSpacing20, BlueText, SafeBlueArea } from '../../BlueComponents';
+import { Icon } from 'react-native-elements';
+
+import { BlueLoading, BlueSpacing20, BlueText } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import loc from '../../loc';
-import { Icon } from 'react-native-elements';
 import { LightningLdkWallet } from '../../class';
 import alert from '../../components/Alert';
 import { useTheme } from '../../components/themes';
+import SafeArea from '../../components/SafeArea';
 const fs = require('../../blue_modules/fs');
 
 const LdkViewLogs = () => {
@@ -109,7 +111,7 @@ const LdkViewLogs = () => {
   }
 
   return (
-    <SafeBlueArea>
+    <SafeArea>
       <ScrollView style={styles.root}>
         <TouchableOpacity accessibilityRole="button" onPress={selfTest} style={styles.button}>
           <BlueText>self test</BlueText>
@@ -127,7 +129,7 @@ const LdkViewLogs = () => {
 
         <BlueText>{logs}</BlueText>
       </ScrollView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/wallets/pleaseBackup.tsx
+++ b/screen/wallets/pleaseBackup.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState, useCallback, useContext } from 'react';
 import { ActivityIndicator, View, BackHandler, Text, ScrollView, StyleSheet, I18nManager } from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 
-import { SafeBlueArea } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import Privacy from '../../blue_modules/Privacy';
 import loc from '../../loc';
@@ -10,6 +9,7 @@ import { BlueStorageContext } from '../../blue_modules/storage-context';
 import { AbstractWallet } from '../../class';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
+import SafeArea from '../../components/SafeArea';
 
 const PleaseBackup: React.FC = () => {
   const { wallets } = useContext(BlueStorageContext);
@@ -72,7 +72,7 @@ const PleaseBackup: React.FC = () => {
   };
 
   return (
-    <SafeBlueArea style={[isLoading ? styles.loading : {}, stylesHook.flex]}>
+    <SafeArea style={[isLoading ? styles.loading : {}, stylesHook.flex]}>
       {isLoading ? (
         <ActivityIndicator />
       ) : (
@@ -88,7 +88,7 @@ const PleaseBackup: React.FC = () => {
           </View>
         </ScrollView>
       )}
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/wallets/pleaseBackupLNDHub.js
+++ b/screen/wallets/pleaseBackupLNDHub.js
@@ -2,7 +2,7 @@ import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { View, StyleSheet, ScrollView, BackHandler } from 'react-native';
 
-import { BlueCopyTextToClipboard, BlueSpacing20, BlueTextCentered, SafeBlueArea } from '../../BlueComponents';
+import { BlueCopyTextToClipboard, BlueSpacing20, BlueTextCentered } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import Privacy from '../../blue_modules/Privacy';
 import loc from '../../loc';
@@ -10,6 +10,7 @@ import { BlueStorageContext } from '../../blue_modules/storage-context';
 import QRCodeComponent from '../../components/QRCodeComponent';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
+import SafeArea from '../../components/SafeArea';
 
 const PleaseBackupLNDHub = () => {
   const { wallets } = useContext(BlueStorageContext);
@@ -52,7 +53,7 @@ const PleaseBackupLNDHub = () => {
     setQRCodeSize(height > width ? width - 40 : e.nativeEvent.layout.width / 1.5);
   };
   return (
-    <SafeBlueArea style={styles.root} onLayout={onLayout}>
+    <SafeArea style={styles.root} onLayout={onLayout}>
       <ScrollView centerContent contentContainerStyle={styles.scrollViewContent}>
         <View>
           <BlueTextCentered>{loc.pleasebackup.text_lnd}</BlueTextCentered>
@@ -64,7 +65,7 @@ const PleaseBackupLNDHub = () => {
         <BlueSpacing20 />
         <Button onPress={pop} title={loc.pleasebackup.ok_lnd} />
       </ScrollView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/wallets/pleaseBackupLdk.js
+++ b/screen/wallets/pleaseBackupLdk.js
@@ -2,13 +2,14 @@ import React, { useCallback, useContext, useEffect } from 'react';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { View, useWindowDimensions, StyleSheet, BackHandler, ScrollView } from 'react-native';
 import QRCode from 'react-native-qrcode-svg';
-import { BlueCopyTextToClipboard, BlueSpacing20, BlueTextCentered, SafeBlueArea } from '../../BlueComponents';
+import { BlueCopyTextToClipboard, BlueSpacing20, BlueTextCentered } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import Privacy from '../../blue_modules/Privacy';
 import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
+import SafeArea from '../../components/SafeArea';
 
 const PleaseBackupLdk = () => {
   const { wallets } = useContext(BlueStorageContext);
@@ -50,7 +51,7 @@ const PleaseBackupLdk = () => {
 
   const pop = () => navigation.getParent().pop();
   return (
-    <SafeBlueArea style={styles.root}>
+    <SafeArea style={styles.root}>
       <ScrollView centerContent contentContainerStyle={styles.scrollViewContent}>
         <View>
           <BlueTextCentered>Please save this wallet backup. It allows you to restore all your channels on other device.</BlueTextCentered>
@@ -73,7 +74,7 @@ const PleaseBackupLdk = () => {
         <BlueSpacing20 />
         <Button onPress={pop} title={loc.pleasebackup.ok_lnd} />
       </ScrollView>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/wallets/provideEntropy.js
+++ b/screen/wallets/provideEntropy.js
@@ -5,11 +5,12 @@ import { Dimensions, PixelRatio, View, ScrollView, Text, Image, TouchableOpacity
 import { Icon } from 'react-native-elements';
 import { useNavigation, useRoute } from '@react-navigation/native';
 
+import loc from '../../loc';
 import { BlueCurrentTheme, useTheme } from '../../components/themes';
 import { FContainer, FButton } from '../../components/FloatButtons';
-import { BlueSpacing20, SafeBlueArea, BlueTabs } from '../../BlueComponents';
+import { BlueSpacing20, BlueTabs } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
-import loc from '../../loc';
+import SafeArea from '../../components/SafeArea';
 
 const ENTROPY_LIMIT = 256;
 
@@ -235,7 +236,7 @@ const Entropy = () => {
   bits = ' '.repeat(bits.length < 3 ? 3 - bits.length : 0) + bits;
 
   return (
-    <SafeBlueArea>
+    <SafeArea>
       <BlueSpacing20 />
       <TouchableOpacity accessibilityRole="button" onPress={() => setShow(!show)}>
         <View style={[styles.entropy, stylesHook.entropy]}>
@@ -267,7 +268,7 @@ const Entropy = () => {
       {tab === 2 && <Dice sides={20} push={push} />}
 
       <Buttons pop={pop} save={save} colors={colors} />
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/wallets/selectWallet.js
+++ b/screen/wallets/selectWallet.js
@@ -3,7 +3,7 @@ import { View, ActivityIndicator, Image, Text, TouchableOpacity, I18nManager, Fl
 import LinearGradient from 'react-native-linear-gradient';
 import { useRoute, useNavigation, useNavigationState } from '@react-navigation/native';
 
-import { SafeBlueArea, BlueText, BlueSpacing20, BluePrivateBalance } from '../../BlueComponents';
+import { BlueText, BlueSpacing20, BluePrivateBalance } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import WalletGradient from '../../class/wallet-gradient';
 import loc, { formatBalance, transactionTimeToReadable } from '../../loc';
@@ -11,6 +11,7 @@ import { LightningLdkWallet, MultisigHDWallet, LightningCustodianWallet } from '
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import { useTheme } from '../../components/themes';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
+import SafeArea from '../../components/SafeArea';
 
 const SelectWallet = () => {
   const { chainType, onWalletSelect, availableWallets, noWalletExplanationText } = useRoute().params;
@@ -190,19 +191,19 @@ const SelectWallet = () => {
     );
   } else if (data.length <= 0) {
     return (
-      <SafeBlueArea>
+      <SafeArea>
         <View style={styles.noWallets}>
           <BlueText style={styles.center}>{loc.wallets.select_no_bitcoin}</BlueText>
           <BlueSpacing20 />
           <BlueText style={styles.center}>{noWalletExplanationText || loc.wallets.select_no_bitcoin_exp}</BlueText>
         </View>
-      </SafeBlueArea>
+      </SafeArea>
     );
   } else {
     return (
-      <SafeBlueArea>
+      <SafeArea>
         <FlatList extraData={data} data={data} renderItem={renderItem} keyExtractor={(_item, index) => `${index}`} />
-      </SafeBlueArea>
+      </SafeArea>
     );
   }
 };

--- a/screen/wallets/signVerify.js
+++ b/screen/wallets/signVerify.js
@@ -14,13 +14,14 @@ import {
 import { useRoute } from '@react-navigation/native';
 import { Icon } from 'react-native-elements';
 import Share from 'react-native-share';
-import { BlueDoneAndDismissKeyboardInputAccessory, BlueFormLabel, BlueSpacing10, BlueSpacing20, SafeBlueArea } from '../../BlueComponents';
+import { BlueDoneAndDismissKeyboardInputAccessory, BlueFormLabel, BlueSpacing10, BlueSpacing20 } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
 import { FContainer, FButton } from '../../components/FloatButtons';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import loc from '../../loc';
 import { useTheme } from '../../components/themes';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
+import SafeArea from '../../components/SafeArea';
 
 const SignVerify = () => {
   const { colors } = useTheme();
@@ -112,7 +113,7 @@ const SignVerify = () => {
     );
 
   return (
-    <SafeBlueArea style={[styles.root, stylesHooks.root]}>
+    <SafeArea style={[styles.root, stylesHooks.root]}>
       <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
         <KeyboardAvoidingView style={[styles.root, stylesHooks.root]}>
           {!isKeyboardVisible && (
@@ -227,7 +228,7 @@ const SignVerify = () => {
           })}
         </KeyboardAvoidingView>
       </TouchableWithoutFeedback>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/screen/wallets/viewEditMultisigCosigners.js
+++ b/screen/wallets/viewEditMultisigCosigners.js
@@ -459,7 +459,6 @@ const ViewEditMultisigCosigners = () => {
     );
   };
 
-
   const hideProvideMnemonicsModal = () => {
     Keyboard.dismiss();
     setIsProvideMnemonicsModalVisible(false);

--- a/screen/wallets/xpub.js
+++ b/screen/wallets/xpub.js
@@ -1,17 +1,19 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { InteractionManager, ActivityIndicator, View, StyleSheet } from 'react-native';
 import { useFocusEffect, useRoute, useNavigation } from '@react-navigation/native';
+import Share from 'react-native-share';
+
 import navigationStyle from '../../components/navigationStyle';
-import { BlueSpacing20, SafeBlueArea, BlueText, BlueCopyTextToClipboard } from '../../BlueComponents';
+import { BlueSpacing20, BlueText, BlueCopyTextToClipboard } from '../../BlueComponents';
 import Privacy from '../../blue_modules/Privacy';
 import Biometric from '../../class/biometrics';
 import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import QRCodeComponent from '../../components/QRCodeComponent';
 import HandoffComponent from '../../components/handoff';
-import Share from 'react-native-share';
 import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
+import SafeArea from '../../components/SafeArea';
 
 const styles = StyleSheet.create({
   root: {
@@ -84,7 +86,7 @@ const WalletXpub = () => {
       <ActivityIndicator />
     </View>
   ) : (
-    <SafeBlueArea style={[styles.root, stylesHook.root]} onLayout={onLayout}>
+    <SafeArea style={[styles.root, stylesHook.root]} onLayout={onLayout}>
       <>
         <View style={styles.container}>
           {wallet && (
@@ -105,7 +107,7 @@ const WalletXpub = () => {
           <Button onPress={handleShareButtonPressed} title={loc.receive.details_share} />
         </View>
       </>
-    </SafeBlueArea>
+    </SafeArea>
   );
 };
 

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -591,6 +591,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await helperSwitchAdvancedMode();
 
     await element(by.id('WalletsList')).swipe('left', 'fast', 1); // in case emu screen is small and it doesnt fit
+    await sleep(100); // wait swipe animation to finish
     // going to Import Wallet screen and importing mnemonic
     await element(by.id('CreateAWallet')).tap();
     await element(by.id('ScrollView')).swipe('up', 'fast', 0.9); // in case emu screen is small and it doesnt fit


### PR DESCRIPTION
Replace SafeAreaView from RN with one from `react-native-safe-area-context`, that works fine on Android
Move SafeBlueArea to SafeArea component file

Before and After. Look at the Import button.

<img src="https://github.com/BlueWallet/BlueWallet/assets/155891/69b00723-a5d7-4c1a-912e-9b1eb5ca1de1" width="300">

<img src="https://github.com/BlueWallet/BlueWallet/assets/155891/98b2c448-cada-4d65-977f-7db3ce7d93b7" width="300">

