### PR TITLE
FIX: Metro warning

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -4,24 +4,22 @@
  *
  * @format
  */
-const path = require('path');
-const exclusionList = require('metro-config/src/defaults/exclusionList');
 
-module.exports = {
-  resolver: {
-    blockList: exclusionList([
-      // This stops "react-native run-windows" from causing the metro server to crash if its already running
-      new RegExp(`${path.resolve(__dirname, 'windows').replace(/[/\\]/g, '/')}.*`),
-      // This prevents "react-native run-windows" from hitting: EBUSY: resource busy or locked, open msbuild.ProjectImports.zip
-      /.*\.ProjectImports\.zip/,
-    ]),
-  },
-  transformer: {
-    getTransformOptions: async () => ({
-      transform: {
-        experimentalImportSupport: false,
-        inlineRequires: true,
-      },
-    }),
-  },
+const { getDefaultConfig } = require('@react-native/metro-config');
+
+// Get the default Metro configuration.
+const defaultConfig = getDefaultConfig(__dirname);
+
+// If you have transformer settings to modify, you can do that here:
+defaultConfig.transformer = {
+  ...defaultConfig.transformer,
+  getTransformOptions: async () => ({
+    transform: {
+      experimentalImportSupport: false,
+      inlineRequires: true,
+    },
+  }),
 };
+
+// Export the updated configuration.
+module.exports = defaultConfig;


### PR DESCRIPTION
> node node_modules/react-native/local-cli/cli.js start --reset-cache

warn From React Native 0.72, your metro.config.js file should extend'@react-native/metro-config'. Please see the React Native 0.72 changelog, or copy the template at:
https://github.com/facebook/react-native/blob/main/packages/react-native/template/metro.config.js
warn Falling back to internal defaults.



This PR updates the metro config file to comply with the changes