### PR TITLE
FIX: Addresses not showing on the newest version #7363

### DIFF
--- a/components/addresses/AddressItem.tsx
+++ b/components/addresses/AddressItem.tsx
@@ -77,19 +77,18 @@ const AddressItem = ({ item, balanceUnit, walletID, allowSignVerifyMessage }: Ad
   }, [navigate, walletID, item.address]);
 
   const menuActions = useMemo(
-    () =>
-      [
-        CommonToolTipActions.CopyTXID,
-        CommonToolTipActions.Share,
-        {
-          ...CommonToolTipActions.SignVerify,
-          hidden: !allowSignVerifyMessage,
-        },
-        {
-          ...CommonToolTipActions.ExportPrivateKey,
-          hidden: !allowSignVerifyMessage,
-        },
-      ].filter(action => 'hidden' in action && !action.hidden),
+    () => [
+      CommonToolTipActions.CopyTXID,
+      CommonToolTipActions.Share,
+      {
+        ...CommonToolTipActions.SignVerify,
+        hidden: !allowSignVerifyMessage,
+      },
+      {
+        ...CommonToolTipActions.ExportPrivateKey,
+        hidden: !allowSignVerifyMessage,
+      },
+    ],
     [allowSignVerifyMessage],
   );
 

--- a/typings/CommonToolTipActions.ts
+++ b/typings/CommonToolTipActions.ts
@@ -299,11 +299,13 @@ export const CommonToolTipActions = {
     id: keys.SignVerify,
     text: loc.addresses.sign_title,
     icon: icons.Signature,
+    hidden: false,
   },
   ExportPrivateKey: {
     id: keys.ExportPrivateKey,
     text: loc.addresses.copy_private_key,
     icon: icons.ExportPrivateKey,
+    hidden: false,
   },
   ResetToDefault: {
     id: keys.ResetToDefault,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `SignVerify` and `ExportPrivateKey` actions are now visible in the user interface.
	- A new action, `ResetToDefault`, has been added to the tooltips.

- **Improvements**
	- Simplified filtering logic in the `AddressItem` component for improved code structure while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->