### PR TITLE
REF: bumped transient dependency elliptic to close a vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7496,7 +7496,9 @@
       }
     },
     "node_modules/elliptic": {
-      "version": "6.5.6",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",


### PR DESCRIPTION
temporarily used `overrides` field in package to bump it and fixate in a lock file