### PR TITLE
FIX: transactions list screen would not always update with new transactions

### DIFF
--- a/components/TransactionListItem.tsx
+++ b/components/TransactionListItem.tsx
@@ -362,6 +362,7 @@ export const TransactionListItem: React.FC<TransactionListItemProps> = React.mem
           rightTitle={rowTitle}
           rightTitleStyle={rowTitleStyle}
           containerStyle={combinedStyle}
+          testID="TransactionListItem"
         />
       </ToolTipMenu>
     );

--- a/screen/wallets/WalletDetails.tsx
+++ b/screen/wallets/WalletDetails.tsx
@@ -367,12 +367,17 @@ const WalletDetails: React.FC = () => {
   const purgeTransactions = async () => {
     if (backdoorPressed < 10) return setBackdoorPressed(backdoorPressed + 1);
     setBackdoorPressed(0);
-    const msg = 'Transactions purged. Pls go to main screen and back to rerender screen';
+    const msg = 'Transactions & balances purged. Pls go to main screen and back to rerender screen';
 
     if (wallet.type === HDSegwitBech32Wallet.type) {
       wallet._txs_by_external_index = {};
       wallet._txs_by_internal_index = {};
       presentAlert({ message: msg });
+
+      wallet._balances_by_external_index = {};
+      wallet._balances_by_internal_index = {};
+      wallet._lastTxFetch = 0;
+      wallet._lastBalanceFetch = 0;
     }
 
     // @ts-expect-error: Need to fix later
@@ -381,6 +386,15 @@ const WalletDetails: React.FC = () => {
       wallet._hdWalletInstance._txs_by_external_index = {};
       // @ts-expect-error: Need to fix later
       wallet._hdWalletInstance._txs_by_internal_index = {};
+
+      // @ts-expect-error: Need to fix later
+      wallet._hdWalletInstance._balances_by_external_index = {};
+      // @ts-expect-error: Need to fix later
+      wallet._hdWalletInstance._balances_by_internal_index = {};
+      // @ts-expect-error: Need to fix later
+      wallet._hdWalletInstance._lastTxFetch = 0;
+      // @ts-expect-error: Need to fix later
+      wallet._hdWalletInstance._lastBalanceFetch = 0;
       presentAlert({ message: msg });
     }
   };
@@ -528,7 +542,7 @@ const WalletDetails: React.FC = () => {
               </View>
             </>
             <>
-              <Text onPress={purgeTransactions} style={[styles.textLabel2, stylesHook.textLabel2]}>
+              <Text onPress={purgeTransactions} style={[styles.textLabel2, stylesHook.textLabel2]} testID="PurgeBackdoorButton">
                 {loc.transactions.transactions_count.toLowerCase()}
               </Text>
               <BlueText>{wallet.getTransactions().length}</BlueText>

--- a/screen/wallets/WalletTransactions.tsx
+++ b/screen/wallets/WalletTransactions.tsx
@@ -119,7 +119,9 @@ const WalletTransactions: React.FC<WalletTransactionsProps> = ({ route }) => {
     const txs = wallet.getTransactions();
     txs.sort((a: { received: string }, b: { received: string }) => +new Date(b.received) - +new Date(a.received));
     return txs;
-  }, [wallet]);
+    // we use `wallet.getLastTxFetch()` to tell if txs list changed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wallet, wallet?.getLastTxFetch()]);
 
   const getTransactions = useCallback((lmt = Infinity): Transaction[] => sortedTransactions.slice(0, lmt), [sortedTransactions]);
 
@@ -171,7 +173,6 @@ const WalletTransactions: React.FC<WalletTransactionsProps> = ({ route }) => {
         setFetchFailures(0);
         const newTimestamp = Date.now();
         setLastFetchTimestamp(newTimestamp);
-        wallet._lastTxFetch = newTimestamp;
       } catch (err) {
         setFetchFailures(prev => {
           const newFailures = prev + 1;
@@ -289,11 +290,6 @@ const WalletTransactions: React.FC<WalletTransactionsProps> = ({ route }) => {
     offset: 64 * index,
     index,
   });
-
-  const listData: Transaction[] = useMemo(() => {
-    const transactions = getTransactions(limit);
-    return transactions;
-  }, [getTransactions, limit]);
 
   const renderItem = useCallback(
     // eslint-disable-next-line react/no-unused-prop-types
@@ -521,6 +517,7 @@ const WalletTransactions: React.FC<WalletTransactionsProps> = ({ route }) => {
           styles.refreshIndicatorBackground,
           { backgroundColor: wallet ? WalletGradient.headerColorFor(wallet.type) : colors.background },
         ]}
+        testID="TransactionsListView"
       />
 
       <FlatList<Transaction>
@@ -529,7 +526,7 @@ const WalletTransactions: React.FC<WalletTransactionsProps> = ({ route }) => {
         onEndReachedThreshold={0.3}
         onEndReached={loadMoreTransactions}
         ListFooterComponent={renderListFooterComponent}
-        data={listData}
+        data={getTransactions(limit)}
         extraData={wallet}
         keyExtractor={_keyExtractor}
         renderItem={renderItem}
@@ -544,7 +541,7 @@ const WalletTransactions: React.FC<WalletTransactionsProps> = ({ route }) => {
         ListHeaderComponent={ListHeaderComponent}
         ListEmptyComponent={
           <ScrollView style={[styles.flex, { backgroundColor: colors.background }]} contentContainerStyle={styles.scrollViewContent}>
-            <Text numberOfLines={0} style={styles.emptyTxs}>
+            <Text numberOfLines={0} style={styles.emptyTxs} testID="TransactionsListEmpty">
               {(isLightning() && loc.wallets.list_empty_txs1_lightning) || loc.wallets.list_empty_txs1}
             </Text>
             {isLightning() && <Text style={styles.emptyTxsLightning}>{loc.wallets.list_empty_txs2_lightning}</Text>}

--- a/tests/e2e/bluewallet3.spec.js
+++ b/tests/e2e/bluewallet3.spec.js
@@ -1,5 +1,13 @@
 import { hashIt, helperDeleteWallet, helperImportWallet, sleep, waitForId } from './helperz';
 
+// if loglevel is set to `error`, this kind of logging will still get through
+console.warn = console.log = (...args) => {
+  let output = '';
+  args.map(arg => (output += String(arg)));
+
+  process.stdout.write(output + '\n');
+};
+
 beforeAll(async () => {
   // reinstalling the app just for any case to clean up app's storage
   await device.launchApp({ delete: true });

--- a/tests/e2e/helperz.js
+++ b/tests/e2e/helperz.js
@@ -228,3 +228,16 @@ export async function tapIfTextPresent(text) {
   } catch (_) {}
   // no need to check for visibility, just silently ignore exception if such testID is not present
 }
+
+export async function countElements(testId) {
+  let count = 0;
+  while (true) {
+    try {
+      await expect(element(by.id(testId)).atIndex(count)).toExist();
+      count++;
+    } catch (_) {
+      break;
+    }
+  }
+  return count;
+}


### PR DESCRIPTION
not sure if i made it correctly,  looks like we have excessive caching on transactions list screen, useMemo inside useCallback inside useMemo etc etc

so i added extra dep in useEffect so that cached tx list is re-calculated.


most importantly, i wrote an e2e test that purges wallet data, pulls-to-refresh and checks that data got pulled