### PR TITLE
Replace cryptographic functions with noble hashes

### DIFF
--- a/class/lnurl.ts
+++ b/class/lnurl.ts
@@ -1,7 +1,7 @@
 import { bech32 } from 'bech32';
 import bolt11 from 'bolt11';
-import createHash from 'create-hash';
-import { createHmac } from 'crypto';
+import { sha256 } from '@noble/hashes/sha256';
+import { hmac } from '@noble/hashes/hmac';
 import CryptoJS from 'crypto-js';
 // @ts-ignore theres no types for secp256k1
 import secp256k1 from 'secp256k1';
@@ -189,7 +189,7 @@ export default class Lnurl {
 
     // check pr description_hash, amount etc:
     const decoded = this.decodeInvoice(this._lnurlPayServiceBolt11Payload.pr);
-    const metadataHash = createHash('sha256').update(this._lnurlPayServicePayload.metadata).digest('hex');
+    const metadataHash = Buffer.from(sha256(this._lnurlPayServicePayload.metadata)).toString('hex');
     if (metadataHash !== decoded.description_hash) {
       console.log(`Invoice description_hash doesn't match metadata.`);
     }
@@ -355,28 +355,25 @@ export default class Lnurl {
 
       const url = parse(Lnurl.getUrlFromLnurl(this._lnurl) || '', true);
 
-      const hmac = createHmac('sha256', secret);
-      hmac.on('readable', async () => {
-        try {
-          const privateKey = hmac.read();
-          if (!privateKey) return;
-          const privateKeyBuf = Buffer.from(privateKey, 'hex');
-          const publicKey = secp256k1.publicKeyCreate(privateKeyBuf);
-          const signatureObj = secp256k1.sign(Buffer.from(url.query.k1 as string, 'hex'), privateKeyBuf);
-          const derSignature = secp256k1.signatureExport(signatureObj.signature);
+      try {
+        const privateKey = hmac(sha256, secret, url.hostname);
+        const privateKeyBuf = Buffer.from(privateKey);
+        const publicKey = secp256k1.publicKeyCreate(privateKeyBuf);
+        const signatureObj = secp256k1.sign(Buffer.from(url.query.k1 as string, 'hex'), privateKeyBuf);
+        const derSignature = secp256k1.signatureExport(signatureObj.signature);
 
-          const reply = await this.fetchGet(`${url.href}&sig=${derSignature.toString('hex')}&key=${publicKey.toString('hex')}`);
+        this.fetchGet(`${url.href}&sig=${derSignature.toString('hex')}&key=${publicKey.toString('hex')}`).then(reply => {
           if (reply.status === 'OK') {
             resolve();
           } else {
             reject(reply.reason);
           }
-        } catch (err) {
+        }).catch(err => {
           reject(err);
-        }
-      });
-      hmac.write(url.hostname);
-      hmac.end();
+        });
+      } catch (err) {
+        reject(err);
+      }
     });
   }
 


### PR DESCRIPTION
Replace `createHash` and `createHmac` with `@noble/hashes` in `class/lnurl.ts` for modern cryptography and a simplified HMAC implementation.

The stream-based `createHmac` usage was replaced with a synchronous call using `@noble/hashes/hmac` for a cleaner and more direct approach.