### PR TITLE
ADD: Allow importing a QR Code image from other sources

### DIFF
--- a/components/AddressInput.js
+++ b/components/AddressInput.js
@@ -82,6 +82,7 @@ const AddressInput = ({
                     launchedBy,
                     onBarScanned,
                     onBarScannerDismissWithoutData,
+                    showFileImportButton: true
                   },
                 });
               });


### PR DESCRIPTION
Perhaps you have the qr code in a private drive or a third party app (like Proton) 