### PR TITLE
Fix improper article usage before "universal" in payment codes description.

### DIFF
--- a/loc/en.json
+++ b/loc/en.json
@@ -109,7 +109,7 @@
     "minSats": "Minimal amount is {min} sats",
     "minSatsFull": "Minimal amount is {min} sats or {currency}",
     "qrcode_for_the_address": "QR Code for the address",
-    "bip47_explanation": "Payment codes are an universal address that avoids disclosing your wallet addresses. Not all services will support them."
+    "bip47_explanation": "Payment codes are a universal address that avoids disclosing your wallet addresses. Not all services will support them."
   },
   "send": {
     "provided_address_is_invoice": "This address appears to be for a Lightning invoice. Please, go to your Lightning wallet in order to make a payment for this invoice.",


### PR DESCRIPTION
This pull request corrects the improper use of the indefinite article "an" before the word "universal" in the payment codes description. While "universal" begins with the orthographic vowel "u," its phonetic onset /juː-/ includes a semi-vowel /j/, making "a" the grammatically correct article.

Replaced "an" with "a" in the following string:
`Payment codes are an universal address that avoids disclosing your wallet addresses.`
Now reads:
`Payment codes are a universal address that avoids disclosing your wallet addresses.`