### PR TITLE
ADD: Allow custom fees below 1 sat/vByte

### DIFF
--- a/loc/en.json
+++ b/loc/en.json
@@ -385,7 +385,9 @@
     "to": "To: {counterparty}",
     "updating": "Updating...",
     "watchOnlyWarningTitle": "Security warning",
-    "watchOnlyWarningDescription": "Be cautious of scammers who often use “watch-only” wallets to deceive users. These wallets do not allow you to control or send funds; they only let you view the balance."
+    "watchOnlyWarningDescription": "Be cautious of scammers who often use “watch-only” wallets to deceive users. These wallets do not allow you to control or send funds; they only let you view the balance.",
+    "custom_fee_warning_title": "Warning",
+    "custom_fee_warning_description": "Fees below 1 sat/vB are valid, but may not be relayed due to node policies."
   },
   "wallets": {
     "add_bitcoin": "Bitcoin",

--- a/screen/SelectFeeScreen.tsx
+++ b/screen/SelectFeeScreen.tsx
@@ -235,7 +235,7 @@ const SelectFeeScreen = () => {
 
   const handleCustomFeeSubmit = useCallback(() => {
     const numericValue = state.customFeeValue.replace(',', '.');
-    if (numericValue && Number(numericValue) > 0) {
+    if (numericValue && Number(numericValue) >= 0) {
       navigateWithFee(numericValue, NetworkTransactionFeeType.CUSTOM);
     }
   }, [state.customFeeValue, navigateWithFee]);
@@ -243,7 +243,7 @@ const SelectFeeScreen = () => {
   const handleCustomFeeBlur = useCallback(() => {
     dispatch({ type: FeeScreenActions.SET_CUSTOM_FEE_BLURRED });
     const numericValue = Number(state.customFeeValue.replace(',', '.'));
-    if (!state.customFeeValue || numericValue === 0) {
+    if (!state.customFeeValue || numericValue < 0) {
       dispatch({ type: FeeScreenActions.CLEAR_CUSTOM_FEE });
     }
   }, [state.customFeeValue]);

--- a/screen/send/SendDetails.tsx
+++ b/screen/send/SendDetails.tsx
@@ -1449,8 +1449,8 @@ const SendDetails = () => {
 
     return (
       <View style={[styles.warningContainer, stylesHook.warningContainer]}>
-        <Text style={[styles.warningHeader, stylesHook.warningText]}>Warning</Text>
-        <Text style={stylesHook.warningText}>Fees below 1 sat/vB are valid, but may not be relayed due to node policies.</Text>
+        <Text style={[styles.warningHeader, stylesHook.warningText]}>{loc.transactions.custom_fee_warning_title}</Text>
+        <Text style={stylesHook.warningText}>{loc.transactions.custom_fee_warning_description}</Text>
       </View>
     );
   };

--- a/screen/send/SendDetails.tsx
+++ b/screen/send/SendDetails.tsx
@@ -491,7 +491,7 @@ const SendDetails = () => {
       } else if (parseFloat(String(transaction.amountSats)) <= 500) {
         error = loc.send.details_amount_field_is_less_than_minimum_amount_sat;
         console.log('validation error');
-      } else if (!requestedSatPerByte || parseFloat(requestedSatPerByte) < 1) {
+      } else if (!requestedSatPerByte || parseFloat(requestedSatPerByte) < 0) {
         error = loc.send.details_fee_field_is_not_valid;
         console.log('validation error');
       } else if (!transaction.address) {

--- a/screen/send/SendDetails.tsx
+++ b/screen/send/SendDetails.tsx
@@ -1264,6 +1264,12 @@ const SendDetails = () => {
     feeValue: {
       color: colors.feeValue,
     },
+    warningContainer: {
+      backgroundColor: colors.changeBackground,
+    },
+    warningText: {
+      color: colors.changeText,
+    },
   });
 
   const calculateTotalAmount = () => {
@@ -1438,6 +1444,17 @@ const SendDetails = () => {
     );
   };
 
+  const renderCustomFeeWarning = () => {
+    if (!customFee || Number(customFee) >= 1) return;
+
+    return (
+      <View style={[styles.warningContainer, stylesHook.warningContainer]}>
+        <Text style={[styles.warningHeader, stylesHook.warningText]}>Warning</Text>
+        <Text style={stylesHook.warningText}>Fees below 1 sat/vB are valid, but may not be relayed due to node policies.</Text>
+      </View>
+    );
+  };
+
   const getItemLayout = (_: any, index: number) => ({
     length: dimensions.width,
     offset: dimensions.width * index,
@@ -1507,6 +1524,7 @@ const SendDetails = () => {
             </View>
           )}
         </Pressable>
+        {renderCustomFeeWarning()}
         {renderCreateButton()}
       </View>
       <DismissKeyboardInputAccessory />
@@ -1630,5 +1648,16 @@ const styles = StyleSheet.create({
   },
   pressed: {
     opacity: 0.6,
+  },
+  warningContainer: {
+    flexDirection: 'column',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    marginHorizontal: 16,
+    borderRadius: 4,
+    marginTop: 12,
+  },
+  warningHeader: {
+    fontWeight: 'bold',
   },
 });


### PR DESCRIPTION
Fixes #7964

This PR removes the restriction that prevented users from entering custom transaction fee rates below 1 sat/vB

### Screenshot with custom fee set to 0 sat/vByte
![image](https://github.com/user-attachments/assets/6c67c5b4-65cb-4075-aebe-aec1a0cad331) 

### Screenshot with custom fee set to 0.5 sat/vByte
![image](https://github.com/user-attachments/assets/90f29028-7bc0-4499-a3ec-d0c29746712d)


