### PR TITLE
Replace react-native-randombytes with get-random-values

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import './gesture-handler';
+import 'react-native-get-random-values';
 import './shim.js';
 
 import React, { useEffect } from 'react';

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "react-native-push-notification": "8.1.1",
     "react-native-qrcode-svg": "6.3.15",
     "react-native-quick-actions": "0.3.13",
-    "react-native-randombytes": "3.6.1",
+    "react-native-get-random-values": "1.11.0",
     "react-native-rate": "1.2.12",
     "react-native-reanimated": "3.18.0",
     "react-native-safe-area-context": "5.5.2",


### PR DESCRIPTION
Replace `react-native-randombytes` with `react-native-get-random-values` to use a more standard and maintained random number polyfill.

---
<a href="https://cursor.com/background-agent?bcId=bc-82b1be3b-fb5a-4e05-9e26-e534ae2f85b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82b1be3b-fb5a-4e05-9e26-e534ae2f85b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

