### PR TITLE
Fix transaction type enum case

### DIFF
--- a/ios/BlueWalletWatch/Objects/Transaction.swift
+++ b/ios/BlueWalletWatch/Objects/Transaction.swift
@@ -41,7 +41,7 @@ extension Transaction {
             Transaction(
                 time: Date(timeIntervalSince1970: 1714308153), // 2024-04-26T11:22:33Z
                 memo: "Another Mock Transaction",
-                type: .timestamp,
+                type: .received,
                 amount: Decimal(string: "0.002")!
             ),
             Transaction(

--- a/ios/BlueWalletWatch/Objects/TransactionTableRow.swift
+++ b/ios/BlueWalletWatch/Objects/TransactionTableRow.swift
@@ -43,7 +43,7 @@ class TransactionTableRow: NSObject {
     willSet {
       if newValue == .pending {
         transactionTypeImage.setImage(UIImage(named: "pendingConfirmation"))
-      } else if newValue == .timestamp {
+      } else if newValue == .received {
         transactionTypeImage.setImage(UIImage(named: "receivedArrow"))
       } else if newValue == .sent {
         transactionTypeImage.setImage(UIImage(named: "sentArrow"))

--- a/ios/BlueWalletWatch/Objects/TransactionType.swift
+++ b/ios/BlueWalletWatch/Objects/TransactionType.swift
@@ -26,7 +26,7 @@ enum TransactionType: Codable, Equatable {
     case unknown(String) // For any unknown or future transaction types
     
     case sent
-    case timestamp
+    case received
 
     // MARK: - Coding Keys
     enum CodingKeys: String, CodingKey {
@@ -50,8 +50,8 @@ enum TransactionType: Codable, Equatable {
         switch typeString.lowercased() {
         case "sent":
             return .sent
-        case "timestamp":
-            return .timestamp
+        case "received":
+            return .received
         case "pending":
             return .pending
         case "bitcoind_tx":
@@ -69,8 +69,8 @@ enum TransactionType: Codable, Equatable {
         switch self {
         case .sent:
             return "sent"
-        case .timestamp:
-            return "timestamp"
+        case .received:
+            return "received"
         case .pending:
             return "pending"
         case .onchain:
@@ -92,8 +92,8 @@ extension TransactionType: CustomStringConvertible {
         switch self {
         case .sent:
             return "Sent"
-        case .timestamp:
-            return "Timestamp"
+        case .received:
+            return "Received"
         case .pending:
             return "pending"
         case .onchain:
@@ -112,7 +112,7 @@ extension TransactionType: CustomStringConvertible {
 extension TransactionType {
     var isIncoming: Bool {
         switch self {
-        case .timestamp:
+        case .received:
             return true
         default:
             return false
@@ -141,7 +141,7 @@ extension TransactionType {
       return .sent
     }
 
-    static var mockTimestamp: TransactionType {
-      return .timestamp
+    static var mockReceived: TransactionType {
+      return .received
     }
 }


### PR DESCRIPTION
Rename `TransactionType.timestamp` to `TransactionType.received` to correct a semantic error and restore proper transaction categorization.