### PR TITLE
FIX: crash when scanning invoice with both ln and onchain address (cl…

### DIFF
--- a/navigation/SendDetailsStackParamList.ts
+++ b/navigation/SendDetailsStackParamList.ts
@@ -29,6 +29,15 @@ export type SendDetailsParams = {
   };
 };
 
+export type TNavigation = {
+  pop: () => void;
+  navigate: () => void;
+};
+
+export type TNavigationWrapper = {
+  navigation: TNavigation;
+};
+
 export type SendDetailsStackParamList = {
   SendDetails: SendDetailsParams;
   Confirm: {
@@ -79,7 +88,7 @@ export type SendDetailsStackParamList = {
   };
   SelectWallet: {
     chainType?: Chain;
-    onWalletSelect?: (wallet: TWallet, navigation: any) => void;
+    onWalletSelect?: (wallet: TWallet, navigationWrapper: TNavigationWrapper) => void;
     availableWallets?: TWallet[];
     noWalletExplanationText?: string;
     onChainRequireSend?: boolean;

--- a/screen/wallets/SelectWallet.tsx
+++ b/screen/wallets/SelectWallet.tsx
@@ -72,7 +72,7 @@ const SelectWallet: React.FC = () => {
   const onPress = (item: TWallet) => {
     triggerHapticFeedback(HapticFeedbackTypes.Selection);
     if (onWalletSelect) {
-      onWalletSelect(item, { navigation: { pop, navigation: navigation.navigate } });
+      onWalletSelect(item, { navigation: { pop, navigate: navigation.navigate } });
     } else {
       // @ts-ignore: fix later
       navigation.popTo(previousRouteName, { walletID: item.getID(), merge: true });


### PR DESCRIPTION
…oses #7653)


in another refactoring parameter was incorrectly called `navigation` instead of `navigate`.
fixed it by writing a proper type for argument (instead of `any`)