### PR TITLE
ADD: single-address Taproot wallets support (import from WIF)

### DIFF
--- a/class/wallet-import.ts
+++ b/class/wallet-import.ts
@@ -18,6 +18,7 @@ import {
   SLIP39LegacyP2PKHWallet,
   SLIP39SegwitBech32Wallet,
   SLIP39SegwitP2SHWallet,
+  TaprootWallet,
   WatchOnlyWallet,
 } from '.';
 import bip39WalletFormats from './bip39_wallet_formats.json'; // https://github.com/spesmilo/electrum/blob/master/electrum/bip39_wallet_formats.json
@@ -108,6 +109,7 @@ const startImport = (
     // 3.2 check if its AEZEED
     // 3.3 check if its SLIP39
     // 4. check if its Segwit WIF (P2SH)
+    // 4.5 check if its Taproot WIF
     // 5. check if its Legacy WIF
     // 6. check if its address (watch-only wallet)
     // 7. check if its private key (segwit address P2SH) TODO
@@ -308,6 +310,16 @@ const startImport = (
         await fetch(segwitBech32Wallet, true);
         walletFound = true;
         yield { wallet: segwitBech32Wallet };
+      }
+
+      yield { progress: 'wif p2tr' };
+      const taprootWallet = new TaprootWallet();
+      taprootWallet.setSecret(text);
+      if (await wasUsed(taprootWallet)) {
+        // yep, its single-address taproot wallet
+        await fetch(taprootWallet, true);
+        walletFound = true;
+        yield { wallet: taprootWallet };
       }
 
       yield { progress: 'wif p2wpkh-p2sh' };

--- a/class/wallets/taproot-wallet.ts
+++ b/class/wallets/taproot-wallet.ts
@@ -1,6 +1,12 @@
 import * as bitcoin from 'bitcoinjs-lib';
+import { ECPairFactory } from 'ecpair';
+
+import ecc from '../../blue_modules/noble_ecc';
 
 import { SegwitBech32Wallet } from './segwit-bech32-wallet';
+import { CreateTransactionResult, CreateTransactionUtxo } from './types.ts';
+import { CoinSelectTarget } from 'coinselect';
+const ECPair = ECPairFactory(ecc);
 
 export class TaprootWallet extends SegwitBech32Wallet {
   static readonly type = 'taproot';
@@ -24,5 +30,109 @@ export class TaprootWallet extends SegwitBech32Wallet {
     } catch (_) {
       return false;
     }
+  }
+
+  allowSend() {
+    return true;
+  }
+
+  allowSendMax() {
+    return true;
+  }
+
+  isSegwit() {
+    return true;
+  }
+
+  allowSignVerifyMessage() {
+    return true;
+  }
+
+  getAddress(): string | false {
+    if (this._address) return this._address;
+    let address;
+    try {
+      const keyPair = ECPair.fromWIF(this.secret);
+      if (!keyPair.compressed) {
+        console.warn('only compressed public keys are good for segwit');
+        return false;
+      }
+      const xOnlyPubkey = keyPair.publicKey.subarray(1, 33);
+      address = bitcoin.payments.p2tr({
+        pubkey: xOnlyPubkey,
+      }).address;
+    } catch (err: any) {
+      console.log(err.message);
+      return false;
+    }
+    this._address = address ?? false;
+
+    return this._address;
+  }
+
+  createTransaction(
+    utxos: CreateTransactionUtxo[],
+    targets: CoinSelectTarget[],
+    feeRate: number,
+    changeAddress: string,
+    sequence: number,
+    skipSigning = false,
+    masterFingerprint: number,
+  ): CreateTransactionResult {
+    if (targets.length === 0) throw new Error('No destination provided');
+    const { inputs, outputs, fee } = this.coinselect(utxos, targets, feeRate);
+    sequence = sequence || 0xffffffff; // default if not passed
+
+    // Derive keyPair & x-only pubkey
+    const keyPair = ECPair.fromWIF(this.secret);
+    const pubkey = keyPair.publicKey; // compressed: 0x02/03 || X
+    const xOnlyPub = pubkey.subarray(1, 33); // strip prefix
+
+    // Precompute the P2TR payment (to rebuild scriptPubKey)
+    const p2tr = bitcoin.payments.p2tr({
+      pubkey: xOnlyPub,
+    });
+    if (!p2tr.output) throw new Error('Could not build p2tr.output');
+
+    const psbt = new bitcoin.Psbt();
+
+    // Add Taproot inputs
+    inputs.forEach((input, idx) => {
+      psbt.addInput({
+        hash: input.txid,
+        index: input.vout,
+        sequence,
+        witnessUtxo: {
+          script: p2tr.output!,
+          value: input.value,
+        },
+        // tell PSBT it’s a key-path Taproot spend
+        tapInternalKey: xOnlyPub,
+      });
+    });
+
+    // Add outputs
+    outputs.forEach(output => {
+      // if output has no address - this is change output
+      if (!output.address) output.address = changeAddress;
+      psbt.addOutput({
+        address: output.address!,
+        value: output.value,
+      });
+    });
+
+    let tx;
+    if (!skipSigning) {
+      // Sign each input as a Taproot key-path spend
+      inputs.forEach((_, idx) => {
+        psbt.signTaprootInput(idx, keyPair);
+      });
+
+      // Finalize all inputs (will auto-detect Taproot)
+      psbt.finalizeAllInputs();
+      tx = psbt.extractTransaction();
+    }
+
+    return { tx, inputs, outputs, fee, psbt };
   }
 }

--- a/class/wallets/types.ts
+++ b/class/wallets/types.ts
@@ -16,6 +16,7 @@ import { SegwitBech32Wallet } from './segwit-bech32-wallet';
 import { SegwitP2SHWallet } from './segwit-p2sh-wallet';
 import { SLIP39LegacyP2PKHWallet, SLIP39SegwitBech32Wallet, SLIP39SegwitP2SHWallet } from './slip39-wallets';
 import { WatchOnlyWallet } from './watch-only-wallet';
+import { TaprootWallet } from './taproot-wallet.ts';
 
 export type Utxo = {
   // Returned by BlueElectrum
@@ -158,6 +159,7 @@ export type TWallet =
   | SLIP39SegwitP2SHWallet
   | SegwitBech32Wallet
   | SegwitP2SHWallet
+  | TaprootWallet
   | WatchOnlyWallet;
 
 export type THDWalletForWatchOnly = HDSegwitBech32Wallet | HDSegwitP2SHWallet | HDLegacyP2PKHWallet;

--- a/tests/unit/taproot-wallet.test.ts
+++ b/tests/unit/taproot-wallet.test.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import * as bitcoin from 'bitcoinjs-lib';
 
 import { TaprootWallet } from '../../class';
 
@@ -10,5 +11,51 @@ describe('Taproot wallet', () => {
     assert.strictEqual(address, false);
     address = TaprootWallet.scriptPubKeyToAddress('trololo');
     assert.strictEqual(address, false);
+  });
+
+  it('can derive address from WIF', () => {
+    const w = new TaprootWallet();
+    w.setSecret('L4PKRVk1Peaar5WuH5LiKfkTygWtFfGrFeH2g2t3YVVqiwpJjMoF');
+    assert.strictEqual(w.getAddress(), 'bc1payhxedzyjtu8w7ven7au9925pmhc5gl59m77ht9vqq0l5xq8fsgqtwg8vf');
+    assert.ok(w.weOwnAddress('bc1payhxedzyjtu8w7ven7au9925pmhc5gl59m77ht9vqq0l5xq8fsgqtwg8vf'));
+  });
+
+  it('can create transaction', () => {
+    const w = new TaprootWallet();
+    w.setSecret('L4PKRVk1Peaar5WuH5LiKfkTygWtFfGrFeH2g2t3YVVqiwpJjMoF');
+
+    const utxos = [
+      {
+        height: 894578,
+        value: 9778,
+        address: 'bc1payhxedzyjtu8w7ven7au9925pmhc5gl59m77ht9vqq0l5xq8fsgqtwg8vf',
+        txid: '511e007f9c96b6d713a72b730506198f61dd96046edee72f0dc636bfe1f3a9cf',
+        vout: 0,
+        confirmations: 1046,
+      },
+    ];
+
+    // sendMax
+    const txNew = w.createTransaction(
+      utxos,
+      [{ address: '13HaCAB4jf7FYSZexJxoczyDDnutzZigjS' }],
+      1,
+      String(w.getAddress()),
+      0xffffffff,
+      false,
+      0,
+    );
+    assert.ok(txNew.tx);
+
+    assert.strictEqual(
+      txNew.tx.toHex(),
+      '02000000000101cfa9f3e1bf36c60d2fe7de6e0496dd618f190605732ba713d7b6969c7f001e510000000000ffffffff01c2250000000000001976a91419129d53e6319baf19dba059bead166df90ab8f588ac0140d75f5e8012a42b7341e9f26e26c45c1e78301f2bb74ed9f4a0183154973649523e3e91a6b61fca600e1904fde467099bc1c46c5a9d9b431d60afc6c7054aadb900000000',
+    );
+
+    // verifying:
+    const tx = bitcoin.Transaction.fromHex(txNew.tx.toHex());
+    assert.strictEqual(tx.ins.length, 1);
+    assert.strictEqual(tx.outs.length, 1);
+    assert.strictEqual('13HaCAB4jf7FYSZexJxoczyDDnutzZigjS', bitcoin.address.fromOutputScript(tx.outs[0].script)); // to address
   });
 });


### PR DESCRIPTION
Adding support for taproot single-address wallets. 
this is first step towards supporting BIP86 (full HD taproot wallets) and SilentPayments receive.

@limpbrains im not sure if i correctly addred it to import procedure
(havent tested the PR in actual app)