### PR TITLE
feat: convert ImportCustomDerivationPath and ImportSpeed screens into Typescript

### DIFF
--- a/navigation/AddWalletStack.tsx
+++ b/navigation/AddWalletStack.tsx
@@ -67,7 +67,11 @@ const AddWalletStack = () => {
           title: loc.wallets.add_title,
         })(theme)}
       />
-      <Stack.Screen name="ImportCustomDerivationPath" component={ImportCustomDerivationPathComponent} />
+      <Stack.Screen
+        name="ImportCustomDerivationPath"
+        component={ImportCustomDerivationPathComponent}
+        options={navigationStyle({ statusBarStyle: 'light', title: loc.wallets.import_derivation_title })(theme)}
+      />
       <Stack.Screen
         name="ImportWallet"
         component={ImportWalletComponent}

--- a/navigation/LazyLoadAddWalletStack.tsx
+++ b/navigation/LazyLoadAddWalletStack.tsx
@@ -4,9 +4,9 @@ import { LazyLoadingIndicator } from './LazyLoadingIndicator';
 
 // Define lazy imports
 const WalletsAdd = lazy(() => import('../screen/wallets/Add'));
-const ImportCustomDerivationPath = lazy(() => import('../screen/wallets/importCustomDerivationPath'));
+const ImportCustomDerivationPath = lazy(() => import('../screen/wallets/ImportCustomDerivationPath'));
 const ImportWalletDiscovery = lazy(() => import('../screen/wallets/ImportWalletDiscovery'));
-const ImportSpeed = lazy(() => import('../screen/wallets/importSpeed'));
+const ImportSpeed = lazy(() => import('../screen/wallets/ImportSpeed'));
 const ImportWallet = lazy(() => import('../screen/wallets/import'));
 const PleaseBackup = lazy(() => import('../screen/wallets/PleaseBackup'));
 const PleaseBackupLNDHub = lazy(() => import('../screen/wallets/pleaseBackupLNDHub'));

--- a/screen/lnd/lnurlPay.tsx
+++ b/screen/lnd/lnurlPay.tsx
@@ -140,9 +140,7 @@ const LnurlPay: React.FC = () => {
       }
 
       const bolt11payload = await _LN.requestBolt11FromLnurlPayService(amountSats, comment);
-      // @ts-ignore fixme after lnurl.js converted to ts
       await wallet.payInvoice(bolt11payload.pr);
-      // @ts-ignore fixme after lnurl.js converted to ts
       const decoded = wallet.decodeInvoice(bolt11payload.pr);
       setPayButtonDisabled(false);
 

--- a/screen/wallets/PleaseBackup.tsx
+++ b/screen/wallets/PleaseBackup.tsx
@@ -1,18 +1,23 @@
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect } from 'react';
-import { useNavigation, useRoute } from '@react-navigation/native';
 import { BackHandler, I18nManager, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { disallowScreenshot } from 'react-native-screen-capture';
 import Button from '../../components/Button';
 import { useTheme } from '../../components/themes';
-import { disallowScreenshot } from 'react-native-screen-capture';
-import loc from '../../loc';
-import { useStorage } from '../../hooks/context/useStorage';
 import { useSettings } from '../../hooks/context/useSettings';
+import { useStorage } from '../../hooks/context/useStorage';
+import loc from '../../loc';
+import { AddWalletStackParamList } from '../../navigation/AddWalletStack';
+
+type RouteProps = RouteProp<AddWalletStackParamList, 'PleaseBackup'>;
+type NavigationProp = NativeStackNavigationProp<AddWalletStackParamList, 'PleaseBackup'>;
 
 const PleaseBackup: React.FC = () => {
   const { wallets } = useStorage();
-  const { walletID } = useRoute().params as { walletID: string };
+  const { walletID } = useRoute<RouteProps>().params;
   const wallet = wallets.find(w => w.getID() === walletID);
-  const navigation = useNavigation();
+  const navigation = useNavigation<NavigationProp>();
   const { isPrivacyBlurEnabled } = useSettings();
   const { colors } = useTheme();
 

--- a/screen/wallets/ProvideEntropy.tsx
+++ b/screen/wallets/ProvideEntropy.tsx
@@ -1,6 +1,8 @@
-import { useNavigation, useRoute } from '@react-navigation/native';
-import BN from 'bignumber.js';
 import React, { useEffect, useReducer, useState } from 'react';
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { Icon } from '@rneui/themed';
+import BN from 'bignumber.js';
 import {
   Alert,
   Dimensions,
@@ -13,15 +15,18 @@ import {
   View,
   useWindowDimensions,
 } from 'react-native';
-import { Icon } from '@rneui/themed';
 
 import { BlueSpacing20 } from '../../BlueComponents';
+import { randomBytes } from '../../class/rng';
 import { FButton, FContainer } from '../../components/FloatButtons';
 import SafeArea from '../../components/SafeArea';
 import { Tabs } from '../../components/Tabs';
 import { BlueCurrentTheme, useTheme } from '../../components/themes';
 import loc from '../../loc';
-import { randomBytes } from '../../class/rng';
+import { AddWalletStackParamList } from '../../navigation/AddWalletStack';
+
+type RouteProps = RouteProp<AddWalletStackParamList, 'ProvideEntropy'>;
+type NavigationProp = NativeStackNavigationProp<AddWalletStackParamList, 'ProvideEntropy'>;
 
 export enum EActionType {
   push = 'push',
@@ -252,11 +257,10 @@ const D20Tab = ({ active }: { active: boolean }) => {
   return <Icon name="dice-d20" type="font-awesome-5" color={active ? colors.buttonAlternativeTextColor : colors.buttonBackgroundColor} />;
 };
 
-const Entropy = () => {
+const ProvideEntropy = () => {
   const [entropy, dispatch] = useReducer(eReducer, initialState);
-  // @ts-ignore: navigation is not typed yet
-  const { onGenerated, words } = useRoute().params;
-  const navigation = useNavigation();
+  const { onGenerated, words } = useRoute<RouteProps>().params;
+  const navigation = useNavigation<NavigationProp>();
   const [tab, setTab] = useState(1);
   const [show, setShow] = useState(false);
   const { colors } = useTheme();
@@ -319,7 +323,6 @@ const Entropy = () => {
               buf = Buffer.concat([buf, random], bufLength);
             }
 
-            // @ts-ignore: navigation is not typed yet
             navigation.pop();
             onGenerated(buf);
           },
@@ -432,4 +435,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default Entropy;
+export default ProvideEntropy;


### PR DESCRIPTION
Convert screens to TS, fix couple of small TS issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced appearance of the `ImportCustomDerivationPath` screen with updated status bar style and title.
	- Improved payment handling in the `LnurlPay` component, including better error management and user feedback.

- **Improvements**
	- Added type safety for navigation and route properties across various components, including `ImportCustomDerivationPath`, `ImportSpeed`, and `PleaseBackup`.
	- Refined logic for wallet type management and error handling in the `ImportSpeed` component.
	- Enhanced structure and clarity of the `ProvideEntropy` component.

- **Bug Fixes**
	- Corrected import casing issues in the `LazyLoadAddWalletStack`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->