### PR TITLE
REF: improve BTC address formatting for readability

### DIFF
--- a/components/CopyTextToClipboard.tsx
+++ b/components/CopyTextToClipboard.tsx
@@ -1,14 +1,15 @@
-import Clipboard from '@react-native-clipboard/clipboard';
-import React, { forwardRef, useEffect, useState } from 'react';
-import { Animated, StyleSheet, TouchableOpacity, View } from 'react-native';
+import Clipboard from '@react-native-clipboard/clipboard'
+import React, { forwardRef, useEffect, useState } from 'react'
+import { Animated, StyleSheet, TouchableOpacity, View } from 'react-native'
 
-import triggerHapticFeedback, { HapticFeedbackTypes } from '../blue_modules/hapticFeedback';
-import loc from '../loc';
+import triggerHapticFeedback, { HapticFeedbackTypes } from '../blue_modules/hapticFeedback'
+import loc from '../loc'
+import { formatBTCAddress } from '../helpers/formatBTCAddress'
 
 type CopyTextToClipboardProps = {
-  text: string;
-  truncated?: boolean;
-};
+  text: string
+  truncated?: boolean
+}
 
 const styleCopyTextToClipboard = StyleSheet.create({
   address: {
@@ -17,28 +18,28 @@ const styleCopyTextToClipboard = StyleSheet.create({
     color: '#9aa0aa',
     textAlign: 'center',
   },
-});
+})
 
 const CopyTextToClipboard = forwardRef<React.ElementRef<typeof TouchableOpacity>, CopyTextToClipboardProps>(({ text, truncated }, ref) => {
-  const [hasTappedText, setHasTappedText] = useState(false);
-  const [address, setAddress] = useState(text);
+  const [hasTappedText, setHasTappedText] = useState(false)
+  const [address, setAddress] = useState(text)
 
   useEffect(() => {
     if (!hasTappedText) {
-      setAddress(text);
+      setAddress(formatBTCAddress(text))
     }
-  }, [text, hasTappedText]);
+  }, [text, hasTappedText])
 
   const copyToClipboard = () => {
-    setHasTappedText(true);
-    Clipboard.setString(text);
-    triggerHapticFeedback(HapticFeedbackTypes.Selection);
-    setAddress(loc.wallets.xpub_copiedToClipboard); // Adjust according to your localization logic
+    setHasTappedText(true)
+    Clipboard.setString(text)
+    triggerHapticFeedback(HapticFeedbackTypes.Selection)
+    setAddress(loc.wallets.xpub_copiedToClipboard) // Adjust according to your localization logic
     setTimeout(() => {
-      setHasTappedText(false);
-      setAddress(text);
-    }, 1000);
-  };
+      setHasTappedText(false)
+      setAddress(text)
+    }, 1000)
+  }
 
   return (
     <View style={styles.container}>
@@ -58,11 +59,11 @@ const CopyTextToClipboard = forwardRef<React.ElementRef<typeof TouchableOpacity>
         </Animated.Text>
       </TouchableOpacity>
     </View>
-  );
-});
+  )
+})
 
-export default CopyTextToClipboard;
+export default CopyTextToClipboard
 
 const styles = StyleSheet.create({
   container: { justifyContent: 'center', alignItems: 'center', paddingHorizontal: 16 },
-});
+})

--- a/components/CopyTextToClipboard.tsx
+++ b/components/CopyTextToClipboard.tsx
@@ -1,15 +1,15 @@
-import Clipboard from '@react-native-clipboard/clipboard'
-import React, { forwardRef, useEffect, useState } from 'react'
-import { Animated, StyleSheet, TouchableOpacity, View } from 'react-native'
+import Clipboard from '@react-native-clipboard/clipboard';
+import React, { forwardRef, useEffect, useState } from 'react';
+import { Animated, StyleSheet, TouchableOpacity, View } from 'react-native';
 
-import triggerHapticFeedback, { HapticFeedbackTypes } from '../blue_modules/hapticFeedback'
-import loc from '../loc'
-import { formatBTCAddress } from '../helpers/formatBTCAddress'
+import triggerHapticFeedback, { HapticFeedbackTypes } from '../blue_modules/hapticFeedback';
+import loc from '../loc';
+import { formatBTCAddress } from '../helpers/formatBTCAddress';
 
 type CopyTextToClipboardProps = {
-  text: string
-  truncated?: boolean
-}
+  text: string;
+  truncated?: boolean;
+};
 
 const styleCopyTextToClipboard = StyleSheet.create({
   address: {
@@ -18,28 +18,28 @@ const styleCopyTextToClipboard = StyleSheet.create({
     color: '#9aa0aa',
     textAlign: 'center',
   },
-})
+});
 
 const CopyTextToClipboard = forwardRef<React.ElementRef<typeof TouchableOpacity>, CopyTextToClipboardProps>(({ text, truncated }, ref) => {
-  const [hasTappedText, setHasTappedText] = useState(false)
-  const [address, setAddress] = useState(text)
+  const [hasTappedText, setHasTappedText] = useState(false);
+  const [address, setAddress] = useState(text);
 
   useEffect(() => {
     if (!hasTappedText) {
-      setAddress(formatBTCAddress(text))
+      setAddress(formatBTCAddress(text));
     }
-  }, [text, hasTappedText])
+  }, [text, hasTappedText]);
 
   const copyToClipboard = () => {
-    setHasTappedText(true)
-    Clipboard.setString(text)
-    triggerHapticFeedback(HapticFeedbackTypes.Selection)
-    setAddress(loc.wallets.xpub_copiedToClipboard) // Adjust according to your localization logic
+    setHasTappedText(true);
+    Clipboard.setString(text);
+    triggerHapticFeedback(HapticFeedbackTypes.Selection);
+    setAddress(loc.wallets.xpub_copiedToClipboard); // Adjust according to your localization logic
     setTimeout(() => {
-      setHasTappedText(false)
-      setAddress(text)
-    }, 1000)
-  }
+      setHasTappedText(false);
+      setAddress(text);
+    }, 1000);
+  };
 
   return (
     <View style={styles.container}>
@@ -59,11 +59,11 @@ const CopyTextToClipboard = forwardRef<React.ElementRef<typeof TouchableOpacity>
         </Animated.Text>
       </TouchableOpacity>
     </View>
-  )
-})
+  );
+});
 
-export default CopyTextToClipboard
+export default CopyTextToClipboard;
 
 const styles = StyleSheet.create({
   container: { justifyContent: 'center', alignItems: 'center', paddingHorizontal: 16 },
-})
+});

--- a/helpers/formatBTCAddress.ts
+++ b/helpers/formatBTCAddress.ts
@@ -1,0 +1,10 @@
+export function formatBTCAddress(address: string): string {
+  const groups: string[] = address.match(/.{1,4}/g) || []
+  const lines: string[] = []
+
+  for (let i = 0; i < groups.length; i += 6) {
+    lines.push(groups.slice(i, i + 6).join(' '))
+  }
+
+  return lines.join('\n')
+}

--- a/tests/unit/formatBTCAddress.test.ts
+++ b/tests/unit/formatBTCAddress.test.ts
@@ -1,0 +1,27 @@
+import assert from 'assert'
+import { formatBTCAddress } from '../../helpers/formatBTCAddress'
+
+
+describe('formatBTCAddress', () => {
+  it('correctly formats a Bech32 address', () => {
+    const input = 'bc1q3vjvgqhsz6yah54ezz54vmqre8n3yl6s8uetxr'
+    const expected = `bc1q 3vjv gqhs z6ya h54e zz54\nvmqr e8n3 yl6s 8uet xr`
+    expect(formatBTCAddress(input)).toBe(expected)
+  })
+
+  it('handles shorter P2PKH addresses', () => {
+    const input = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
+    const expected = `1A1z P1eP 5QGe fi2D MPTf TL5S\nLmv7 Divf Na`
+    expect(formatBTCAddress(input)).toBe(expected)
+  })
+
+  it('formats addresses that do not fill all 6 groups per line', () => {
+    const input = 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh'
+    const expected = `bc1q xy2k gdyg jrsq tzq2 n0yr\nf249 3p83 kkfj hx0w lh`
+    expect(formatBTCAddress(input)).toBe(expected)
+  })
+
+  it('returns an empty string when the input is empty', () => {
+    expect(formatBTCAddress('')).toBe('')
+  })
+})

--- a/tests/unit/formatBTCAddress.test.ts
+++ b/tests/unit/formatBTCAddress.test.ts
@@ -1,27 +1,25 @@
-import assert from 'assert'
-import { formatBTCAddress } from '../../helpers/formatBTCAddress'
-
+import { formatBTCAddress } from '../../helpers/formatBTCAddress';
 
 describe('formatBTCAddress', () => {
   it('correctly formats a Bech32 address', () => {
-    const input = 'bc1q3vjvgqhsz6yah54ezz54vmqre8n3yl6s8uetxr'
-    const expected = `bc1q 3vjv gqhs z6ya h54e zz54\nvmqr e8n3 yl6s 8uet xr`
-    expect(formatBTCAddress(input)).toBe(expected)
-  })
+    const input = 'bc1q3vjvgqhsz6yah54ezz54vmqre8n3yl6s8uetxr';
+    const expected = `bc1q 3vjv gqhs z6ya h54e zz54\nvmqr e8n3 yl6s 8uet xr`;
+    expect(formatBTCAddress(input)).toBe(expected);
+  });
 
   it('handles shorter P2PKH addresses', () => {
-    const input = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
-    const expected = `1A1z P1eP 5QGe fi2D MPTf TL5S\nLmv7 Divf Na`
-    expect(formatBTCAddress(input)).toBe(expected)
-  })
+    const input = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+    const expected = `1A1z P1eP 5QGe fi2D MPTf TL5S\nLmv7 Divf Na`;
+    expect(formatBTCAddress(input)).toBe(expected);
+  });
 
   it('formats addresses that do not fill all 6 groups per line', () => {
-    const input = 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh'
-    const expected = `bc1q xy2k gdyg jrsq tzq2 n0yr\nf249 3p83 kkfj hx0w lh`
-    expect(formatBTCAddress(input)).toBe(expected)
-  })
+    const input = 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh';
+    const expected = `bc1q xy2k gdyg jrsq tzq2 n0yr\nf249 3p83 kkfj hx0w lh`;
+    expect(formatBTCAddress(input)).toBe(expected);
+  });
 
   it('returns an empty string when the input is empty', () => {
-    expect(formatBTCAddress('')).toBe('')
-  })
-})
+    expect(formatBTCAddress('')).toBe('');
+  });
+});


### PR DESCRIPTION
### Summary

Improved the formatting of BTC addresses by splitting them into groups of 4 characters over multiple lines to enhance readability for users.

### Changes

- Created a utility function `formatBTCAddress`
- Applied the format in the UI only in the CopyTextToClipboard component

No logic was changed, only formatting for better UX.

### Screenshots

Before:
![image](https://github.com/user-attachments/assets/5cd6d9d7-1d81-4d72-8246-163859a4d1b6)

After:
![image](https://github.com/user-attachments/assets/89aecb01-a93a-46b8-88e9-45f1ffe7fb74)
