### PR TITLE
Fix hidden passphrase prompt during wallet import

### DIFF
--- a/components/PassphrasePrompt.tsx
+++ b/components/PassphrasePrompt.tsx
@@ -1,0 +1,149 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Keyboard, KeyboardAvoidingView, Modal, Platform, StyleSheet, Text, TextInput, View } from 'react-native';
+import Button from './Button';
+import { SecondButton } from './SecondButton';
+import { BlueSpacing10, BlueSpacing20 } from './BlueSpacing';
+import { useTheme } from './themes';
+
+interface PassphrasePromptProps {
+  visible: boolean;
+  title: string;
+  message: string;
+  cancelButtonText?: string;
+  continueButtonText?: string;
+  defaultValue?: string;
+  onCancel: () => void;
+  onSubmit: (value: string) => void;
+  testID?: string;
+}
+
+const PassphrasePrompt: React.FC<PassphrasePromptProps> = ({
+  visible,
+  title,
+  message,
+  cancelButtonText = 'Cancel',
+  continueButtonText = 'OK',
+  defaultValue = '',
+  onCancel,
+  onSubmit,
+  testID = 'PassphrasePrompt',
+}) => {
+  const { colors } = useTheme();
+  const [value, setValue] = useState(defaultValue);
+
+  const stylesHook = useMemo(
+    () => ({
+      content: {
+        backgroundColor: colors.elevated,
+      },
+      title: {
+        color: colors.foregroundColor,
+      },
+      message: {
+        color: colors.feeText,
+      },
+      input: {
+        backgroundColor: colors.inputBackgroundColor,
+        borderColor: colors.formBorder,
+        color: colors.foregroundColor,
+      },
+    }),
+    [colors],
+  );
+
+  useEffect(() => {
+    if (visible) {
+      setValue(defaultValue);
+    }
+  }, [visible, defaultValue]);
+
+  const handleSubmit = useCallback(() => {
+    Keyboard.dismiss();
+    onSubmit(value);
+  }, [onSubmit, value]);
+
+  const handleCancel = useCallback(() => {
+    Keyboard.dismiss();
+    onCancel();
+  }, [onCancel]);
+
+  return (
+    <Modal visible={visible} animationType="fade" transparent onRequestClose={handleCancel} presentationStyle="overFullScreen">
+      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={styles.container}>
+        <View style={styles.overlay}>
+          <View style={[styles.content, stylesHook.content]} accessibilityViewIsModal accessibilityLabel={title} testID={testID}>
+            <Text style={[styles.title, stylesHook.title]}>{title}</Text>
+            <BlueSpacing10 />
+            <Text style={[styles.message, stylesHook.message]}>{message}</Text>
+            <BlueSpacing20 />
+            <TextInput
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoFocus
+              blurOnSubmit={false}
+              onSubmitEditing={handleSubmit}
+              onChangeText={setValue}
+              placeholder={''}
+              secureTextEntry
+              style={[styles.input, stylesHook.input]}
+              value={value}
+              testID={`${testID}Input`}
+            />
+            <BlueSpacing20 />
+            <View style={styles.buttonsRow}>
+              <SecondButton title={cancelButtonText} onPress={handleCancel} testID={`${testID}CancelButton`} />
+              <View style={styles.buttonSpacer} />
+              <Button title={continueButtonText} onPress={handleSubmit} testID={`${testID}ConfirmButton`} />
+            </View>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  overlay: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  content: {
+    borderRadius: 16,
+    padding: 24,
+    shadowColor: '#000',
+    shadowOpacity: 0.25,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 4,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  message: {
+    fontSize: 16,
+    textAlign: 'center',
+  },
+  input: {
+    borderRadius: 12,
+    borderWidth: 1,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    fontSize: 16,
+  },
+  buttonsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  buttonSpacer: {
+    width: 12,
+  },
+});
+
+export default PassphrasePrompt;

--- a/tests/unit/ImportWalletDiscovery.passphrase.test.js
+++ b/tests/unit/ImportWalletDiscovery.passphrase.test.js
@@ -1,0 +1,161 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import ImportWalletDiscovery from '../../screen/wallets/ImportWalletDiscovery';
+import loc from '../../loc';
+import startImport from '../../class/wallet-import';
+import { useRoute } from '@react-navigation/native';
+import { useExtendedNavigation } from '../../hooks/useExtendedNavigation';
+
+jest.mock('../../components/WalletToImport', () => {
+  const ReactNative = require('react-native');
+  const React = require('react');
+  return ({ onPress, title }) =>
+    React.createElement(
+      ReactNative.TouchableOpacity,
+      { onPress, accessibilityLabel: title },
+      React.createElement(ReactNative.Text, null, title),
+    );
+});
+
+jest.mock('../../BlueComponents', () => {
+  const React = require('react');
+  const { Text, TouchableOpacity } = require('react-native');
+  return {
+    BlueButtonLink: ({ title, onPress, testID }) =>
+      React.createElement(TouchableOpacity, { onPress, testID }, React.createElement(Text, null, title)),
+    BlueFormLabel: ({ children }) => React.createElement(Text, null, children),
+    BlueText: ({ children }) => React.createElement(Text, null, children),
+  };
+});
+
+jest.mock('../../components/themes', () => {
+  const actual = jest.requireActual('../../components/themes');
+  return {
+    ...actual,
+    useTheme: () => actual.BlueDefaultTheme,
+  };
+});
+
+jest.mock('../../hooks/context/useStorage', () => {
+  const addAndSaveWallet = jest.fn();
+  return {
+    useStorage: () => ({ addAndSaveWallet }),
+  };
+});
+
+jest.mock('../../hooks/context/useSettings', () => {
+  const settings = { isElectrumDisabled: false, isPrivacyBlurEnabled: false };
+  return {
+    useSettings: () => settings,
+  };
+});
+
+jest.mock('../../hooks/useScreenProtect', () => {
+  const screenProtect = { enableScreenProtect: jest.fn(), disableScreenProtect: jest.fn() };
+  return {
+    useScreenProtect: () => screenProtect,
+  };
+});
+
+jest.mock('../../blue_modules/hapticFeedback', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  HapticFeedbackTypes: { ImpactLight: 'ImpactLight', Selection: 'Selection' },
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('../../components/PassphrasePrompt', () => {
+  const React = require('react');
+  const { View, Text, TextInput, Button } = require('react-native');
+
+  return ({ visible, title, message, onCancel, onSubmit }) => {
+    const [value, setValue] = React.useState('');
+
+    if (!visible) {
+      return null;
+    }
+
+    return React.createElement(
+      View,
+      { accessibilityLabel: 'PassphrasePrompt' },
+      React.createElement(Text, null, title),
+      React.createElement(Text, null, message),
+      React.createElement(TextInput, {
+        testID: 'PassphrasePromptInput',
+        value,
+        onChangeText: setValue,
+      }),
+      React.createElement(Button, {
+        testID: 'PassphrasePromptConfirmButton',
+        title: 'OK',
+        onPress: () => onSubmit(value),
+      }),
+      React.createElement(Button, {
+        testID: 'PassphrasePromptCancelButton',
+        title: 'Cancel',
+        onPress: onCancel,
+      }),
+    );
+  };
+});
+
+jest.mock('@react-navigation/native', () => ({
+  ...(jest.requireActual('@react-navigation/native')),
+  useRoute: jest.fn(),
+}));
+
+jest.mock('../../hooks/useExtendedNavigation', () => ({
+  useExtendedNavigation: jest.fn(),
+}));
+
+jest.mock('../../class/wallet-import');
+
+const startImportMock = startImport;
+const useRouteMock = useRoute;
+const useExtendedNavigationMock = useExtendedNavigation;
+const parentNavigationMock = { goBack: jest.fn() };
+const navigationMock = {
+  navigate: jest.fn(),
+  getParent: () => parentNavigationMock,
+  goBack: jest.fn(),
+  setOptions: jest.fn(),
+};
+
+describe('ImportWalletDiscovery passphrase prompt', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useRouteMock.mockReturnValue({
+      params: {
+        importText: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+        askPassphrase: true,
+        searchAccounts: false,
+      },
+    });
+    useExtendedNavigationMock.mockReturnValue(navigationMock);
+  });
+
+  it('resolves passphrase from inline prompt', async () => {
+    let passwordRequestPromise = null;
+    startImportMock.mockImplementation((_, __, ___, ____, _____, ______, onPassword) => {
+      passwordRequestPromise = onPassword(loc.wallets.import_passphrase_title, loc.wallets.import_passphrase_message);
+      return {
+        promise: new Promise(() => {}),
+        stop: jest.fn(),
+      };
+    });
+
+    const { getByText, getByTestId } = render(<ImportWalletDiscovery />);
+
+    await waitFor(() => expect(startImportMock).toHaveBeenCalled());
+    await waitFor(() => expect(getByText(loc.wallets.import_passphrase_title)).toBeTruthy());
+
+    fireEvent.changeText(getByTestId('PassphrasePromptInput'), 'secret');
+    fireEvent.press(getByTestId('PassphrasePromptConfirmButton'));
+
+    await waitFor(() => expect(passwordRequestPromise).not.toBeNull());
+    await expect(passwordRequestPromise).resolves.toBe('secret');
+  });
+});


### PR DESCRIPTION
## Summary
- replace the Android prompt helper with a controlled passphrase modal
- coordinate wallet discovery with the inline prompt so it always stays on top
- cover the regression with a unit test that resolves the passphrase request

Fixes #7927

## Testing
- npx jest tests/unit/ImportWalletDiscovery.passphrase.test.js
- npx tsc --noEmit