### PR TITLE
FIX: Make value text grow on TransactionListItem.

### DIFF
--- a/components/ListItem.tsx
+++ b/components/ListItem.tsx
@@ -56,6 +56,9 @@ const ListItem: React.FC<ListItemProps> = React.memo(props => {
       fontWeight: '400',
       fontSize: 14,
     },
+    rightTitleContainer: {
+      flex: 1,
+    },
     containerStyle: {
       backgroundColor: colors.background,
     },
@@ -94,7 +97,7 @@ const ListItem: React.FC<ListItemProps> = React.memo(props => {
         )}
       </RNElementsListItem.Content>
       {props.rightTitle && (
-        <RNElementsListItem.Content right>
+        <RNElementsListItem.Content right style={stylesHook.rightTitleContainer}>
           <RNElementsListItem.Title style={props.rightTitleStyle} numberOfLines={0} right>
             {props.rightTitle}
           </RNElementsListItem.Title>

--- a/components/TransactionListItem.tsx
+++ b/components/TransactionListItem.tsx
@@ -117,7 +117,6 @@ export const TransactionListItem: React.FC<TransactionListItemProps> = React.mem
       fontSize: 14,
       fontWeight: '600',
       textAlign: 'right',
-      width: 96,
     };
   }, [item, colors.foregroundColor, colors.successColor]);
 


### PR DESCRIPTION
I modified some styles so that the Bitcoin quantity in the transaction list does not wrap even when the text size is increased in the iPhone settings.  
Below screenshots are captured on iPhone 13 Mini with maximized text size setting.

|  master branch | this PR  |
|---|---|
|  ![Simulator Screenshot - iPhone 13 mini - 2024-05-07 at 02 33 16](https://github.com/BlueWallet/BlueWallet/assets/5436405/1dd5316b-150d-4961-9e47-c29006c713dc) | ![Simulator Screenshot - iPhone 13 mini - 2024-05-07 at 02 30 42](https://github.com/BlueWallet/BlueWallet/assets/5436405/833ef77d-8e55-424c-a7b2-cfe9eabb88e8) |