### PR TITLE
Info.plist: fixed NSFaceIDUsageDescription & removed ATS redundancy

### DIFF
--- a/ios/BlueWallet/Info.plist
+++ b/ios/BlueWallet/Info.plist
@@ -149,8 +149,6 @@
 	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 		<key>NSExceptionDomains</key>
@@ -186,7 +184,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>In order to quickly scan the recipient's address, we need your permission to use the camera to scan their QR Code.</string>
 	<key>NSFaceIDUsageDescription</key>
-	<string>In order to use FaceID please confirm your permission.</string>
+	<string>In order to use FaceID for authentication when performing sensitive actions, we need your permission.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Your authorization is required to save this image.</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
Added accurate `NSFaceIDUsageDescription` that fulfills the requirement of ["A message that tells people why the app is requesting the ability to authenticate with Face ID"](https://developer.apple.com/documentation/bundleresources/information-property-list/nsfaceidusagedescription) rather than restating the system popup. 

Removed App Transport Security redundancy. (The value of `NSAllowsArbitraryLoads` is [ignored](https://developer.apple.com/documentation/BundleResources/Information-Property-List/NSAppTransportSecurity/NSAllowsArbitraryLoads) in the presence of `NSAllowsLocalNetworking`)