### PR TITLE
feat: import xpub as zpub/ypub if it was ever used

### DIFF
--- a/class/wallets/abstract-hd-electrum-wallet.ts
+++ b/class/wallets/abstract-hd-electrum-wallet.ts
@@ -1417,6 +1417,12 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     if (!this.allowBIP47()) {
       return false;
     }
+    try {
+      // watch-only wallet will throw an error here
+      this.getDerivationPath();
+    } catch (_) {
+      return false;
+    }
     // only check BIP47 if derivation path is regular, otherwise too many wallets will be found
     if (!["m/84'/0'/0'", "m/44'/0'/0'", "m/49'/0'/0'"].includes(this.getDerivationPath() as string)) {
       return false;

--- a/class/wallets/watch-only-wallet.ts
+++ b/class/wallets/watch-only-wallet.ts
@@ -312,4 +312,9 @@ export class WatchOnlyWallet extends LegacyWallet {
     if (this._hdWalletInstance) return this._hdWalletInstance.isSegwit();
     return super.isSegwit();
   }
+
+  wasEverUsed(): Promise<boolean> {
+    if (this._hdWalletInstance) return this._hdWalletInstance.wasEverUsed();
+    return super.wasEverUsed();
+  }
 }

--- a/tests/integration/import.test.ts
+++ b/tests/integration/import.test.ts
@@ -489,6 +489,24 @@ describe('import procedure', () => {
     assert.strictEqual(store.state.wallets[0].getDerivationPath(), "m/84'/0'/0'");
   });
 
+  it('can import watch-only xpub as a zpub if it has been used', async () => {
+    const store = createStore();
+    const { promise } = startImport(
+      'xpub6C8z87Nj7vuUqntJdNfkY4LJBSih9BkA3kUVjmTbSmA4Fk88vrBJwcjCt2q8yb2Pt8axgDkonSfdGiACPYNH7yoyQnX3iETHLneSYvPcnRy',
+      false,
+      false,
+      false,
+      ...store.callbacks,
+    );
+    await promise;
+    assert.strictEqual(store.state.wallets[0].type, WatchOnlyWallet.type);
+    assert.strictEqual(store.state.wallets[0].getDerivationPath(), "m/84'/0'/0'");
+    assert.strictEqual(
+      store.state.wallets[0].getSecret(),
+      'zpub6qoWjSiZRHzSYPGYJ6EzxEXJXP1b2Rj9syWwJZFNCmupMwkbSAWSBk3UvSkJyQLEhQpaBAwvhmNj3HPKpwCJiTBB9Tutt46FtEmjL2DoU3J',
+    );
+  });
+
   it('can import BIP39 wallets with truncated words', async () => {
     // 12 words
     const store1 = createStore();


### PR DESCRIPTION
If a user attempts to import an xpub without a derivation path or fingerprint, try converting it to a zpub or ypub. If the converted version was previously used, import it as such; otherwise, default to importing it as an xpub.

I don't think we really also need to check other conversions (like ypub -> zpub)

closes #2958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced wallet import process to support multiple wallet formats (xpub, ypub, zpub)
	- Improved error handling for watch-only wallets during import and usage checks

- **Bug Fixes**
	- Added robust error handling for wallet derivation path checks
	- Implemented fallback mechanism for determining wallet usage status

- **Tests**
	- Added integration test for importing watch-only wallets with different key formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->