### PR TITLE
REF: subscribe to battery level instead of checking at everyt call

### DIFF
--- a/blue_modules/hapticFeedback.ts
+++ b/blue_modules/hapticFeedback.ts
@@ -1,4 +1,4 @@
-import { NativeEventEmitter, NativeModules } from 'react-native';
+import { DeviceEventEmitter } from 'react-native';
 import DeviceInfo, { PowerState } from 'react-native-device-info';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 
@@ -12,7 +12,7 @@ export const enum HapticFeedbackTypes {
   NotificationError = 'notificationError',
 }
 
-const deviceInfoEmitter = new NativeEventEmitter(NativeModules.RNDeviceInfo);
+const deviceInfoEmitter = DeviceEventEmitter;
 
 let currentPowerState: Partial<PowerState> = {
   batteryLevel: 1.0,

--- a/blue_modules/hapticFeedback.ts
+++ b/blue_modules/hapticFeedback.ts
@@ -26,11 +26,11 @@ const initializePowerStateListener = async () => {
     const initialPowerState: Partial<PowerState> = await DeviceInfo.getPowerState();
     currentPowerState = initialPowerState;
     isPowerStateInitialized = true;
-    console.log('Initial Power State:', initialPowerState);
+    console.debug('Initial Power State:', initialPowerState);
 
     deviceInfoEmitter.addListener('RNDeviceInfo_powerStateDidChange', (powerState: Partial<PowerState>) => {
       currentPowerState = powerState;
-      console.log('Power State Updated:', powerState);
+      console.debug('Power State Updated:', powerState);
     });
   } catch (error) {
     console.error('Failed to initialize power state listener:', error);
@@ -42,7 +42,7 @@ initializePowerStateListener();
 
 const triggerHapticFeedback = (type: HapticFeedbackTypes) => {
   if (!isPowerStateInitialized) {
-    console.log('Power state not initialized yet. Skipping haptic feedback.');
+    console.debug('Power state not initialized yet. Skipping haptic feedback.');
     return;
   }
 
@@ -52,7 +52,7 @@ const triggerHapticFeedback = (type: HapticFeedbackTypes) => {
       enableVibrateFallback: true,
     });
   } else {
-    console.log('Haptic feedback not triggered due to low power mode.');
+    console.debug('Haptic feedback not triggered due to low power mode.');
   }
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated device power state management into haptic feedback functionality.
	- Added a listener for power state changes to enhance feedback triggering.
- **Bug Fixes**
	- Improved error handling during power state initialization.
	- Ensured haptic feedback is only triggered when the device is not in low power mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->