### PR TITLE
OPS: Norwegian code for fastlane is "nb"

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -309,7 +309,7 @@ lane :update_release_notes do |options|
     'it' => release_notes_text, # Italian
     'ja' => release_notes_text, # Japanese
     'ms' => release_notes_text, # Malay
-    'nb-NO' => release_notes_text, # Norwegian
+    'nb' => release_notes_text, # Norwegian
     'pl' => release_notes_text, # Polish
     'pt-BR' => release_notes_text, # Portuguese (Brazil)
     'pt-PT' => release_notes_text, # Portuguese (Portugal)


### PR DESCRIPTION

Wrong locale was used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified the language code for Norwegian in the release notes, enhancing localization for Norwegian users.
  
- **Bug Fixes**
	- Adjusted language identifier to improve consistency in how release notes are displayed for Norwegian users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->