### PR TITLE
refactor: speed-up getting utxo (improves send screen performance)

### DIFF
--- a/class/measure.ts
+++ b/class/measure.ts
@@ -1,0 +1,18 @@
+/**
+ * Simple helper to measure execution time of a code block
+ */
+export class Measure {
+  private _label: string;
+  private _start: number;
+
+  constructor(label: string) {
+    this._label = label;
+    this._start = Date.now();
+  }
+
+  public end() {
+    const end = Date.now();
+    const duration = Number(((end - this._start) / 1000).toFixed(3));
+    console.log(`${this._label} took ${duration}s`);
+  }
+}

--- a/class/wallets/abstract-hd-electrum-wallet.ts
+++ b/class/wallets/abstract-hd-electrum-wallet.ts
@@ -1052,10 +1052,11 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     if (returnSpentUtxoAsWell) return utxos;
 
     // got all utxos we ever had. lets filter out the ones that are spent:
+    const txs = this.getTransactions();
     const ret = [];
     for (const utxo of utxos) {
       let spent = false;
-      for (const tx of this.getTransactions()) {
+      for (const tx of txs) {
         for (const input of tx.inputs) {
           if (input.txid === utxo.txid && input.vout === utxo.vout) spent = true;
           // utxo we got previously was actually spent right here ^^

--- a/class/wallets/legacy-wallet.ts
+++ b/class/wallets/legacy-wallet.ts
@@ -215,9 +215,10 @@ export class LegacyWallet extends AbstractWallet {
 
     // got all utxos we ever had. lets filter out the ones that are spent:
     const ret = [];
+    const txs = this.getTransactions();
     for (const utxo of utxos) {
       let spent = false;
-      for (const tx of this.getTransactions()) {
+      for (const tx of txs) {
         for (const input of tx.inputs) {
           if (input.txid === utxo.txid && input.vout === utxo.vout) spent = true;
           // utxo we got previously was actually spent right here ^^

--- a/screen/send/SendDetails.tsx
+++ b/screen/send/SendDetails.tsx
@@ -55,6 +55,7 @@ import { SendDetailsStackParamList } from '../../navigation/SendDetailsStackPara
 import { CommonToolTipActions, ToolTipAction } from '../../typings/CommonToolTipActions';
 import ActionSheet from '../ActionSheet';
 import { isCancel, pickTransaction } from '../../blue_modules/fs';
+import { Measure } from '../../class/measure';
 
 interface IPaymentDestinations {
   address: string; // btc address or payment code
@@ -291,7 +292,9 @@ const SendDetails = () => {
     if (!wallet) return; // wait for it
     const fees = networkTransactionFees;
     const requestedSatPerByte = Number(feeRate);
+    const m = new Measure('getUtxo');
     const lutxo = utxos || wallet.getUtxo();
+    m.end();
     let frozen = 0;
     if (!utxos) {
       // if utxo is not limited search for frozen outputs and calc it's balance


### PR DESCRIPTION
`getDerivedUtxoFromOurTransaction()`  was calling `.getTransactions()` in cycle, which is a heavy operation.  simply caching resolved performance issues on midsize-large wallets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cache `getTransactions()` when deriving UTXOs and add a `Measure` utility to time `getUtxo` in SendDetails, improving send screen performance.
> 
> - **Wallets**:
>   - Cache `getTransactions()` result in `getDerivedUtxoFromOurTransaction()` to avoid repeated calls when filtering spent UTXOs in:
>     - `class/wallets/abstract-hd-electrum-wallet.ts`
>     - `class/wallets/legacy-wallet.ts`
> - **UI (Send)**:
>   - Time UTXO retrieval in `screen/send/SendDetails.tsx` fee recalculation via new `Measure('getUtxo')`.
> - **Utils**:
>   - Add `class/measure.ts` simple timing helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c943aba11d00bd712c54c091564b54ce4020b42f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->