### PR TITLE
REF: Allow large screen iPhone devices to use same UI as iPad/macSO

### DIFF
--- a/components/Context/LargeScreenProvider.tsx
+++ b/components/Context/LargeScreenProvider.tsx
@@ -1,55 +1,63 @@
 import React, { createContext, ReactNode, useEffect, useMemo, useState } from 'react';
-import { Dimensions } from 'react-native';
-
-import { isDesktop, isTablet } from '../../blue_modules/environment';
-
-type ScreenSize = 'Handheld' | 'LargeScreen' | undefined;
+import { Dimensions, ScaledSize } from 'react-native';
 
 interface ILargeScreenContext {
   isLargeScreen: boolean;
-  setLargeScreenValue: (value: ScreenSize) => void;
+  setIsLargeScreen: React.Dispatch<React.SetStateAction<boolean | undefined>>;
 }
+
+const useScreenDimensions = () => {
+  const [metrics, setMetrics] = useState(() => ({
+    window: Dimensions.get('window'),
+    screen: Dimensions.get('screen'),
+  }));
+
+  useEffect(() => {
+    const onChange = ({ window, screen }: { window: ScaledSize; screen: ScaledSize }) => {
+      setMetrics({ window, screen });
+    };
+
+    const subscription = Dimensions.addEventListener('change', onChange);
+
+    // Force an initial metrics check
+    onChange({
+      window: Dimensions.get('window'),
+      screen: Dimensions.get('screen'),
+    });
+
+    return () => subscription.remove();
+  }, []);
+
+  return metrics;
+};
+
+const useLargeScreen = (initialValue?: boolean) => {
+  const { window: dimensions } = useScreenDimensions();
+  const [overrideValue, setIsLargeScreen] = useState<boolean | undefined>(initialValue);
+
+  const isLargeScreen = useMemo(() => {
+    if (overrideValue !== undefined) return overrideValue;
+
+    const DRAWER_WIDTH = 320;
+    const MIN_CONTENT_WIDTH = 375;
+    const REQUIRED_WIDTH = DRAWER_WIDTH + MIN_CONTENT_WIDTH;
+
+    return dimensions.width >= REQUIRED_WIDTH;
+  }, [dimensions.width, overrideValue]);
+
+  return { isLargeScreen, setIsLargeScreen };
+};
+
+type LargeScreenProviderProps = {
+  children: ReactNode;
+};
 
 export const LargeScreenContext = createContext<ILargeScreenContext | undefined>(undefined);
 
-interface LargeScreenProviderProps {
-  children: ReactNode;
-}
-
 export const LargeScreenProvider: React.FC<LargeScreenProviderProps> = ({ children }) => {
-  const [windowWidth, setWindowWidth] = useState<number>(Dimensions.get('window').width);
-  const [largeScreenValue, setLargeScreenValue] = useState<ScreenSize>(undefined);
-
-  useEffect(() => {
-    const updateScreenUsage = (): void => {
-      const newWindowWidth = Dimensions.get('window').width;
-      if (newWindowWidth !== windowWidth) {
-        setWindowWidth(newWindowWidth);
-      }
-    };
-
-    const subscription = Dimensions.addEventListener('change', updateScreenUsage);
-    return () => subscription.remove();
-  }, [windowWidth]);
-
-  const isLargeScreen: boolean = useMemo(() => {
-    if (largeScreenValue === 'LargeScreen') {
-      return true;
-    } else if (largeScreenValue === 'Handheld') {
-      return false;
-    }
-    const screenWidth: number = Dimensions.get('screen').width;
-    const halfScreenWidth = windowWidth >= screenWidth / 2;
-    return (isTablet && halfScreenWidth) || isDesktop;
-  }, [windowWidth, largeScreenValue]);
-
-  const contextValue = useMemo(
-    () => ({
-      isLargeScreen,
-      setLargeScreenValue,
-    }),
-    [isLargeScreen, setLargeScreenValue],
-  );
+  const contextValue = useLargeScreen();
 
   return <LargeScreenContext.Provider value={contextValue}>{children}</LargeScreenContext.Provider>;
 };
+
+export { useLargeScreen };

--- a/components/DevMenu.tsx
+++ b/components/DevMenu.tsx
@@ -3,7 +3,6 @@ import { DevSettings, Alert, Platform, AlertButton } from 'react-native';
 import { useStorage } from '../hooks/context/useStorage';
 import { HDSegwitBech32Wallet } from '../class';
 import Clipboard from '@react-native-clipboard/clipboard';
-import { useIsLargeScreen } from '../hooks/useIsLargeScreen';
 import { TWallet } from '../class/wallets/types';
 
 const getRandomLabelFromSecret = (secret: string): string => {
@@ -71,7 +70,6 @@ const showAlertWithWalletOptions = (
 
 const DevMenu: React.FC = () => {
   const { wallets, addWallet } = useStorage();
-  const { setLargeScreenValue } = useIsLargeScreen();
 
   useEffect(() => {
     if (__DEV__) {
@@ -163,23 +161,8 @@ const DevMenu: React.FC = () => {
           Alert.alert(msg);
         });
       });
-
-      DevSettings.addMenuItem('Force Large Screen Interface', () => {
-        setLargeScreenValue('LargeScreen');
-        Alert.alert('Large Screen Interface forced.');
-      });
-
-      DevSettings.addMenuItem('Force Handheld Interface', () => {
-        setLargeScreenValue('Handheld');
-        Alert.alert('Handheld Interface forced.');
-      });
-
-      DevSettings.addMenuItem('Reset Screen Interface', () => {
-        setLargeScreenValue(undefined);
-        Alert.alert('Screen Interface reset to default.');
-      });
     }
-  }, [wallets, addWallet, setLargeScreenValue]);
+  }, [wallets, addWallet]);
 
   return null;
 };

--- a/hooks/useIsLargeScreen.ts
+++ b/hooks/useIsLargeScreen.ts
@@ -3,7 +3,7 @@ import { LargeScreenContext } from '../components/Context/LargeScreenProvider';
 
 interface UseIsLargeScreenResult {
   isLargeScreen: boolean;
-  setLargeScreenValue: (value: 'Handheld' | 'LargeScreen' | undefined) => void;
+  setLargeScreenValue: React.Dispatch<React.SetStateAction<boolean | undefined>>;
 }
 
 export const useIsLargeScreen = (): UseIsLargeScreenResult => {
@@ -13,6 +13,6 @@ export const useIsLargeScreen = (): UseIsLargeScreenResult => {
   }
   return {
     isLargeScreen: context.isLargeScreen,
-    setLargeScreenValue: context.setLargeScreenValue,
+    setLargeScreenValue: context.setIsLargeScreen,
   };
 };

--- a/ios/BlueWallet/AppDelegate.mm
+++ b/ios/BlueWallet/AppDelegate.mm
@@ -424,4 +424,15 @@
     }
 }
 
+- (UIInterfaceOrientationMask)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window {
+  UITraitCollection *traitCollection = window.traitCollection;
+  if (traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular ||
+      traitCollection.verticalSizeClass == UIUserInterfaceSizeClassRegular) {
+    // iPad or large iPhone
+    return UIInterfaceOrientationMaskAll;
+  }
+  // Regular iPhone
+  return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
+}
+
 @end

--- a/ios/BlueWallet/Info.plist
+++ b/ios/BlueWallet/Info.plist
@@ -223,6 +223,8 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
@@ -230,6 +232,18 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~iphone</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~iphone-MaxScreenSizePhone</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -1,10 +1,10 @@
 import { createNativeStackNavigator, NativeStackNavigationOptions } from '@react-navigation/native-stack';
 import React, { lazy, Suspense } from 'react';
-import { isHandset } from '../blue_modules/environment';
 import UnlockWith from '../screen/UnlockWith';
 import { LazyLoadingIndicator } from './LazyLoadingIndicator';
 import { DetailViewStackParamList } from './DetailViewStackParamList';
 import { useStorage } from '../hooks/context/useStorage';
+import { useIsLargeScreen } from '../hooks/useIsLargeScreen';
 
 const DetailViewScreensStack = lazy(() => import('./DetailViewScreensStack'));
 const DrawerRoot = lazy(() => import('./DrawerRoot'));
@@ -32,13 +32,14 @@ const UnlockRoot = () => {
 
 const MainRoot = () => {
   const { walletsInitialized } = useStorage();
+  const { isLargeScreen } = useIsLargeScreen();
 
   const renderRoot = () => {
     if (!walletsInitialized) {
       return <UnlockRoot />;
     } else {
       // Conditional rendering based on the environment
-      const Component = isHandset ? DetailViewScreensStack : DrawerRoot;
+      const Component = isLargeScreen ? DrawerRoot : DetailViewScreensStack;
       return (
         <Suspense fallback={<LazyLoadingIndicator />}>
           <Component />

--- a/screen/wallets/Add.tsx
+++ b/screen/wallets/Add.tsx
@@ -418,7 +418,14 @@ const WalletsAdd: React.FC = () => {
   );
 
   return (
-    <ScrollView style={stylesHook.root} testID="ScrollView" automaticallyAdjustKeyboardInsets>
+    <ScrollView
+      style={stylesHook.root}
+      testID="ScrollView"
+      automaticallyAdjustKeyboardInsets
+      contentInsetAdjustmentBehavior="automatic"
+      automaticallyAdjustContentInsets
+      automaticallyAdjustsScrollIndicatorInsets
+    >
       <BlueSpacing20 />
       <BlueFormLabel>{loc.wallets.add_wallet_name}</BlueFormLabel>
       <View style={[styles.label, stylesHook.label]}>


### PR DESCRIPTION
Standard iOS behavior we werent allowing
<img width="810" alt="Screenshot 2025-03-14 at 12 51 42 AM" src="https://github.com/user-attachments/assets/eb3fca29-e784-4a27-b3bb-2395b0b262b5" />
