### PR TITLE
feat: useWalletSubscribe hook

### DIFF
--- a/hooks/useWalletSubscribe.tsx
+++ b/hooks/useWalletSubscribe.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useStorage } from './context/useStorage';
 import { TWallet } from '../class/wallets/types';
 
@@ -7,10 +7,14 @@ import { TWallet } from '../class/wallets/types';
  */
 const useWalletSubscribe = (walletID: string): TWallet => {
   const { wallets } = useStorage();
-  const origWallet = wallets.find(w => w.getID() === walletID);
+
+  // get wallet by ID or used cached wallet
+  const previousWallet = useRef<TWallet | undefined>();
+  const origWallet = wallets.find(w => w.getID() === walletID) ?? previousWallet.current;
   if (!origWallet) {
     throw new Error(`Wallet with ID ${walletID} not found`);
   }
+  previousWallet.current = origWallet;
 
   const [lastTxFetch, setLastTxFetch] = useState(origWallet.getLastTxFetch());
 

--- a/hooks/useWalletSubscribe.tsx
+++ b/hooks/useWalletSubscribe.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useStorage } from './context/useStorage';
+import { TWallet } from '../class/wallets/types';
+
+/**
+ * A React hook that provides a proxied wallet instance that automatically updates when new transactions are fetched.
+ */
+const useWalletSubscribe = (walletID: string): TWallet => {
+  const { wallets } = useStorage();
+  const origWallet = wallets.find(w => w.getID() === walletID);
+  if (!origWallet) {
+    throw new Error(`Wallet with ID ${walletID} not found`);
+  }
+
+  const [lastTxFetch, setLastTxFetch] = useState(origWallet.getLastTxFetch());
+
+  const walletProxy = useMemo(() => {
+    return new Proxy(origWallet, {});
+    // force update when lastTxFetch changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lastTxFetch, origWallet]);
+
+  // check every second for getLastTxFetch
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setLastTxFetch(origWallet.getLastTxFetch());
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [origWallet]);
+
+  return walletProxy;
+};
+
+export default useWalletSubscribe;


### PR DESCRIPTION
We have an ongoing problem with React hook dependencies. Since our `Wallet` class is not designed with reactivity in mind, we can't use it as a dependency—it does not mutate.

For example:
```ts
const wallet = wallets.find(w => w.getID() === walletID);

useMemo(() => {
  return wallet.getTransactions();
}, [wallet]);
```

This will never update when the wallet has new transactions.

With this hook you can do:
```ts
const wallet = useWallet(walletID);

useMemo(() => {
  return wallet.getTransactions();
}, [wallet]);
```

And it will update the tx list.
I've tested it with `WalletTransactions` screen.

**The downside** of this approach is that all `useEffect` hooks will now trigger whenever the wallet is updated, so we need to be careful about this.

It is possible to use this hook when you need to watch for wallet changes, and the old `wallets.find` approach if you only need to trigger something on component mount.