### PR TITLE
fix: e2e import wallet tests

### DIFF
--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -698,13 +698,14 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await element(by.id('DoImport')).tap();
     await sleep(1000);
     await element(by.text('OK')).tap();
-    await waitFor(element(by.id('Loading'))) // wait for discovery to be completed
-      .not.toExist()
-      .withTimeout(300 * 1000);
 
+    // wait for discovery to be completed
+    await waitFor(element(by.text("m/84'/0'/0'")))
+      .toBeVisible()
+      .withTimeout(300 * 1000);
     await expect(element(by.text("m/44'/0'/1'"))).toBeVisible();
     await expect(element(by.text("m/49'/0'/0'"))).toBeVisible();
-    await expect(element(by.text("m/84'/0'/0'"))).toBeVisible();
+    await expect(element(by.id('Loading'))).not.toBeVisible();
 
     // open custom derivation path screen and import the wallet
     await element(by.id('CustomDerivationPathButton')).tap();


### PR DESCRIPTION
With the recent update to the import logic, found items are now rendered one by oneinstead of  all at once. Therefore, we must wait for the last item to appear before validating all of them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced wallet management tests for improved verification of wallet discovery and import processes.
	- Updated assertions to confirm visibility of specific derivation paths, ensuring clarity and robustness in testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->