### PR TITLE
fix: TS localization vocabulary

### DIFF
--- a/components/TransactionListItem.tsx
+++ b/components/TransactionListItem.tsx
@@ -73,7 +73,7 @@ export const TransactionListItem: React.FC<TransactionListItemProps> = React.mem
     if (sub !== '') sub += ' ';
     sub += txMemo;
     if (item.memo) sub += item.memo;
-    return sub || null;
+    return sub || undefined;
   }, [txMemo, item.confirmations, item.memo]);
 
   const rowTitle = useMemo(() => {
@@ -87,7 +87,7 @@ export const TransactionListItem: React.FC<TransactionListItemProps> = React.mem
 
       if (invoiceExpiration > now) {
         return formatBalanceWithoutSuffix(item.value && item.value, itemPriceUnit, true).toString();
-      } else if (invoiceExpiration < now) {
+      } else {
         if (item.ispaid) {
           return formatBalanceWithoutSuffix(item.value && item.value, itemPriceUnit, true).toString();
         } else {
@@ -249,7 +249,7 @@ export const TransactionListItem: React.FC<TransactionListItemProps> = React.mem
 
   const handleOnCopyAmountTap = useCallback(() => Clipboard.setString(rowTitle.replace(/[\s\\-]/g, '')), [rowTitle]);
   const handleOnCopyTransactionID = useCallback(() => Clipboard.setString(item.hash), [item.hash]);
-  const handleOnCopyNote = useCallback(() => Clipboard.setString(subtitle), [subtitle]);
+  const handleOnCopyNote = useCallback(() => Clipboard.setString(subtitle ?? ''), [subtitle]);
   const handleOnViewOnBlockExplorer = useCallback(() => {
     const url = `https://mempool.space/tx/${item.hash}`;
     Linking.canOpenURL(url).then(supported => {

--- a/navigation/SendDetailsStack.tsx
+++ b/navigation/SendDetailsStack.tsx
@@ -22,7 +22,7 @@ const Stack = createNativeStackNavigator<SendDetailsStackParamList>();
 
 const SendDetailsStack = () => {
   const theme = useTheme();
-  const DetailsButton = useMemo(() => <HeaderRightButton testID="Save" disabled={true} title={loc.wallets.create_details} />, []);
+  const DetailsButton = useMemo(() => <HeaderRightButton testID="Save" disabled={true} title={loc.send.create_details} />, []);
 
   return (
     <Stack.Navigator initialRouteName="SendDetails" screenOptions={{ headerShadowVisible: false }}>

--- a/screen/settings/EncryptStorage.tsx
+++ b/screen/settings/EncryptStorage.tsx
@@ -195,7 +195,7 @@ const EncryptStorage = () => {
     return isCapable ? (
       <>
         <BlueText />
-        <BlueText>{loc.formatString(loc.settings.biometrics_fail, { type: deviceBiometricType })}</BlueText>
+        <BlueText>{loc.formatString(loc.settings.biometrics_fail, { type: deviceBiometricType! })}</BlueText>
       </>
     ) : null;
   };
@@ -213,14 +213,14 @@ const EncryptStorage = () => {
             {loc.settings.biometrics}
           </Text>
           <ListItem
-            title={loc.formatString(loc.settings.encrypt_use, { type: deviceBiometricType })}
+            title={loc.formatString(loc.settings.encrypt_use, { type: deviceBiometricType! })}
             Component={TouchableWithoutFeedback}
             switch={{ value: biometricEnabled, onValueChange: onUseBiometricSwitch, disabled: state.currentLoadingSwitch !== null }}
             isLoading={state.currentLoadingSwitch === 'biometric' && state.isLoading}
             containerStyle={[styles.row, styleHooks.root]}
           />
           <BlueCard>
-            <BlueText>{loc.formatString(loc.settings.encrypt_use_expl, { type: deviceBiometricType })}</BlueText>
+            <BlueText>{loc.formatString(loc.settings.encrypt_use_expl, { type: deviceBiometricType! })}</BlueText>
             {renderPasscodeExplanation()}
           </BlueCard>
           <BlueSpacing20 />

--- a/screen/wallets/WalletsList.tsx
+++ b/screen/wallets/WalletsList.tsx
@@ -367,7 +367,7 @@ const WalletsList: React.FC = () => {
     const anchor = findNodeHandle(walletActionButtonsRef.current);
 
     if (anchor) {
-      options.push(anchor);
+      options.push(String(anchor));
     }
 
     ActionSheet.showActionSheetWithOptions(props, buttonIndex => {


### PR DESCRIPTION
Helps easily find mistakes in using localization strings.

<img width="731" alt="image" src="https://github.com/BlueWallet/BlueWallet/assets/155891/c25324ea-3040-46bd-bf52-9a035c15e03e">

```
❯ npx tsc
screen/wallets/WalletsList.tsx:362:32 - error TS2339: Property 'WRONG_STRING_ID' does not exist on type '{ add_bitcoin: string; add_bitcoin_explain: string; add_create: string; add_entropy_generated: string; add_entropy_provide: string; add_entropy_remain: string; add_import_wallet: string; ... 86 more ...; search_wallets: string; }'.

362       options.push(loc.wallets.WRONG_STRING_ID);
                                   ~~~~~~~~~~~~~~~


Found 1 error in screen/wallets/WalletsList.tsx:362
```