### PR TITLE
FIX: Blur toggle inversed

### DIFF
--- a/screen/settings/SettingsPrivacy.tsx
+++ b/screen/settings/SettingsPrivacy.tsx
@@ -92,7 +92,7 @@ const SettingsPrivacy: React.FC = () => {
 
   const onTemporaryScreenshotsValueChange = (value: boolean) => {
     setIsLoading(SettingsPrivacySection.TemporaryScreenshots);
-    setIsPrivacyBlurEnabledState(value);
+    setIsPrivacyBlurEnabledState(!value);
     setIsLoading(SettingsPrivacySection.None);
   };
 
@@ -145,17 +145,13 @@ const SettingsPrivacy: React.FC = () => {
         Component={TouchableWithoutFeedback}
         switch={{
           onValueChange: onTemporaryScreenshotsValueChange,
-          value: isPrivacyBlurEnabled,
+          value: !isPrivacyBlurEnabled,
           disabled: isLoading === SettingsPrivacySection.All,
         }}
       />
       <BlueCard>
         <BlueText>{loc.settings.privacy_temporary_screenshots_instructions}</BlueText>
       </BlueCard>
-
-      <BlueSpacing20 />
-      <ListItem title={loc.settings.privacy_system_settings} chevron onPress={openApplicationSettings} testID="PrivacySystemSettings" />
-      <BlueSpacing20 />
       <ListItem
         title={loc.settings.privacy_do_not_track}
         Component={TouchableWithoutFeedback}
@@ -186,6 +182,9 @@ const SettingsPrivacy: React.FC = () => {
           </BlueCard>
         </>
       )}
+
+      <BlueSpacing20 />
+      <ListItem title={loc.settings.privacy_system_settings} chevron onPress={openApplicationSettings} testID="PrivacySystemSettings" />
       <BlueSpacing20 />
     </ScrollView>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the temporary screenshots privacy setting to invert the behavior of the privacy blur feature.
	- Adjusted the switch component's value to reflect the new control flow for privacy options.
- **Refactor**
	- Reordered components within the `SettingsPrivacy` section for improved clarity and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->