### PR TITLE
DOC: update backlog link to point to issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ MIT
 
 ## WANT TO CONTRIBUTE?
 
-Grab an issue from [the backlog](https://github.com/BlueWallet/BlueWallet/projects/1), try to start or submit a PR, any doubts we will try to guide you. Contributors have a private telegram group, request access by email bluewallet@bluewallet.io
+Grab an issue from [the backlog](https://github.com/BlueWallet/BlueWallet/issues), try to start or submit a PR, any doubts we will try to guide you. Contributors have a private telegram group, request access by email bluewallet@bluewallet.io
 
 ## Translations
 


### PR DESCRIPTION
Previously, this link in the README pointed to a Projects link which threw a 404 for me (see attached screenshot).

<img width="744" alt="Screenshot 2024-08-08 at 11 55 44" src="https://github.com/user-attachments/assets/e27ae794-7516-4331-a381-2542664963c9">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the hyperlink in the README.md to direct contributors to the issues section of the GitHub repository, enhancing clarity and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->