### PR TITLE
FIX: isItMyAddress fails for uppercase Bech32 multisig addresses

### DIFF
--- a/class/wallets/abstract-hd-electrum-wallet.ts
+++ b/class/wallets/abstract-hd-electrum-wallet.ts
@@ -17,6 +17,7 @@ import { randomBytes } from '../rng';
 import { AbstractHDWallet } from './abstract-hd-wallet';
 import { CreateTransactionResult, CreateTransactionTarget, CreateTransactionUtxo, Transaction, Utxo } from './types';
 import { SilentPayment, UTXOType as SPUTXOType, UTXO as SPUTXO } from 'silent-payments';
+import { isValidBech32Address } from '../../utils/isValidBech32Address';
 
 const ECPair = ECPairFactory(ecc);
 const bip32 = BIP32Factory(ecc);
@@ -1109,8 +1110,10 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     if (!address) return false;
     let cleanAddress = address;
 
-    if (this.segwitType === 'p2wpkh') {
-      cleanAddress = address.toLowerCase();
+    const isBech32Address = isValidBech32Address(address);
+
+    if (isBech32Address) {
+      cleanAddress = address.toLocaleLowerCase();
     }
 
     for (let c = 0; c < this.next_free_address_index + this.gap_limit; c++) {

--- a/tests/unit/isValidBech32Address.test.ts
+++ b/tests/unit/isValidBech32Address.test.ts
@@ -1,0 +1,31 @@
+import { isValidBech32Address } from '../../utils/isValidBech32Address';
+
+describe('isValidBech32Address', () => {
+  const validBech32Addresses: string[] = [
+    'bc1qatswv5uv7qetzz4n8u9u2x2ckmaxvc8qng5s7r', // P2WPKH (SegWit v0)
+    'bc1ph76f32dqjkvd523g02ucylqstljj5pysqe3lmyuepnuyz5d7lw9sl0pp4m', // P2TR (Taproot v1)
+    'tb1ql4jps5nxnyz7qxgle9dp3q0mww2jk4ckfua6lr', // Testnet SegWit v0
+    'tb1p4tp4l6glyr2gs94neqcpr5gha7344nfyznfkc8szkreflscsdkgqsdent4', // Testnet Taproot v1
+  ];
+
+  const invalidBech32Addresses: (string | null | undefined)[] = [
+    'moKVV6XEhfrBCE3QCYq6ppT7AaMF8KsZ1B',
+    '16X9EwoL5fgUr2ordTy8bs7wT4Ff3QGQPW', // Legacy (P2PKH)
+    '3HFvmZJhc7KbqVXXQXaa34StUPk4gxcQyR', // P2SH
+    'bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj', // Invalid checksum
+    'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kyd39', // Too short
+    'BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KYGT080', // Uppercase (invalid Bech32)
+    'bcrt1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh', // Regtest
+    '', // Empty string
+    null,
+    undefined,
+  ];
+
+  test.each(validBech32Addresses)('should return true for valid Bech32 address: %s', (address: string) => {
+    expect(isValidBech32Address(address)).toBe(true);
+  });
+
+  test.each(invalidBech32Addresses)('should return false for invalid Bech32 address: %s', (address: string | null | undefined) => {
+    expect(isValidBech32Address(address as string)).toBe(false);
+  });
+});

--- a/utils/isValidBech32Address.ts
+++ b/utils/isValidBech32Address.ts
@@ -1,0 +1,10 @@
+import * as bitcoin from 'bitcoinjs-lib';
+
+export function isValidBech32Address(address: string): boolean {
+  try {
+    const result = bitcoin.address.fromBech32(address);    
+    return true;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
This fix detects if the address is Bech32, then normalizes it to lowercase before comparison

Fixes #7888


![image](https://github.com/user-attachments/assets/725a3251-c932-48d3-a679-a9f9a531b9c2)
