### PR TITLE
REF: Component cycle

### DIFF
--- a/components/TooltipMenu.ios.js
+++ b/components/TooltipMenu.ios.js
@@ -1,7 +1,6 @@
 import React, { forwardRef } from 'react';
 import { ContextMenuView, ContextMenuButton } from 'react-native-ios-context-menu';
 import PropTypes from 'prop-types';
-import QRCodeComponent from './QRCodeComponent';
 import { TouchableOpacity } from 'react-native';
 
 const ToolTipMenu = (props, ref) => {
@@ -40,8 +39,7 @@ const ToolTipMenu = (props, ref) => {
   const menuTitle = props.title ?? '';
   const isButton = !!props.isButton;
   const isMenuPrimaryAction = props.isMenuPrimaryAction ? props.isMenuPrimaryAction : false;
-  const previewQRCode = props.previewQRCode ?? false;
-  const previewValue = props.previewValue;
+  const renderPreview = props.renderPreview ?? undefined;
   const disabled = props.disabled ?? false;
 
   const buttonStyle = props.buttonStyle;
@@ -80,13 +78,13 @@ const ToolTipMenu = (props, ref) => {
           menuTitle,
           menuItems,
         }}
-        {...(previewQRCode
+        {...(renderPreview
           ? {
               previewConfig: {
                 previewType: 'CUSTOM',
                 backgroundColor: 'white',
               },
-              renderPreview: () => <QRCodeComponent value={previewValue} isMenuAvailable={false} />,
+              renderPreview,
             }
           : {})}
       >
@@ -105,13 +103,13 @@ const ToolTipMenu = (props, ref) => {
         menuTitle,
         menuItems,
       }}
-      {...(previewQRCode
+      {...(renderPreview
         ? {
             previewConfig: {
               previewType: 'CUSTOM',
               backgroundColor: 'white',
             },
-            renderPreview: () => <QRCodeComponent value={previewValue} isMenuAvailable={false} />,
+            renderPreview,
           }
         : {})}
     >
@@ -128,7 +126,7 @@ ToolTipMenu.propTypes = {
   onPressMenuItem: PropTypes.func.isRequired,
   isMenuPrimaryAction: PropTypes.bool,
   isButton: PropTypes.bool,
-  previewQRCode: PropTypes.bool,
+  renderPreview: PropTypes.element,
   onPress: PropTypes.func,
   previewValue: PropTypes.string,
   disabled: PropTypes.bool,

--- a/components/addresses/AddressItem.tsx
+++ b/components/addresses/AddressItem.tsx
@@ -15,6 +15,7 @@ import { AbstractWallet } from '../../class';
 import Biometric from '../../class/biometrics';
 import presentAlert from '../Alert';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
+import QRCodeComponent from '../QRCodeComponent';
 const confirm = require('../../helpers/confirm');
 
 interface AddressItemProps {
@@ -162,6 +163,10 @@ const AddressItem = ({ item, balanceUnit, walletID, allowSignVerifyMessage }: Ad
     return actions;
   };
 
+  const renderPreview = () => {
+    return <QRCodeComponent value={item.address} isMenuAvailable={false} />;
+  };
+
   const render = () => {
     return (
       <TooltipMenu
@@ -169,8 +174,7 @@ const AddressItem = ({ item, balanceUnit, walletID, allowSignVerifyMessage }: Ad
         ref={menuRef}
         actions={getAvailableActions()}
         onPressMenuItem={onToolTipPress}
-        previewQRCode
-        previewValue={item.address}
+        renderPreview={renderPreview}
         onPress={navigateToReceive}
       >
         <ListItem key={item.key} containerStyle={stylesHook.container}>


### PR DESCRIPTION
Require cycle: components/QRCodeComponent.tsx -> components/TooltipMenu.ios.js -> components/QRCodeComponent.tsx

Require cycles are allowed, but can result in uninitialized values. Consider refactoring to remove the need for a cycle.