### PR TITLE
REF: Replace TouchableOpacity with Pressable

### DIFF
--- a/components/AmountInput.tsx
+++ b/components/AmountInput.tsx
@@ -11,7 +11,6 @@ import {
   TextInput,
   TextInputProps,
   TextInputSelectionChangeEventData,
-  TouchableOpacity,
   View,
 } from 'react-native';
 
@@ -296,15 +295,15 @@ export const AmountInput: React.FC<AmountInputProps> = props => {
           </View>
         </View>
         {!disabled && amount !== BitcoinUnit.MAX && (
-          <TouchableOpacity
+          <Pressable
             accessibilityRole="button"
             accessibilityLabel={loc._.change_input_currency}
             testID="changeAmountUnitButton"
-            style={styles.changeAmountUnit}
+            style={({ pressed }) => [styles.changeAmountUnit, pressed && styles.pressed]}
             onPress={changeAmountUnit}
           >
             <Image source={require('../img/round-compare-arrows-24-px.png')} />
-          </TouchableOpacity>
+          </Pressable>
         )}
       </View>
       {outdatedRefreshRate && (
@@ -313,15 +312,15 @@ export const AmountInput: React.FC<AmountInputProps> = props => {
           <View style={styles.spacing8} />
           <BlueText>{loc.formatString(loc.send.outdated_rate, { date: dayjs(outdatedRefreshRate.LastUpdated).format('l LT') })}</BlueText>
           <View style={styles.spacing8} />
-          <TouchableOpacity
+          <Pressable
             accessibilityRole="button"
             accessibilityLabel={loc._.refresh}
             onPress={updateRate}
             disabled={isRateBeingUpdatedLocal}
-            style={isRateBeingUpdatedLocal ? styles.disabledButton : styles.enabledButon}
+            style={({ pressed }) => [isRateBeingUpdatedLocal ? styles.disabledButton : styles.enabledButon, pressed && styles.pressed]}
           >
             <Icon name="sync" type="font-awesome-5" size={16} color={colors.buttonAlternativeTextColor} />
-          </TouchableOpacity>
+          </Pressable>
         </View>
       )}
     </Pressable>
@@ -392,5 +391,8 @@ const styles = StyleSheet.create({
     marginRight: 16,
     paddingLeft: 16,
     paddingVertical: 16,
+  },
+  pressed: {
+    opacity: 0.6,
   },
 });

--- a/components/CoinsSelected.tsx
+++ b/components/CoinsSelected.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, Pressable, View } from 'react-native';
 import { Avatar } from '@rneui/themed';
 
 import loc from '../loc';
@@ -31,6 +31,9 @@ const styles = StyleSheet.create({
     borderRadius: 13,
     backgroundColor: 'rgba(255, 255, 255, 0.32)',
   },
+  pressed: {
+    opacity: 0.6,
+  },
 });
 
 interface CoinsSelectedProps {
@@ -40,14 +43,14 @@ interface CoinsSelectedProps {
 }
 
 const CoinsSelected: React.FC<CoinsSelectedProps> = ({ number, onContainerPress, onClose }) => (
-  <TouchableOpacity accessibilityRole="button" style={styles.root} onPress={onContainerPress}>
+  <Pressable accessibilityRole="button" style={({ pressed }) => [styles.root, pressed && styles.pressed]} onPress={onContainerPress}>
     <View style={styles.labelContainer}>
       <Text style={styles.labelText}>{loc.formatString(loc.cc.coins_selected, { number })}</Text>
     </View>
-    <TouchableOpacity accessibilityRole="button" style={styles.buttonContainer} onPress={onClose}>
+    <Pressable accessibilityRole="button" style={({ pressed }) => [styles.buttonContainer, pressed && styles.pressed]} onPress={onClose}>
       <Avatar rounded containerStyle={[styles.ball]} icon={{ name: 'close', size: 22, type: 'ionicons', color: 'white' }} />
-    </TouchableOpacity>
-  </TouchableOpacity>
+    </Pressable>
+  </Pressable>
 );
 
 export default CoinsSelected;

--- a/components/CopyTextToClipboard.tsx
+++ b/components/CopyTextToClipboard.tsx
@@ -1,6 +1,6 @@
 import Clipboard from '@react-native-clipboard/clipboard';
 import React, { forwardRef, useEffect, useState } from 'react';
-import { Animated, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Animated, StyleSheet, Pressable, View } from 'react-native';
 
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../blue_modules/hapticFeedback';
 import loc from '../loc';
@@ -19,7 +19,7 @@ const styleCopyTextToClipboard = StyleSheet.create({
   },
 });
 
-const CopyTextToClipboard = forwardRef<React.ElementRef<typeof TouchableOpacity>, CopyTextToClipboardProps>(({ text, truncated }, ref) => {
+const CopyTextToClipboard = forwardRef<React.ElementRef<typeof Pressable>, CopyTextToClipboardProps>(({ text, truncated }, ref) => {
   const [hasTappedText, setHasTappedText] = useState(false);
   const [address, setAddress] = useState(text);
 
@@ -42,12 +42,13 @@ const CopyTextToClipboard = forwardRef<React.ElementRef<typeof TouchableOpacity>
 
   return (
     <View style={styles.container}>
-      <TouchableOpacity
+      <Pressable
         ref={ref}
         accessibilityRole="button"
         onPress={copyToClipboard}
         disabled={hasTappedText}
         testID="CopyTextToClipboard"
+        style={({ pressed }) => [pressed && styles.pressed]}
       >
         <Animated.Text
           style={styleCopyTextToClipboard.address}
@@ -56,7 +57,7 @@ const CopyTextToClipboard = forwardRef<React.ElementRef<typeof TouchableOpacity>
         >
           {address}
         </Animated.Text>
-      </TouchableOpacity>
+      </Pressable>
     </View>
   );
 });
@@ -65,4 +66,7 @@ export default CopyTextToClipboard;
 
 const styles = StyleSheet.create({
   container: { justifyContent: 'center', alignItems: 'center', paddingHorizontal: 16 },
+  pressed: {
+    opacity: 0.6,
+  },
 });

--- a/components/CopyToClipboardButton.tsx
+++ b/components/CopyToClipboardButton.tsx
@@ -1,6 +1,6 @@
 import Clipboard from '@react-native-clipboard/clipboard';
 import React from 'react';
-import { StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { StyleSheet, Text, Pressable } from 'react-native';
 
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../blue_modules/hapticFeedback';
 import loc from '../loc';
@@ -17,14 +17,17 @@ export const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({ st
   };
 
   return (
-    <TouchableOpacity accessibilityRole="button" onPress={onPress}>
+    <Pressable accessibilityRole="button" onPress={onPress} style={({ pressed }) => [pressed && styles.pressed]}>
       <Text style={styles.text}>{displayText && displayText.length > 0 ? displayText : loc.transactions.details_copy}</Text>
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 
 const styles = StyleSheet.create({
   text: { fontSize: 16, fontWeight: '400', color: '#68bbe1' },
+  pressed: {
+    opacity: 0.6,
+  },
 });
 
 export default CopyToClipboardButton;

--- a/components/HeaderRightButton.tsx
+++ b/components/HeaderRightButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { StyleSheet, Text, Pressable } from 'react-native';
 
 import { useTheme } from './themes';
 
@@ -14,15 +14,15 @@ const HeaderRightButton: React.FC<HeaderRightButtonProps> = ({ disabled = true, 
   const { colors } = useTheme();
   const opacity = disabled ? 0.5 : 1;
   return (
-    <TouchableOpacity
+    <Pressable
       accessibilityRole="button"
       disabled={disabled}
-      style={[styles.save, { backgroundColor: colors.lightButton }, { opacity }]}
+      style={({ pressed }) => [styles.save, { backgroundColor: colors.lightButton }, { opacity }, pressed && styles.pressed]}
       onPress={onPress}
       testID={testID}
     >
       <Text style={[styles.saveText, { color: colors.buttonTextColor }]}>{title}</Text>
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 
@@ -37,6 +37,9 @@ const styles = StyleSheet.create({
   saveText: {
     fontSize: 15,
     fontWeight: '600',
+  },
+  pressed: {
+    opacity: 0.6,
   },
 });
 

--- a/components/ManageWalletsListItem.tsx
+++ b/components/ManageWalletsListItem.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState, useEffect, useRef } from 'react';
-import { StyleSheet, ViewStyle, TouchableOpacity, ActivityIndicator, Platform, Animated, View, Text, TextStyle } from 'react-native';
+import { StyleSheet, ViewStyle, Pressable, ActivityIndicator, Platform, Animated, View, Text, TextStyle } from 'react-native';
 import { Icon, ListItem } from '@rneui/base';
 import { ExtendedTransaction, LightningTransaction, Transaction, TWallet } from '../class/wallets/types';
 import { WalletCarouselItem } from './WalletsCarousel';
@@ -54,25 +54,29 @@ interface SwipeContentProps {
 }
 
 const LeftSwipeContent: React.FC<SwipeContentProps> = ({ onPress, hideBalance, colors }) => (
-  <TouchableOpacity
+  <Pressable
     onPress={onPress}
-    style={[styles.leftButtonContainer, { backgroundColor: colors.buttonAlternativeTextColor } as ViewStyle]}
+    style={({ pressed }) => [
+      styles.leftButtonContainer,
+      { backgroundColor: colors.buttonAlternativeTextColor } as ViewStyle,
+      pressed && styles.pressed,
+    ]}
     accessibilityRole="button"
     accessibilityLabel={hideBalance ? loc.transactions.details_balance_show : loc.transactions.details_balance_hide}
   >
     <Icon name={hideBalance ? 'eye' : 'eye-slash'} color={colors.brandingColor} type="font-awesome-5" />
-  </TouchableOpacity>
+  </Pressable>
 );
 
 const RightSwipeContent: React.FC<Partial<SwipeContentProps>> = ({ onPress }) => (
-  <TouchableOpacity
+  <Pressable
     onPress={onPress}
-    style={styles.rightButtonContainer as ViewStyle}
+    style={({ pressed }) => [styles.rightButtonContainer as ViewStyle, pressed && styles.pressed]}
     accessibilityRole="button"
     accessibilityLabel="Delete Wallet"
   >
     <Icon name={Platform.OS === 'android' ? 'delete' : 'delete-outline'} color="#FFFFFF" />
-  </TouchableOpacity>
+  </Pressable>
 );
 
 const ManageWalletsListItem: React.FC<ManageWalletsListItemProps> = ({
@@ -524,6 +528,9 @@ const styles = StyleSheet.create({
   itemDivider: {
     height: 1,
     width: '100%',
+  },
+  pressed: {
+    opacity: 0.6,
   },
 });
 

--- a/components/SecondButton.tsx
+++ b/components/SecondButton.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View, ActivityIndicator } from 'react-native';
+import { StyleSheet, Text, Pressable, View, ActivityIndicator } from 'react-native';
 import { Icon } from '@rneui/themed';
 
 import { useTheme } from './themes';
@@ -20,7 +20,7 @@ type SecondButtonProps = {
   testID?: string;
 };
 
-export const SecondButton = forwardRef<React.ElementRef<typeof TouchableOpacity>, SecondButtonProps>((props, ref) => {
+export const SecondButton = forwardRef<React.ElementRef<typeof Pressable>, SecondButtonProps>((props, ref) => {
   const { colors } = useTheme();
   let backgroundColor = props.backgroundColor ? props.backgroundColor : colors.buttonGrayBackgroundColor;
   let fontColor = colors.secondButtonTextColor;
@@ -39,16 +39,16 @@ export const SecondButton = forwardRef<React.ElementRef<typeof TouchableOpacity>
   );
 
   return props.onPress ? (
-    <TouchableOpacity
+    <Pressable
       disabled={props.disabled || props.loading}
       accessibilityRole="button"
       testID={props.testID}
-      style={[styles.button, { backgroundColor }]}
+      style={({ pressed }) => [styles.button, { backgroundColor }, pressed && styles.pressed]}
       {...props}
       ref={ref}
     >
       {buttonView}
-    </TouchableOpacity>
+    </Pressable>
   ) : (
     <View style={[styles.button, { backgroundColor }]}>{buttonView}</View>
   );
@@ -79,5 +79,8 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  pressed: {
+    opacity: 0.6,
   },
 });

--- a/components/SquareButton.tsx
+++ b/components/SquareButton.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import { StyleProp, StyleSheet, Text, TouchableOpacity, View, ViewStyle } from 'react-native';
+import { StyleProp, StyleSheet, Text, Pressable, View, ViewStyle } from 'react-native';
 
 import { useTheme } from './themes';
 
@@ -10,7 +10,7 @@ interface SquareButtonProps {
   testID?: string;
 }
 
-export const SquareButton = forwardRef<React.ElementRef<typeof TouchableOpacity>, SquareButtonProps>((props, ref) => {
+export const SquareButton = forwardRef<React.ElementRef<typeof Pressable>, SquareButtonProps>((props, ref) => {
   const { title, onPress, style, testID } = props;
   const { colors } = useTheme();
 
@@ -27,9 +27,15 @@ export const SquareButton = forwardRef<React.ElementRef<typeof TouchableOpacity>
   );
 
   return onPress ? (
-    <TouchableOpacity ref={ref} style={style} onPress={onPress} testID={testID} accessibilityRole="button">
+    <Pressable
+      ref={ref}
+      style={({ pressed }) => [style, pressed && styles.pressed]}
+      onPress={onPress}
+      testID={testID}
+      accessibilityRole="button"
+    >
       {buttonView}
-    </TouchableOpacity>
+    </Pressable>
   ) : (
     <View style={style}>{buttonView}</View>
   );
@@ -44,5 +50,8 @@ const styles = StyleSheet.create({
   text: {
     marginHorizontal: 8,
     fontSize: 16,
+  },
+  pressed: {
+    opacity: 0.6,
   },
 });

--- a/components/StyledButton.tsx
+++ b/components/StyledButton.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, Pressable, View } from 'react-native';
 
 import { useTheme } from './themes';
 
@@ -46,11 +46,16 @@ const StyledButton: FC<StyledButtonProps> = ({ onPress, text, disabled = false, 
   };
 
   return (
-    <TouchableOpacity accessibilityRole="button" onPress={onPress} disabled={disabled} style={stylesHook.container}>
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      disabled={disabled}
+      style={({ pressed }) => [stylesHook.container, pressed && styles.pressed]}
+    >
       <View style={[styles.buttonContainer, buttonStyles()]}>
         <Text style={[styles.text, textStyles()]}>{text}</Text>
       </View>
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 
@@ -81,6 +86,9 @@ const styles = StyleSheet.create({
   },
   textDestroy: {
     color: '#D0021B',
+  },
+  pressed: {
+    opacity: 0.6,
   },
 });
 

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Pressable, View } from 'react-native';
 
 import { useTheme } from './themes';
 
@@ -24,6 +24,9 @@ const tabsStyles = StyleSheet.create({
   marginBottom: {
     marginBottom: 30,
   },
+  pressed: {
+    opacity: 0.6,
+  },
 });
 
 interface TabProps {
@@ -42,14 +45,18 @@ export const Tabs: React.FC<TabsProps> = ({ active, onSwitch, tabs, isIpad = fal
   return (
     <View style={[tabsStyles.root, isIpad && tabsStyles.marginBottom]}>
       {tabs.map((Tab, i) => (
-        <TouchableOpacity
+        <Pressable
           key={i}
           accessibilityRole="button"
           onPress={() => onSwitch(i)}
-          style={[tabsStyles.tabRoot, active === i && { ...tabsStyles.activeTabRoot, borderColor: colors.buttonAlternativeTextColor }]}
+          style={({ pressed }) => [
+            tabsStyles.tabRoot,
+            active === i && { ...tabsStyles.activeTabRoot, borderColor: colors.buttonAlternativeTextColor },
+            pressed && tabsStyles.pressed,
+          ]}
         >
           <Tab active={active === i} />
-        </TouchableOpacity>
+        </Pressable>
       ))}
     </View>
   );

--- a/screen/transactions/TransactionStatus.tsx
+++ b/screen/transactions/TransactionStatus.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
 import { RouteProp, useRoute } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { ActivityIndicator, BackHandler, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, BackHandler, StyleSheet, Text, Pressable, View } from 'react-native';
 import { Icon } from '@rneui/themed';
 import * as BlueElectrum from '../../blue_modules/BlueElectrum';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
@@ -434,11 +434,11 @@ const TransactionStatus: React.FC<TransactionStatusProps> = ({ transaction, txid
     } else if (isRBFCancelPossible === ButtonStatus.Possible) {
       return (
         <>
-          <TouchableOpacity accessibilityRole="button" style={styles.cancel}>
+          <Pressable accessibilityRole="button" style={({ pressed }) => [styles.cancel, pressed && styles.pressed]}>
             <Text onPress={navigateToRBFCancel} style={styles.cancelText}>
               {loc.transactions.status_cancel}
             </Text>
-          </TouchableOpacity>
+          </Pressable>
           <BlueSpacing10 />
         </>
       );
@@ -731,5 +731,8 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: '500',
     textAlign: 'center',
+  },
+  pressed: {
+    opacity: 0.6,
   },
 });

--- a/screen/wallets/ImportWallet.tsx
+++ b/screen/wallets/ImportWallet.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { RouteProp, useRoute } from '@react-navigation/native';
 import Clipboard from '@react-native-clipboard/clipboard';
-import { Keyboard, Platform, StyleSheet, TouchableWithoutFeedback, View, TouchableOpacity, Image } from 'react-native';
+import { Keyboard, Platform, StyleSheet, View, Pressable, Image } from 'react-native';
 import { BlueFormLabel, BlueFormMultiInput } from '../../BlueComponents';
 import Button from '../../components/Button';
 import {
@@ -52,6 +52,9 @@ const ImportWallet = () => {
     },
     button: {
       padding: 10,
+    },
+    pressed: {
+      opacity: 0.6,
     },
   });
 
@@ -177,19 +180,19 @@ const ImportWallet = () => {
       headerLeft:
         navigation.getState().index === 0
           ? () => (
-              <TouchableOpacity
+              <Pressable
                 accessibilityRole="button"
                 accessibilityLabel={loc._.close}
-                style={styles.button}
+                style={({ pressed }) => [styles.button, pressed && styles.pressed]}
                 onPress={() => navigation.goBack()}
                 testID="NavigationCloseButton"
               >
                 <Image source={closeImage} />
-              </TouchableOpacity>
+              </Pressable>
             )
           : undefined,
     });
-  }, [colors, navigation, toolTipActions, HeaderRight, styles.button, closeImage]);
+  }, [colors, navigation, toolTipActions, HeaderRight, styles.button, styles.pressed, closeImage]);
 
   const renderOptionsAndImportButton = (
     <>
@@ -207,9 +210,9 @@ const ImportWallet = () => {
   return (
     <SafeAreaScrollView contentContainerStyle={styles.root} keyboardShouldPersistTaps="always" automaticallyAdjustKeyboardInsets>
       <BlueSpacing20 />
-      <TouchableWithoutFeedback accessibilityRole="button" onPress={speedBackdoorTap} testID="SpeedBackdoor">
+      <Pressable accessibilityRole="button" onPress={speedBackdoorTap} testID="SpeedBackdoor">
         <BlueFormLabel>{loc.wallets.import_explanation}</BlueFormLabel>
-      </TouchableWithoutFeedback>
+      </Pressable>
       <BlueSpacing20 />
       <BlueFormMultiInput
         value={importText}

--- a/screen/wallets/ManageWallets.tsx
+++ b/screen/wallets/ManageWallets.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useLayoutEffect, useReducer, useCallback, useMemo, useRef, useState, lazy, Suspense } from 'react';
 import {
   StyleSheet,
-  TouchableOpacity,
+  Pressable,
   Image,
   Alert,
   Animated,
@@ -517,16 +517,16 @@ const ManageWallets: React.FC = () => {
   const buttonOpacity = useMemo(() => ({ opacity: saveInProgress ? 0.5 : 1 }), [saveInProgress]);
   const HeaderLeftButton = useMemo(
     () => (
-      <TouchableOpacity
+      <Pressable
         accessibilityRole="button"
         accessibilityLabel={loc._.close}
-        style={[styles.button, buttonOpacity]}
+        style={({ pressed }) => [styles.button, buttonOpacity, pressed && styles.pressed]}
         onPress={goBack}
         disabled={saveInProgress}
         testID="NavigationCloseButton"
       >
         <Image source={closeImage} />
-      </TouchableOpacity>
+      </Pressable>
     ),
     [buttonOpacity, goBack, saveInProgress, closeImage],
   );
@@ -757,5 +757,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     padding: 20,
+  },
+  pressed: {
+    opacity: 0.6,
   },
 });

--- a/screen/wallets/ProvideEntropy.tsx
+++ b/screen/wallets/ProvideEntropy.tsx
@@ -3,18 +3,7 @@ import { RouteProp, StackActions, useNavigation, useRoute } from '@react-navigat
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Icon } from '@rneui/themed';
 import BN from 'bignumber.js';
-import {
-  Alert,
-  Dimensions,
-  Image,
-  PixelRatio,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-  useWindowDimensions,
-} from 'react-native';
+import { Alert, Dimensions, Image, PixelRatio, ScrollView, StyleSheet, Text, Pressable, View, useWindowDimensions } from 'react-native';
 
 import { randomBytes } from '../../class/rng';
 import { FButton, FContainer } from '../../components/FloatButtons';
@@ -154,12 +143,20 @@ export const convertToBuffer = ({ entropy, bits }: { entropy: BN; bits: number }
 
 const Coin = ({ push }: { push: TPush }) => (
   <View style={styles.coinRoot}>
-    <TouchableOpacity accessibilityRole="button" onPress={() => push(getEntropy(0, 2))} style={styles.coinBody}>
+    <Pressable
+      accessibilityRole="button"
+      onPress={() => push(getEntropy(0, 2))}
+      style={({ pressed }) => [styles.coinBody, pressed && styles.pressed]}
+    >
       <Image style={styles.coinImage} source={require('../../img/coin1.png')} />
-    </TouchableOpacity>
-    <TouchableOpacity accessibilityRole="button" onPress={() => push(getEntropy(1, 2))} style={styles.coinBody}>
+    </Pressable>
+    <Pressable
+      accessibilityRole="button"
+      onPress={() => push(getEntropy(1, 2))}
+      style={({ pressed }) => [styles.coinBody, pressed && styles.pressed]}
+    >
       <Image style={styles.coinImage} source={require('../../img/coin2.png')} />
-    </TouchableOpacity>
+    </Pressable>
   </View>
 );
 
@@ -199,7 +196,12 @@ const Dice = ({ push, sides }: { push: TPush; sides: number }) => {
   return (
     <ScrollView contentContainerStyle={[styles.diceContainer, stylesHook.diceContainer]}>
       {[...Array(sides)].map((_, i) => (
-        <TouchableOpacity accessibilityRole="button" key={i} onPress={() => push(getEntropy(i, sides))}>
+        <Pressable
+          accessibilityRole="button"
+          key={i}
+          onPress={() => push(getEntropy(i, sides))}
+          style={({ pressed }) => [pressed && styles.pressed]}
+        >
           <View style={[styles.diceRoot, { width: diceWidth }]}>
             {sides === 6 ? (
               <Icon style={styles.diceIcon} name={diceIcon(i + 1)} size={70} color="grey" type="font-awesome-5" />
@@ -209,7 +211,7 @@ const Dice = ({ push, sides }: { push: TPush; sides: number }) => {
               </View>
             )}
           </View>
-        </TouchableOpacity>
+        </Pressable>
       ))}
     </ScrollView>
   );
@@ -346,13 +348,13 @@ const ProvideEntropy = () => {
   return (
     <SafeArea>
       <BlueSpacing20 />
-      <TouchableOpacity accessibilityRole="button" onPress={() => setShow(!show)}>
+      <Pressable accessibilityRole="button" onPress={() => setShow(!show)} style={({ pressed }) => [pressed && styles.pressed]}>
         <View style={[styles.entropy, stylesHook.entropy]}>
           <Text style={[styles.entropyText, stylesHook.entropyText]}>
             {show ? hex : loc.formatString(loc.entropy.amountOfEntropy, { bits, limit: entropy.limit })}
           </Text>
         </View>
-      </TouchableOpacity>
+      </Pressable>
 
       <Tabs active={tab} onSwitch={setTab} tabs={[TollTab, D6Tab, D20Tab]} />
 
@@ -438,6 +440,9 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
     transform: [{ rotate: '-45deg' }],
     alignItems: 'center',
+  },
+  pressed: {
+    opacity: 0.6,
   },
 });
 

--- a/screen/wallets/WalletDetails.tsx
+++ b/screen/wallets/WalletDetails.tsx
@@ -1,15 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  ActivityIndicator,
-  InteractionManager,
-  LayoutAnimation,
-  StyleSheet,
-  Switch,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { ActivityIndicator, InteractionManager, LayoutAnimation, StyleSheet, Switch, Text, TextInput, Pressable, View } from 'react-native';
 import { writeFileAndExport } from '../../blue_modules/fs';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
 import { BlueCard, BlueText } from '../../BlueComponents';
@@ -595,9 +585,9 @@ const WalletDetails: React.FC = () => {
                       {isMasterFingerPrintVisible ? (
                         <BlueText selectable>{masterFingerprint ?? <ActivityIndicator />}</BlueText>
                       ) : (
-                        <TouchableOpacity onPress={onViewMasterFingerPrintPress}>
+                        <Pressable onPress={onViewMasterFingerPrintPress} style={({ pressed }) => [pressed && styles.pressed]}>
                           <BlueText>{loc.multisig.view}</BlueText>
-                        </TouchableOpacity>
+                        </Pressable>
                       )}
                     </View>
                   )}
@@ -710,6 +700,9 @@ const styles = StyleSheet.create({
   },
   marginRight16: {
     marginRight: 16,
+  },
+  pressed: {
+    opacity: 0.6,
   },
 });
 


### PR DESCRIPTION
This PR is a continuation  from https://github.com/BlueWallet/BlueWallet/pull/7965 to replace `TouchableOpacity` with `Pressable`



Related to issue https://github.com/BlueWallet/BlueWallet/issues/2144