### PR TITLE
FIX: Custom fee displayed in exponent form (eg 1.5e-7)

### DIFF
--- a/loc/index.ts
+++ b/loc/index.ts
@@ -319,7 +319,7 @@ export function formatBalance(balance: number, toUnit: string, withFormatting = 
   }
   if (toUnit === BitcoinUnit.BTC) {
     const value = new BigNumber(balance).dividedBy(100000000).toFixed(8);
-    return removeTrailingZeros(+value) + ' ' + loc.units[BitcoinUnit.BTC];
+    return removeTrailingZeros(value) + ' ' + loc.units[BitcoinUnit.BTC];
   } else if (toUnit === BitcoinUnit.SATS) {
     return (withFormatting ? new Intl.NumberFormat().format(balance).toString() : String(balance)) + ' ' + loc.units[BitcoinUnit.SATS];
   } else {

--- a/tests/unit/loc.test.js
+++ b/tests/unit/loc.test.js
@@ -71,6 +71,9 @@ describe('Localization', () => {
   it.each([
     [123000000, BitcoinUnit.SATS, false, '123000000 sats'],
     [123000000, BitcoinUnit.BTC, false, '1.23 BTC'],
+    [15, BitcoinUnit.BTC, false, '0.00000015 BTC'],
+    [1, BitcoinUnit.BTC, false, '0.00000001 BTC'],
+    [0, BitcoinUnit.BTC, false, '0 BTC'],
     [123000000, BitcoinUnit.LOCAL_CURRENCY, false, '$1.23'],
   ])(
     'can formatBalance',


### PR DESCRIPTION
When user enters a custom fee below 1 sat/vByte, the fee was being calculated and displayed in exponent form eg 1.5e-7 BTC

This PR fixes that bug and displays the amount in decimals eg 0.00000015 BTC

<img width="540" height="1170" alt="image" src="https://github.com/user-attachments/assets/f208886e-14da-44eb-9ac0-10795a3a065a" />


