### PR TITLE
Remove ecurve dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "dayjs": "1.11.13",
         "detox": "20.28.0",
         "ecpair": "3.0.0",
-        "ecurve": "1.0.6",
         "electrum-client": "github:BlueWallet/rn-electrum-client#d9f511d",
         "electrum-mnemonic": "2.0.0",
         "events": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "dayjs": "1.11.13",
     "detox": "20.28.0",
     "ecpair": "3.0.0",
-    "ecurve": "1.0.6",
     "electrum-client": "github:BlueWallet/rn-electrum-client#d9f511d",
     "electrum-mnemonic": "2.0.0",
     "events": "3.3.0",


### PR DESCRIPTION
Remove direct `ecurve` dependency.

The `ecurve` dependency was removed from direct dependencies. It remains as a transitive dependency through `bip38` (github.com/BlueWallet/bip38.git).