### PR TITLE
ADD: Use defaultsource prop to pre-load wallet image on iOS.

### DIFF
--- a/components/TransactionsNavigationHeader.tsx
+++ b/components/TransactionsNavigationHeader.tsx
@@ -175,25 +175,24 @@ const TransactionsNavigationHeader: React.FC<TransactionsNavigationHeaderProps> 
         ];
   }, [wallet.hideBalance]);
 
+  const imageSource = useMemo(() => {
+    switch (wallet.type) {
+      case LightningCustodianWallet.type:
+        return I18nManager.isRTL ? require('../img/lnd-shape-rtl.png') : require('../img/lnd-shape.png');
+      case MultisigHDWallet.type:
+        return I18nManager.isRTL ? require('../img/vault-shape-rtl.png') : require('../img/vault-shape.png');
+      default:
+        return I18nManager.isRTL ? require('../img/btc-shape-rtl.png') : require('../img/btc-shape.png');
+    }
+  }, [wallet.type]);
+
   return (
     <LinearGradient
       colors={WalletGradient.gradientsFor(wallet.type)}
       style={styles.lineaderGradient}
       {...WalletGradient.linearGradientProps(wallet.type)}
     >
-      <Image
-        source={(() => {
-          switch (wallet.type) {
-            case LightningCustodianWallet.type:
-              return I18nManager.isRTL ? require('../img/lnd-shape-rtl.png') : require('../img/lnd-shape.png');
-            case MultisigHDWallet.type:
-              return I18nManager.isRTL ? require('../img/vault-shape-rtl.png') : require('../img/vault-shape.png');
-            default:
-              return I18nManager.isRTL ? require('../img/btc-shape-rtl.png') : require('../img/btc-shape.png');
-          }
-        })()}
-        style={styles.chainIcon}
-      />
+      <Image source={imageSource} defaultSource={imageSource} style={styles.chainIcon} />
 
       <Text testID="WalletLabel" numberOfLines={1} style={styles.walletLabel} selectable>
         {wallet.getLabel()}

--- a/components/WalletsCarousel.tsx
+++ b/components/WalletsCarousel.tsx
@@ -237,7 +237,7 @@ export const WalletCarouselItem: React.FC<WalletCarouselItemProps> = React.memo(
         >
           <View style={[iStyles.shadowContainer, { backgroundColor: colors.background, shadowColor: colors.shadowColor }]}>
             <LinearGradient colors={WalletGradient.gradientsFor(item.type)} style={iStyles.grad}>
-              <Image source={image} style={iStyles.image} />
+              <Image defaultSource={image} source={image} style={iStyles.image} />
               <Text style={iStyles.br} />
               <Text numberOfLines={1} style={[iStyles.label, { color: colors.inverseForegroundColor }]}>
                 {renderHighlightedText && searchQuery ? renderHighlightedText(item.getLabel(), searchQuery) : item.getLabel()}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a placeholder image in the wallet carousel while the actual image loads, enhancing visual feedback for users.
  
- **Improvements**
  - Simplified the image source calculation in the Transactions Navigation Header for better readability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->