### PR TITLE
Fix return type for latest transaction time

### DIFF
--- a/class/wallets/lightning-custodian-wallet.ts
+++ b/class/wallets/lightning-custodian-wallet.ts
@@ -666,7 +666,11 @@ export class LightningCustodianWallet extends LegacyWallet {
   }
 
   getLatestTransactionTime(): string | 0 {
-    return new Date(this.getTransactions().reduce((max: number, tx: any) => Math.max(max, tx.timestamp), 0) * 1000).toString();
+    const transactions = this.getTransactions();
+    if (transactions.length === 0) {
+      return 0;
+    }
+    return new Date(transactions.reduce((max: number, tx: any) => Math.max(max, tx.timestamp), 0) * 1000).toString();
   }
 }
 


### PR DESCRIPTION
Fix `getLatestTransactionTime()` to return `0` when no transactions exist, resolving type mismatch and pull-to-refresh issues.