### PR TITLE
ADD: add Egyptian Pound (EGP) support using yadioConverter

### DIFF
--- a/android/app/src/main/assets/fiatUnits.json
+++ b/android/app/src/main/assets/fiatUnits.json
@@ -111,6 +111,13 @@
         "symbol": "kr",
         "country": "Denmark (Danish Krone)"
     },
+    "EGP": {
+        "endPointKey": "EGP",
+        "locale": "ar-EG",
+        "source": "YadioConvert",
+        "symbol": "ج.م.",
+        "country": "Egypt (Egyptian Pound)"
+    },
     "EUR": {
         "endPointKey": "EUR",
         "locale": "en-IE",

--- a/ios/Widgets/Shared/FiatUnitEnum.swift
+++ b/ios/Widgets/Shared/FiatUnitEnum.swift
@@ -21,6 +21,7 @@ enum FiatUnitEnum: String, AppEnum, CaseIterable, Identifiable, Codable {
     case COP
     case CZK
     case DKK
+    case EGP
     case EUR
     case GBP
     case HRK
@@ -98,6 +99,8 @@ enum FiatUnitEnum: String, AppEnum, CaseIterable, Identifiable, Codable {
             return "CoinGecko"
         case .DKK:
             return "CoinGecko"
+        case .EGP:
+            return "YadioConvert"
         case .EUR:
             return "Kraken"
         case .GBP:
@@ -208,6 +211,7 @@ enum FiatUnitEnum: String, AppEnum, CaseIterable, Identifiable, Codable {
             .COP: DisplayRepresentation(stringLiteral: "Colombia (Colombian Peso)"),
             .CZK: DisplayRepresentation(stringLiteral: "Czech Republic (Czech Koruna)"),
             .DKK: DisplayRepresentation(stringLiteral: "Denmark (Danish Krone)"),
+            .EGP: DisplayRepresentation(stringLiteral: "Egypt (Egyptian Pound)"),
             .EUR: DisplayRepresentation(stringLiteral: "European Union (Euro)"),
             .GBP: DisplayRepresentation(stringLiteral: "United Kingdom (British Pound)"),
             .HRK: DisplayRepresentation(stringLiteral: "Croatia (Croatian Kuna)"),

--- a/models/fiatUnits.json
+++ b/models/fiatUnits.json
@@ -111,6 +111,13 @@
         "symbol": "kr",
         "country": "Denmark (Danish Krone)"
     },
+    "EGP": {
+        "endPointKey": "EGP",
+        "locale": "ar-EG",
+        "source": "YadioConvert",
+        "symbol": "ج.م.",
+        "country": "Egypt (Egyptian Pound)"
+    },
     "EUR": {
         "endPointKey": "EUR",
         "locale": "en-IE",


### PR DESCRIPTION
#### Summary

This PR introduces support for the **Egyptian Pound (EGP)** as a fiat currency across Android, iOS, and shared models.

#### Changes

* **fiatUnits.json** (Android & models):

  * Added `EGP` entry with ISO code, locale (`ar-EG`), symbol (`ج.م.`), and country.
  * Configured source as **YadioConverter**.

* **FiatUnitEnum (iOS)**:

  * Added `EGP` case with source `YadioConvert`.
  * Added display representation: `"Egypt (Egyptian Pound)"`.

Closes #8077