### PR TITLE
FIX: unpaid ln invoices were rendered as paid

### DIFF
--- a/components/TransactionListItem.tsx
+++ b/components/TransactionListItem.tsx
@@ -164,6 +164,11 @@ export const TransactionListItem: React.FC<TransactionListItemProps> = React.mem
             label: loc.transactions.expired_transaction,
             icon: <TransactionExpiredIcon />,
           };
+        } else if (!item.ispaid) {
+          return {
+            label: loc.transactions.expired_transaction,
+            icon: <TransactionPendingIcon />,
+          };
         } else {
           return {
             label: loc.transactions.incoming_transaction,


### PR DESCRIPTION
before the fix when i created invoice using (my own lndhub) it rendered  icon like the payment was received.
thats a fix for that, now it looks like it should:

![image](https://github.com/user-attachments/assets/f0cb5ae5-0b17-4d8b-b274-af6bef3b9876)
