### PR TITLE
FIX: errors when working with multisig seeds with passphrases 

### DIFF
--- a/screen/wallets/ViewEditMultisigCosigners.tsx
+++ b/screen/wallets/ViewEditMultisigCosigners.tsx
@@ -78,7 +78,7 @@ const ViewEditMultisigCosigners = ({ route }: Props) => {
   const [exportString, setExportString] = useState('{}'); // used in exportCosigner()
   const [exportStringURv2, setExportStringURv2] = useState(''); // used in QR
   const [exportFilename, setExportFilename] = useState('bw-cosigner.json');
-  const [vaultKeyData, setVaultKeyData] = useState({ keyIndex: 1, xpub: '', seed: '', path: '', fp: '', isLoading: false }); // string rendered in modal
+  const [vaultKeyData, setVaultKeyData] = useState({ keyIndex: 1, xpub: '', seed: '', passphrase: '', path: '', fp: '', isLoading: false }); // string rendered in modal
   const [askPassphrase, setAskPassphrase] = useState(false);
   const [isAdvancedModeEnabledRender, setIsAdvancedModeEnabledRender] = useState(false);
   const data = useRef<any[]>();
@@ -275,6 +275,9 @@ const ViewEditMultisigCosigners = ({ route }: Props) => {
                 entries={vaultKeyData.seed.split(' ')}
                 appendNumber
               />
+              {vaultKeyData.passphrase.length > 1 && (
+                <Text style={[styles.textDestination, stylesHook.textDestination]}>{vaultKeyData.passphrase}</Text>
+              )}
             </>
           )}
           <BlueSpacing20 />
@@ -344,6 +347,7 @@ const ViewEditMultisigCosigners = ({ route }: Props) => {
                     setVaultKeyData({
                       keyIndex,
                       seed: '',
+                      passphrase: '',
                       xpub,
                       fp,
                       path,
@@ -385,12 +389,14 @@ const ViewEditMultisigCosigners = ({ route }: Props) => {
                   onPress: () => {
                     const keyIndex = el.index + 1;
                     const seed = wallet.getCosigner(keyIndex);
+                    const passphrase = wallet.getCosignerPassphrase(keyIndex);
                     setVaultKeyData({
                       keyIndex,
                       seed,
                       xpub: '',
                       fp: '',
                       path: '',
+                      passphrase: passphrase ?? '',
                       isLoading: false,
                     });
                     setIsMnemonicsModalVisible(true);
@@ -400,7 +406,7 @@ const ViewEditMultisigCosigners = ({ route }: Props) => {
                       presentAlert({ message: 'Cannot find derivation path for this cosigner' });
                       return;
                     }
-                    const xpub = wallet.convertXpubToMultisignatureXpub(MultisigHDWallet.seedToXpub(seed, path));
+                    const xpub = wallet.convertXpubToMultisignatureXpub(MultisigHDWallet.seedToXpub(seed, path, passphrase));
                     setExportString(MultisigCosigner.exportToJson(fp, xpub, path));
                     setExportStringURv2(encodeUR(MultisigCosigner.exportToJson(fp, xpub, path))[0]);
                     setExportFilename('bw-cosigner-' + fp + '.json');

--- a/screen/wallets/addMultisigStep2.js
+++ b/screen/wallets/addMultisigStep2.js
@@ -191,7 +191,6 @@ const WalletsAddMultisigStep2 = () => {
       setIsLoading(true);
       setIsMnemonicsModalVisible(true);
 
-      // filling cache
       setTimeout(() => {
         // filling cache
         setXpubCacheForMnemonics(w.getSecret());
@@ -229,7 +228,7 @@ const WalletsAddMultisigStep2 = () => {
     } else {
       const path = getPath();
 
-      const xpub = getXpubCacheForMnemonics(cosigner[0]);
+      const xpub = getXpubCacheForMnemonics(cosigner[0], cosigner[3]);
       const fp = getFpCacheForMnemonics(cosigner[0], cosigner[3]);
       setCosignerXpub(MultisigCosigner.exportToJson(fp, xpub, path));
       setCosignerXpubURv2(encodeUR(MultisigCosigner.exportToJson(fp, xpub, path))[0]);
@@ -238,17 +237,17 @@ const WalletsAddMultisigStep2 = () => {
     }
   };
 
-  const getXpubCacheForMnemonics = seed => {
+  const getXpubCacheForMnemonics = (seed, passphrase) => {
     const path = getPath();
-    return staticCache[seed + path] || setXpubCacheForMnemonics(seed);
+    return staticCache[seed + path + passphrase] || setXpubCacheForMnemonics(seed, passphrase);
   };
 
-  const setXpubCacheForMnemonics = seed => {
+  const setXpubCacheForMnemonics = (seed, passphrase) => {
     const path = getPath();
     const w = new MultisigHDWallet();
     w.setDerivationPath(path);
-    staticCache[seed + path] = w.convertXpubToMultisignatureXpub(MultisigHDWallet.seedToXpub(seed, path));
-    return staticCache[seed + path];
+    staticCache[seed + path + passphrase] = w.convertXpubToMultisignatureXpub(MultisigHDWallet.seedToXpub(seed, path, passphrase));
+    return staticCache[seed + path + passphrase];
   };
 
   const getFpCacheForMnemonics = (seed, passphrase) => {

--- a/tests/unit/multisig-hd-wallet.test.js
+++ b/tests/unit/multisig-hd-wallet.test.js
@@ -1951,6 +1951,59 @@ describe('multisig-wallet (native segwit)', () => {
     assert.strictEqual(w.getCosignerPassphrase(3), w2.getCosignerPassphrase(3));
   });
 
+  it('can work with passphrases when seeds are the same but passwords differ', () => {
+    // test case from https://github.com/BlueWallet/BlueWallet/issues/3665#issuecomment-907377442
+    const path = "m/48'/0'/0'/2'";
+    const w = new MultisigHDWallet();
+    w.addCosigner(
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+      undefined,
+      undefined,
+      '1',
+    );
+    w.addCosigner(
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+      undefined,
+      undefined,
+      '2',
+    );
+    w.setDerivationPath(path);
+    w.setM(2);
+
+    assert.strictEqual(w.getCosignerPassphrase(1), '1');
+    assert.strictEqual(w.getCosignerPassphrase(2), '2');
+
+    assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1qhlxgpu8deq24p3hgyh0f9zkj3uxzg2hcs4ccfy65cr9fg8vm30tqdlssmv');
+
+    assert.strictEqual(
+      w.convertXpubToMultisignatureXpub(
+        MultisigHDWallet.seedToXpub(w.getCosigner(1), w.getCustomDerivationPathForCosigner(1), w.getCosignerPassphrase(1)),
+      ),
+      'Zpub74GDyQuS45cpaH8C24Mfrk3Kvrtw78ZtX918Wj4T7dBQSW5BMcxiJAYh95Upjf9ywSbzomNf1SqVrzeZLpwxBjH488uWNaFWkXv1B93HRe7',
+    );
+
+    //
+
+    const w2 = new MultisigHDWallet();
+    w2.setSecret(w.getSecret());
+
+    assert.strictEqual(w._getExternalAddressByIndex(0), w2._getExternalAddressByIndex(0));
+    assert.strictEqual(w._getExternalAddressByIndex(1), w2._getExternalAddressByIndex(1));
+    assert.strictEqual(w.getCosignerPassphrase(1), w2.getCosignerPassphrase(1));
+    assert.strictEqual(w.getCosignerPassphrase(2), w2.getCosignerPassphrase(2));
+
+    const w3coordinator = new MultisigHDWallet();
+    w3coordinator.setSecret(w.getXpub());
+    assert.strictEqual(w3coordinator.getFingerprint(1), '126CF4F5');
+    assert.strictEqual(
+      w3coordinator.getCosigner(1),
+      'Zpub74GDyQuS45cpaH8C24Mfrk3Kvrtw78ZtX918Wj4T7dBQSW5BMcxiJAYh95Upjf9ywSbzomNf1SqVrzeZLpwxBjH488uWNaFWkXv1B93HRe7',
+    );
+
+    assert.strictEqual(w._getExternalAddressByIndex(0), w3coordinator._getExternalAddressByIndex(0));
+    assert.strictEqual(w._getInternalAddressByIndex(0), w3coordinator._getInternalAddressByIndex(0));
+  });
+
   it('can import descriptor from Sparrow', () => {
     const payload =
       'UR:CRYPTO-OUTPUT/TAADMETAADMSOEADAOAOLSTAADDLOLAOWKAXHDCLAOCEBDFLNNTKJTIOJSFSURBNFXRPEEHKDLGYRTEMRPYTGYZOCASWENCYMKPAVWJKHYAAHDCXJEFTGSZOIMFEYNDYHYZEJTBAMSJEHLDSRDDIYLSRFYTSZTKNRNYLRNDPAMTLDPZCAHTAADEHOEADAEAOAEAMTAADDYOTADLOCSDYYKAEYKAEYKAOYKAOCYUOHFJPKOAXAAAYCYCSYASAVDTAADDLOLAOWKAXHDCLAXMSZTWZDIGERYDKFSFWTYDPFNDKLNAYSWTTMUHYZTOXHSETPEWSFXPEAYWLJSDEMTAAHDCXSPLTSTDPNTLESANSUTTLPRPFHNVSPFCNMHESOYGASTLRPYVAATNNDKFYHLQZPKLEAHTAADEHOEADAEAOAEAMTAADDYOTADLOCSDYYKAEYKAEYKAOYKAOCYWZFEPLETAXAAAYCYCPCKRENBTAADDLOLAOWKAXHDCLAOLSFWYKYLKTFHJLPYEMGLCEDPFNSNRDDSRFASEOZTGWIALFLUIYDNFXHGVESFEMMEAAHDCXHTZETLJNKPHHAYLSCXWPNDSWPSTPGTEOJKKGHDAELSKPNNBKBSYAWZJTFWNNBDKTAHTAADEHOEADAEAOAEAMTAADDYOTADLOCSDYYKAEYKAEYKAOYKAOCYSKTPJPMSAXAAAYCYCEBKWLAMTDWZGRZE\n';


### PR DESCRIPTION
* Passphrases werenr taken into account when offering to share cosigners xpubs
* incorrect xpubs were taken when deriving addresses in multisig when  cosigners have same seeds BUT different passphrases (cosigners were looked up by seed)