### PR TITLE
Update Alert.ts

### DIFF
--- a/components/Alert.ts
+++ b/components/Alert.ts
@@ -26,7 +26,7 @@ const presentAlert = ({
   }
   switch (type) {
     case AlertType.Toast:
-      ToastAndroid.showWithGravity(message, ToastAndroid.LONG, ToastAndroid.BOTTOM);
+      ToastAndroid.show(message, ToastAndroid.LONG);
       break;
     default:
       RNAlert.alert(title ?? loc.alert.default, message);


### PR DESCRIPTION
E/Toast   (12400): setGravity() shouldn't be called on text toasts, the values won't be used09

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the display method for toast messages on Android, changing the positioning to a default setting, which may alter user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->