### PR TITLE
FIX: Dont allow gesture dismiss cause the discard listener can break …

### DIFF
--- a/Navigation.tsx
+++ b/Navigation.tsx
@@ -592,7 +592,7 @@ const Navigation = () => {
       <RootStack.Screen
         name="ViewEditMultisigCosignersRoot"
         component={ViewEditMultisigCosignersRoot}
-        options={{ ...NavigationDefaultOptions, ...StatusBarLightOptions }}
+        options={{ ...NavigationDefaultOptions, ...StatusBarLightOptions, gestureEnabled: false, fullScreenGestureEnabled: false }}
       />
       <RootStack.Screen
         name="WalletXpubRoot"


### PR DESCRIPTION
…the stack"

" ERROR  The screen 'ViewEditMultisigCosignersRoot' was removed natively but didn't get removed from JS state. This can happen if the action was prevented in a 'beforeRemove' listener, which is not fully supported in native-stack.
"