### PR TITLE
FIX: Keyboard covering input and background on seedwords

### DIFF
--- a/components/SeedWords.tsx
+++ b/components/SeedWords.tsx
@@ -18,7 +18,6 @@ const SeedWords = ({ seed }: { seed: string }) => {
     },
     secret: {
       flexDirection: direction === 'rtl' ? 'row-reverse' : 'row',
-      backgroundColor: colors.lightBorder,
     },
   });
 

--- a/components/themes.ts
+++ b/components/themes.ts
@@ -71,6 +71,7 @@ export const BlueDefaultTheme = {
     receiveText: '#37C0A1',
     navigationBarColor: '#FFFFFF',
     androidRippleColor: '#CCCCCC',
+    modalOverlayColor: 'rgba(0,0,0,0.3)',
   },
 };
 
@@ -129,6 +130,7 @@ export const BlueDarkTheme: Theme = {
     receiveText: '#37C0A1',
     navigationBarColor: '#3A3A3C',
     androidRippleColor: '#444444',
+    modalOverlayColor: 'rgba(0,0,0,0.6)',
   },
 };
 

--- a/screen/receive/ReceiveDetails.tsx
+++ b/screen/receive/ReceiveDetails.tsx
@@ -608,10 +608,10 @@ const ReceiveDetails = () => {
         </View>
       </SafeAreaScrollView>
 
-      <Modal visible={isModalVisible} animationType="slide" transparent onRequestClose={() => setIsModalVisible(false)}>
+      <Modal visible={isModalVisible} animationType="fade" transparent statusBarTranslucent onRequestClose={() => setIsModalVisible(false)}>
         <Pressable style={[stylesHook.modal, styles.modal]} onPress={() => setIsModalVisible(false)}>
           <KeyboardAvoidingView
-            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+            behavior="padding"
             keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
             style={[stylesHook.keyboardAvoidingView, styles.keyboardAvoidingView]}
           >


### PR DESCRIPTION
I fixed the following in this PR
- Removed background color on the container for the SeedWords
- Fixed the issue of keyboard covering the input when you try to recieve with amount 
   I replaced  `BottomModal`  component with the `Modal` from ` react-native`
  
   The `BottomModal`  is using `@lodev09/react-native-true-sheet` as a dependency so I decided to use `Modal` from `react-native` 




I tested these changes on Samsung A54. 

<img width="498" height="1080" alt="image" src="https://github.com/user-attachments/assets/ea27af07-eb11-45c0-8e30-472aa30b1eb7" />
<img width="498" height="1080" alt="image" src="https://github.com/user-attachments/assets/4cb84203-cdbd-441b-8af4-1910a26977d0" />
