### PR TITLE
OPS: Remove local master branch if it exists

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -65,7 +65,7 @@ platform :ios do
 
     platform = options[:platform] || "ios" # Default to iOS if not specified
   
-    # Remove local master branch if it exists
+    # Remove local master branch if it exists (Exit status: 128 - 'fatal: a branch named 'master' already exists')
     sh("git branch -D master || true")
   
     target_to_app_identifier.each do |target, app_identifier|

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -64,6 +64,10 @@ platform :ios do
     }
 
     platform = options[:platform] || "ios" # Default to iOS if not specified
+  
+    # Remove local master branch if it exists
+    sh("git branch -D master || true")
+  
     target_to_app_identifier.each do |target, app_identifier|
       match(
         git_basic_authorization: ENV["GIT_ACCESS_TOKEN"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new command to manage local git branches by removing the `master` branch if it exists, enhancing script functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->