### PR TITLE
FIX:  Wallet shadow set to wrong view

### DIFF
--- a/components/WalletsCarousel.js
+++ b/components/WalletsCarousel.js
@@ -101,7 +101,6 @@ const iStyles = StyleSheet.create({
     padding: 15,
     borderRadius: 12,
     minHeight: 164,
-    elevation: 5,
   },
   image: {
     width: 99,
@@ -134,6 +133,20 @@ const iStyles = StyleSheet.create({
     fontWeight: 'bold',
     writingDirection: I18nManager.isRTL ? 'rtl' : 'ltr',
     fontSize: 16,
+  },
+  shadowContainer: {
+    ...Platform.select({
+      ios: {
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 25 / 100,
+        shadowRadius: 8,
+        borderRadius: 12,
+      },
+      android: {
+        elevation: 8,
+        borderRadius: 12,
+      },
+    }),
   },
 });
 
@@ -183,9 +196,6 @@ export const WalletCarouselItem = ({ item, _, onPress, handleLongPress, isSelect
         isLargeScreen ? iStyles.rootLargeDevice : customStyle ?? { ...iStyles.root, width: itemWidth },
         { opacity, transform: [{ scale: scaleValue }] },
       ]}
-      shadowOpacity={25 / 100}
-      shadowOffset={{ width: 0, height: 3 }}
-      shadowRadius={8}
     >
       <Pressable
         accessibilityRole="button"
@@ -200,33 +210,35 @@ export const WalletCarouselItem = ({ item, _, onPress, handleLongPress, isSelect
           }, 50);
         }}
       >
-        <LinearGradient shadowColor={colors.shadowColor} colors={WalletGradient.gradientsFor(item.type)} style={iStyles.grad}>
-          <Image source={image} style={iStyles.image} />
-          <Text style={iStyles.br} />
-          <Text numberOfLines={1} style={[iStyles.label, { color: colors.inverseForegroundColor }]}>
-            {item.getLabel()}
-          </Text>
-          {item.hideBalance ? (
-            <BluePrivateBalance />
-          ) : (
-            <Text
-              numberOfLines={1}
-              key={balance} // force component recreation on balance change. To fix right-to-left languages, like Farsi
-              adjustsFontSizeToFit
-              style={[iStyles.balance, { color: colors.inverseForegroundColor }]}
-            >
-              {balance}
+        <View style={[iStyles.shadowContainer, { backgroundColor: colors.background, shadowColor: colors.shadowColor }]}>
+          <LinearGradient colors={WalletGradient.gradientsFor(item.type)} style={iStyles.grad}>
+            <Image source={image} style={iStyles.image} />
+            <Text style={iStyles.br} />
+            <Text numberOfLines={1} style={[iStyles.label, { color: colors.inverseForegroundColor }]}>
+              {item.getLabel()}
             </Text>
-          )}
-          <Text style={iStyles.br} />
-          <Text numberOfLines={1} style={[iStyles.latestTx, { color: colors.inverseForegroundColor }]}>
-            {loc.wallets.list_latest_transaction}
-          </Text>
+            {item.hideBalance ? (
+              <BluePrivateBalance />
+            ) : (
+              <Text
+                numberOfLines={1}
+                key={balance} // force component recreation on balance change. To fix right-to-left languages, like Farsi
+                adjustsFontSizeToFit
+                style={[iStyles.balance, { color: colors.inverseForegroundColor }]}
+              >
+                {balance}
+              </Text>
+            )}
+            <Text style={iStyles.br} />
+            <Text numberOfLines={1} style={[iStyles.latestTx, { color: colors.inverseForegroundColor }]}>
+              {loc.wallets.list_latest_transaction}
+            </Text>
 
-          <Text numberOfLines={1} style={[iStyles.latestTxTime, { color: colors.inverseForegroundColor }]}>
-            {latestTransactionText}
-          </Text>
-        </LinearGradient>
+            <Text numberOfLines={1} style={[iStyles.latestTxTime, { color: colors.inverseForegroundColor }]}>
+              {latestTransactionText}
+            </Text>
+          </LinearGradient>
+        </View>
       </Pressable>
     </Animated.View>
   );
@@ -318,7 +330,7 @@ const WalletsCarousel = forwardRef((props, ref) => {
       showsHorizontalScrollIndicator={false}
       initialNumToRender={10}
       ListHeaderComponent={ListHeaderComponent}
-      style={{ minHeight: sliderHeight + 9 }}
+      style={{ minHeight: sliderHeight + 12 }}
       onScrollToIndexFailed={onScrollToIndexFailed}
       {...props}
     />


### PR DESCRIPTION
 WARN  (ADVICE) View #199 of type RCTView has a shadow set but cannot calculate shadow efficiently. Consider setting a background color to fix this, or apply the shadow to a more specific component.
 WARN  (ADVICE) View #163 of type RCTView has a shadow set but cannot calculate shadow efficiently. Consider setting a background color to fix this, or apply the shadow to a more specific component.
 WARN  (ADVICE) View #125 of type RCTView has a shadow set but cannot calculate shadow efficiently. Consider setting a background color to fix this, or apply the shadow to a more specific component.

LinearGradient shouldn't draw shadows.