### PR TITLE
FIX: Hide caret so its easier to type amounts

### DIFF
--- a/components/AmountInput.js
+++ b/components/AmountInput.js
@@ -264,6 +264,7 @@ class AmountInput extends Component {
                 {amount !== BitcoinUnit.MAX ? (
                   <TextInput
                     {...this.props}
+                    caretHidden
                     testID="BitcoinAmountInput"
                     keyboardType="numeric"
                     adjustsFontSizeToFit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property `caretHidden` to the `TextInput` component, enhancing the visual presentation of the input field by hiding the text caret when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->