### PR TITLE
FIX: Scan button on Broadcast tool

### DIFF
--- a/screen/send/broadcast.js
+++ b/screen/send/broadcast.js
@@ -22,8 +22,7 @@ import { useTheme } from '../../components/themes';
 import Button from '../../components/Button';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
 import SafeArea from '../../components/SafeArea';
-
-const scanqr = require('../../helpers/scan-qr');
+import { scanQrHelper } from '../../helpers/scan-qr';
 
 const BROADCAST_RESULT = Object.freeze({
   none: 'Input transaction hex',
@@ -77,7 +76,7 @@ const Broadcast = () => {
   };
 
   const handleQRScan = async () => {
-    const scannedData = await scanqr(navigate, name);
+    const scannedData = await scanQrHelper(navigate, name);
     if (!scannedData) return;
 
     if (scannedData.indexOf('+') === -1 && scannedData.indexOf('=') === -1 && scannedData.indexOf('=') === -1) {


### PR DESCRIPTION
If you go to **Settings -> Tools -> Broadcast transaction** and press on the **Scan or import file** button, nothing happens. The helper function for scanning QR codes changed to a named export on [#5737](https://github.com/BlueWallet/BlueWallet/pull/5737/files#diff-7772257044ad461701957c3a7542ee19127dbdb5f5de60d04f9a0f47607532edL11) and this screen wasn't updated with the new name.

![Screenshot 2024-02-14 at 13 07 30-2](https://github.com/BlueWallet/BlueWallet/assets/48102227/cf214398-2346-4d81-adbc-d71cf08da7b9)

