### PR TITLE
fix: upgrade slip39 dependency

### DIFF
--- a/class/wallets/slip39-wallets.ts
+++ b/class/wallets/slip39-wallets.ts
@@ -1,6 +1,6 @@
 import createHash from 'create-hash';
 import slip39 from 'slip39';
-import { WORD_LIST } from 'slip39/dist/slip39_helper';
+import { WORD_LIST } from 'slip39/src/slip39_helper';
 
 import { HDLegacyP2PKHWallet } from './hd-legacy-p2pkh-wallet';
 import { HDSegwitBech32Wallet } from './hd-segwit-bech32-wallet';

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
         "rn-nodeify": "10.3.0",
         "scryptsy": "2.1.0",
         "silent-payments": "github:BlueWallet/SilentPayments#7ac4d17",
-        "slip39": "https://github.com/BlueWallet/slip39-js",
+        "slip39": "https://github.com/BlueWallet/slip39-js#d316ee6",
         "stream-browserify": "3.0.0",
         "url": "0.11.3",
         "wif": "2.0.6"
@@ -21093,8 +21093,8 @@
       }
     },
     "node_modules/slip39": {
-      "version": "0.1.7",
-      "resolved": "git+ssh://git@github.com/BlueWallet/slip39-js.git#35619ed112fa022de1f5a3b6e2996dd3025472b2",
+      "version": "0.1.9",
+      "resolved": "git+ssh://git@github.com/BlueWallet/slip39-js.git#d316ee6a929ab645fe5462ef1c91720eb66889c8",
       "license": "MIT"
     },
     "node_modules/source-map": {
@@ -38395,8 +38395,8 @@
       }
     },
     "slip39": {
-      "version": "git+ssh://git@github.com/BlueWallet/slip39-js.git#35619ed112fa022de1f5a3b6e2996dd3025472b2",
-      "from": "slip39@https://github.com/BlueWallet/slip39-js"
+      "version": "git+ssh://git@github.com/BlueWallet/slip39-js.git#d316ee6a929ab645fe5462ef1c91720eb66889c8",
+      "from": "slip39@https://github.com/BlueWallet/slip39-js#d316ee6"
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "rn-nodeify": "10.3.0",
     "scryptsy": "2.1.0",
     "silent-payments": "github:BlueWallet/SilentPayments#7ac4d17",
-    "slip39": "https://github.com/BlueWallet/slip39-js",
+    "slip39": "https://github.com/BlueWallet/slip39-js#d316ee6",
     "stream-browserify": "3.0.0",
     "url": "0.11.3",
     "wif": "2.0.6"

--- a/typings/slip39.d.ts
+++ b/typings/slip39.d.ts
@@ -3,6 +3,6 @@ declare module 'slip39' {
   export function validateMnemonic(mnemonic: string): boolean;
 }
 
-declare module 'slip39/dist/slip39_helper' {
+declare module 'slip39/src/slip39_helper' {
   export const WORD_LIST: string[];
 }


### PR DESCRIPTION
React native now has native BigInt support. We don't have to maintain our slip39-js fork anymore.
Also new version now includes "extendable backup flag" feature

closes #6603