### PR TITLE
FIX: Remove trailing slash in lightning wallet

### DIFF
--- a/class/wallets/lightning-custodian-wallet.ts
+++ b/class/wallets/lightning-custodian-wallet.ts
@@ -36,7 +36,7 @@ export class LightningCustodianWallet extends LegacyWallet {
    * @param URI
    */
   setBaseURI(URI: string | undefined) {
-    this.baseURI = URI;
+    this.baseURI = URI?.endsWith("/") ? URI.slice(0, -1) : URI;
   }
 
   getBaseURI() {
@@ -579,7 +579,7 @@ export class LightningCustodianWallet extends LegacyWallet {
   }
 
   static async isValidNodeAddress(address: string) {
-    const response = await fetch(address + '/getinfo', {
+    const response = await fetch((address?.endsWith("/") ? address.slice(0, -1) : address) + '/getinfo', {
       method: 'GET',
       headers: {
         'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION
This should resolve the issue noted in #6953 in a backwards compatible way with any existing wallets, performing the transform on baseURI and the isValidNodeAddress edge case called from lightning settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the `baseURI` and `address` parameters by standardizing URL formatting to prevent issues with trailing slashes.
  
- **Refactor**
	- Updated methods to ensure consistent URL construction, enhancing robustness during network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->