### PR TITLE
FIX: Linking test fails in selftest

### DIFF
--- a/screen/settings/SelfTest.tsx
+++ b/screen/settings/SelfTest.tsx
@@ -325,7 +325,7 @@ export default class SelfTest extends Component {
       //
 
       if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') {
-        assertStrictEqual(await Linking.canOpenURL('https://github.com/BlueWallet/BlueWallet/'), true, 'Linking can not open https url');
+        assertStrictEqual(await Linking.canOpenURL('https://bluewallet.io/'), true, 'Linking can not open https url');
       } else {
         // skipping RN-specific test'
       }


### PR DESCRIPTION
Fixes #8127

I updated the URL in the self-test from `https://github.com/BlueWallet/BlueWallet/` to `https://bluewallet.io/` because if a user has the GitHub mobile app installed, the test fails.
Similarly, testing with `https://x.com/bluewalletio/` also fails if the user has the X app installed.

Using `https://bluewallet.io/` is a better alternative because it opens directly in the system browser rather than being intercepted by an installed app. This ensures that `Linking.canOpenURL `consistently returns true across devices, making the test stable and deterministic.