### PR TITLE
OPS: improve CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
 
   lint:
     docker:
-      - image: cimg/node:20.17.0
+      - image: cimg/node:22.14.0
 
     working_directory: ~/repo
 
@@ -13,7 +13,7 @@ jobs:
       - restore_cache:
           key: node_modules-{{ checksum "package-lock.json" }}
 
-      - run: test -d node_modules || npm i
+      - run: test -d node_modules || npm ci
 
       - save_cache:
           key: node_modules-{{ checksum "package-lock.json" }}
@@ -26,7 +26,7 @@ jobs:
 
   unit:
     docker:
-      - image: cimg/node:20.17.0
+      - image: cimg/node:22.14.0
 
     working_directory: ~/repo
 
@@ -36,7 +36,7 @@ jobs:
       - restore_cache:
           key: node_modules-{{ checksum "package-lock.json" }}
 
-      - run: test -d node_modules || npm i
+      - run: test -d node_modules || npm ci
 
       - save_cache:
           key: node_modules-{{ checksum "package-lock.json" }}
@@ -50,7 +50,7 @@ jobs:
 
   integration:
     docker:
-      - image: cimg/node:20.17.0
+      - image: cimg/node:22.14.0
 
     environment:
       RETRY: "1"
@@ -65,7 +65,7 @@ jobs:
       - restore_cache:
           key: node_modules-{{ checksum "package-lock.json" }}
 
-      - run: test -d node_modules || npm i
+      - run: test -d node_modules || npm ci
 
       - save_cache:
           key: node_modules-{{ checksum "package-lock.json" }}

--- a/.github/workflows/build-ios-release-pullrequest.yml
+++ b/.github/workflows/build-ios-release-pullrequest.yml
@@ -67,8 +67,9 @@ jobs:
       - name: Specify Node.js Version
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -101,7 +102,7 @@ jobs:
           bundle install --jobs 4 --retry 3 --quiet
 
       - name: Install Node Modules
-        run: npm install --omit=dev --yes
+        run: npm ci --omit=dev --yes
 
       - name: Install CocoaPods Dependencies
         run: |

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -22,15 +22,9 @@ jobs:
       - name: Specify node version
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-
-      - name: Use npm caches
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-
+          node-version: 22
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Use specific Java version for sdkmanager to work
         uses: actions/setup-java@v4
@@ -40,7 +34,7 @@ jobs:
           cache: 'gradle'
 
       - name: Install node_modules
-        run: npm install --omit=dev --yes
+        run: npm ci --omit=dev --yes
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -106,7 +100,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,18 +20,11 @@ jobs:
     - name: Specify node version
       uses: actions/setup-node@v4
       with:
-        node-version: 20
-
-    - name: Use npm caches
-      uses: actions/cache@v4
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-npm-
+        node-version: 22
+        cache: 'npm'
+        cache-dependency-path: package-lock.json
 
     - name: Install node_modules
-      if: steps.cache-nm.outputs.cache-hit != 'true'
       run: npm ci
 
     - name: Run tests
@@ -47,9 +40,6 @@ jobs:
         MNEMONICS_COBO: ${{ secrets.MNEMONICS_COBO }}
         MNEMONICS_COLDCARD: ${{ secrets.MNEMONICS_COLDCARD }}
         RETRY: 1
-
-    - name: Prune devDependencies
-      run: npm prune --omit=dev
 
   e2e:
     runs-on: ubuntu-latest
@@ -89,7 +79,10 @@ jobs:
     - name: Specify node version
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
+        cache: 'npm'
+        cache-dependency-path: package-lock.json
+
 
     - name: Use gradle caches
       uses: actions/cache@v4
@@ -101,16 +94,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-
 
-    - name: Use npm caches
-      uses: actions/cache@v4
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-npm-
-
     - name: Install node_modules
-      run: npm install || npm install
+      run: npm ci --omit=dev --yes
 
     - name: Use specific Java version for sdkmanager to work
       uses: actions/setup-java@v4
@@ -126,6 +111,9 @@ jobs:
 
     - name: Build
       run: npm run e2e:release-build
+
+    - name: Install dev deps needed for tests
+      run: npm i
 
     - name: Run tests
       uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/lockfiles_update.yml
+++ b/.github/workflows/lockfiles_update.yml
@@ -30,10 +30,12 @@ jobs:
       - name: Specify node version
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Install node modules
-        run: npm install
+        run: npm ci
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "react-native-quick-actions": "0.3.13",
         "react-native-randombytes": "3.6.1",
         "react-native-rate": "1.2.12",
-        "react-native-reanimated": "3.17.3",
+        "react-native-reanimated": "3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screen-capture": "github:BlueWallet/react-native-screen-capture#18cb79f",
         "react-native-screens": "4.10.0",
@@ -18511,9 +18511,9 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.3.tgz",
-      "integrity": "sha512-0dN+AB7Om9Fdq3Bvq4+ClGhv2sl1o6BhKum18CFNPh4dgMKybDSdRo2vhxTaZUJq6R3LC8gFI84IV0qCZmPbiw==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.4.tgz",
+      "integrity": "sha512-vmkG/N5KZrexHr4v0rZB7ohPVseGVNaCXjGxoRo+NYKgC9+mIZAkg/QIfy9xxfJ73FfTrryO9iYUrxks3ZfKbA==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",


### PR DESCRIPTION
switched from `npm install` to `npm ci` 
simplified npm caches
added omit-dev deps for e2e pipeline