### PR TITLE
FIX: Remove  background color from seed words

### DIFF
--- a/components/SeedWords.tsx
+++ b/components/SeedWords.tsx
@@ -18,7 +18,6 @@ const SeedWords = ({ seed }: { seed: string }) => {
     },
     secret: {
       flexDirection: direction === 'rtl' ? 'row-reverse' : 'row',
-      backgroundColor: colors.lightBorder,
     },
   });
 


### PR DESCRIPTION
Summary

This PR removes the background color from the seed words to improve the overall UI/UX, resulting in a cleaner and more consistent look.

Context

This change was originally part of [#8032](https://github.com/BlueWallet/BlueWallet/pull/8032/commits), but following [this discussion](https://github.com/BlueWallet/BlueWallet/pull/8032#issuecomment-3364422400), it was separated into its own PR. The previous PR (#8032) has since been closed.

Before
<img width="502" height="1041" alt="Screenshot from 2025-10-05 17-43-21" src="https://github.com/user-attachments/assets/aea8d352-aa5d-4289-b451-ef8d838f33c9" />


After


<img width="502" height="1041" alt="Screenshot from 2025-10-05 17-48-44" src="https://github.com/user-attachments/assets/77d913ff-21b5-41e6-ade4-9ccb0ceaac84" />