### PR TITLE
FIX: select fee modal wouldnt use preferred unit

### DIFF
--- a/components/SelectFeeModal.tsx
+++ b/components/SelectFeeModal.tsx
@@ -2,8 +2,9 @@ import React, { useState, useRef, forwardRef, useImperativeHandle } from 'react'
 import { View, Text, TouchableOpacity, TextInput, StyleSheet, Platform } from 'react-native';
 import BottomModal, { BottomModalHandle } from './BottomModal';
 import { useTheme } from './themes';
-import loc from '../loc';
+import loc, { formatBalance } from '../loc';
 import { SecondButton } from './SecondButton';
+import { BitcoinUnit } from '../models/bitcoinUnits';
 
 interface NetworkTransactionFees {
   fastestFee: number;
@@ -33,10 +34,11 @@ interface SelectFeeModalProps {
   feeRate: number | string;
   setCustomFee: (fee: string) => void;
   setFeePrecalc: (fn: (fp: FeePrecalc) => FeePrecalc) => void;
+  feeUnit: BitcoinUnit;
 }
 
 const SelectFeeModal = forwardRef<BottomModalHandle, SelectFeeModalProps>(
-  ({ networkTransactionFees, feePrecalc, feeRate, setCustomFee, setFeePrecalc }, ref) => {
+  ({ networkTransactionFees, feePrecalc, feeRate, setCustomFee, setFeePrecalc, feeUnit }, ref) => {
     const [customFee, setCustomFeeState] = useState('');
     const feeModalRef = useRef<BottomModalHandle>(null);
     const customModalRef = useRef<BottomModalHandle>(null);
@@ -128,9 +130,7 @@ const SelectFeeModal = forwardRef<BottomModalHandle, SelectFeeModalProps>(
       },
     ];
 
-    const formatFee = (fee: number | null): string => {
-      return fee ? `${fee} sat/vB` : '';
-    };
+    const formatFee = (fee: number) => formatBalance(fee, feeUnit!, true);
 
     const handleCustomFeeSubmit = async () => {
       if (!/^\d+$/.test(customFee) || Number(customFee) <= 0) {

--- a/screen/send/SendDetails.tsx
+++ b/screen/send/SendDetails.tsx
@@ -1380,6 +1380,7 @@ const SendDetails = () => {
           feeRate={feeRate}
           setCustomFee={setCustomFee}
           setFeePrecalc={setFeePrecalc}
+          feeUnit={feeUnit || BitcoinUnit.BTC}
         />
       </View>
       <BlueDismissKeyboardInputAccessory />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction fee handling with the addition of a `feeUnit` property in the fee selection modal.
	- Improved keyboard interaction management across multiple components by replacing `KeyboardAvoidingView` with properties directly on `ScrollView` and `FlatList`.
- **Bug Fixes**
	- Streamlined user interface for input fields in the Electrum settings, improving usability and overall performance.
- **Refactor**
	- Simplified component structure and layout in various screens, improving readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->