### PR TITLE
FIX: hw wallets with taproot integration

### DIFF
--- a/class/wallets/hd-taproot-wallet.ts
+++ b/class/wallets/hd-taproot-wallet.ts
@@ -62,12 +62,22 @@ export class HDTaprootWallet extends AbstractHDElectrumWallet {
     index = index * 1; // cast to int
 
     if (node === 0 && !this._node0) {
-      const hdNode = bip32.fromBase58(this.getXpub());
+      let xpub = this.getXpub();
+      if (xpub.startsWith('zpub')) {
+        // bip32.fromBase58() wont work with zpub prefix, need to swap it for the traditional one
+        xpub = this._zpubToXpub(xpub);
+      }
+      const hdNode = bip32.fromBase58(xpub);
       this._node0 = hdNode.derive(node);
     }
 
     if (node === 1 && !this._node1) {
-      const hdNode = bip32.fromBase58(this.getXpub());
+      let xpub = this.getXpub();
+      if (xpub.startsWith('zpub')) {
+        // bip32.fromBase58() wont work with zpub prefix, need to swap it for the traditional one
+        xpub = this._zpubToXpub(xpub);
+      }
+      const hdNode = bip32.fromBase58(xpub);
       this._node1 = hdNode.derive(node);
     }
 

--- a/class/wallets/watch-only-wallet.ts
+++ b/class/wallets/watch-only-wallet.ts
@@ -75,13 +75,12 @@ export class WatchOnlyWallet extends LegacyWallet {
    */
   init() {
     let hdWalletInstance: THDWalletForWatchOnly;
-    if (this.secret.startsWith('xpub')) {
-      // its either legacy OR taproot HD since industry decided to not add new prefixes (like ypub or zpub)
-      if (this._derivationPath?.startsWith("m/86'")) {
-        hdWalletInstance = new HDTaprootWallet();
-      } else {
-        hdWalletInstance = new HDLegacyP2PKHWallet();
-      }
+
+    if (this._derivationPath?.startsWith("m/86'")) {
+      // if path is explicit taproot path - its definately BIP86
+      hdWalletInstance = new HDTaprootWallet();
+    } else if (this.secret.startsWith('xpub')) {
+      hdWalletInstance = new HDLegacyP2PKHWallet();
     } else if (this.secret.startsWith('ypub')) hdWalletInstance = new HDSegwitP2SHWallet();
     else if (this.secret.startsWith('zpub')) hdWalletInstance = new HDSegwitBech32Wallet();
     else return this;
@@ -251,7 +250,7 @@ export class WatchOnlyWallet extends LegacyWallet {
   }
 
   allowMasterFingerprint() {
-    return this.getSecret().startsWith('zpub');
+    return this.getSecret().startsWith('zpub') || this.getSecret().startsWith('ypub') || this.getSecret().startsWith('xpub');
   }
 
   useWithHardwareWalletEnabled() {

--- a/screen/send/SendDetails.tsx
+++ b/screen/send/SendDetails.tsx
@@ -564,6 +564,7 @@ const SendDetails = () => {
     } catch (Err: any) {
       setIsLoading(false);
       presentAlert({ title: loc.errors.error, message: Err.message });
+      console.log(Err);
       triggerHapticFeedback(HapticFeedbackTypes.NotificationError);
     }
   };
@@ -864,6 +865,7 @@ const SendDetails = () => {
         psbt = bitcoin.Psbt.fromBase64(psbtBase64);
         tx = (wallet as MultisigHDWallet).cosignPsbt(psbt).tx;
       } catch (e: any) {
+        console.log(e);
         presentAlert({ title: loc.errors.error, message: e.message });
         return;
       } finally {

--- a/tests/e2e/bluewallet3.spec.js
+++ b/tests/e2e/bluewallet3.spec.js
@@ -45,7 +45,7 @@ describe('BlueWallet UI Tests - import Watch-only wallet (zpub)', () => {
       await element(by.text(`No, and do not ask me again.`)).tap(); // sometimes the first click doesnt work (detox issue, not app's)
     } catch (_) {}
     await expect(element(by.id('BitcoinAddressQRCodeContainer'))).toBeVisible();
-    await expect(element(by.text('bc1qc8wun6lf9vcajpddtgdpd2pdrp0kwp29j6upgv'))).toBeVisible();
+    await expect(element(by.text('bc1qgrhr5xc5774maph97d73ydrjlqqmg2v6jjlr29'))).toBeVisible();
     await element(by.id('SetCustomAmountButton')).tap();
     await element(by.id('BitcoinAmountInput')).replaceText('1');
     await element(by.id('CustomAmountDescription')).typeText('Test');
@@ -56,7 +56,7 @@ describe('BlueWallet UI Tests - import Watch-only wallet (zpub)', () => {
 
     await expect(element(by.id('BitcoinAddressQRCodeContainer'))).toBeVisible();
 
-    await expect(element(by.text('bitcoin:BC1QC8WUN6LF9VCAJPDDTGDPD2PDRP0KWP29J6UPGV?amount=1&label=Test'))).toBeVisible();
+    await expect(element(by.text('bitcoin:BC1QGRHR5XC5774MAPH97D73YDRJLQQMG2V6JJLR29?amount=1&label=Test'))).toBeVisible();
     await device.pressBack();
     await element(by.id('SendButton')).tap();
     await element(by.text('OK')).tap();

--- a/tests/unit/watch-only-wallet.test.js
+++ b/tests/unit/watch-only-wallet.test.js
@@ -64,30 +64,38 @@ describe('Watch only wallet', () => {
   });
 
   it('can create PSBT base64 without signature for HW wallet xpub', async () => {
-    const w = new WatchOnlyWallet();
-    w.setSecret('xpub6CQdfC3v9gU86eaSn7AhUFcBVxiGhdtYxdC5Cw2vLmFkfth2KXCMmYcPpvZviA89X6DXDs4PJDk5QVL2G2xaVjv7SM4roWHr1gR4xB3Z7Ps');
-    w.init();
-    const changeAddress = '1KZjqYHm7a1DjhjcdcjfQvYfF2h6PqatjX';
-    // hardcoding so we wont have to call w.getChangeAddressAsync()
-    const utxos = [
-      {
-        height: 530926,
-        value: 1000,
-        address: '12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG',
-        txid: 'd0432027a86119c63a0be8fa453275c2333b59067f1e559389cd3e0e377c8b96',
-        vout: 1,
-        txhex:
-          '0100000001b630ac364a04b83548994ded4705b98316b2d1fe18b9fffa2627be9eef11bf60000000006b48304502210096e68d94d374e3a688ed2e6605289f81172540abaab5f6cc431c231919860746022075ee4e64c867ed9d369d01a9b35d8b1689a821be8d729fff7fb3dfcc75d16f6401210281d2e40ba6422fc97b61fd5643bee83dd749d8369339edc795d7b3f00e96c681fdffffff02ef020000000000001976a914e4271ef9e9a03a89b981c73d3d6936d2f6fccc0688ace8030000000000001976a914120ad7854152901ebeb269acb6cef20e71b3cf5988acea190800',
-      },
-    ];
-    // hardcoding utxo so we wont have to call w.fetchUtxo() and w.getUtxo()
+    for (const cleanupInternals of [false, true]) {
+      const w = new WatchOnlyWallet();
+      w.setSecret('xpub6CQdfC3v9gU86eaSn7AhUFcBVxiGhdtYxdC5Cw2vLmFkfth2KXCMmYcPpvZviA89X6DXDs4PJDk5QVL2G2xaVjv7SM4roWHr1gR4xB3Z7Ps');
+      w.init();
+      const changeAddress = '1KZjqYHm7a1DjhjcdcjfQvYfF2h6PqatjX';
+      // hardcoding so we wont have to call w.getChangeAddressAsync()
+      const utxos = [
+        {
+          height: 530926,
+          value: 1000,
+          address: '12eQ9m4sgAwTSQoNXkRABKhCXCsjm2jdVG',
+          txid: 'd0432027a86119c63a0be8fa453275c2333b59067f1e559389cd3e0e377c8b96',
+          vout: 1,
+          txhex:
+            '0100000001b630ac364a04b83548994ded4705b98316b2d1fe18b9fffa2627be9eef11bf60000000006b48304502210096e68d94d374e3a688ed2e6605289f81172540abaab5f6cc431c231919860746022075ee4e64c867ed9d369d01a9b35d8b1689a821be8d729fff7fb3dfcc75d16f6401210281d2e40ba6422fc97b61fd5643bee83dd749d8369339edc795d7b3f00e96c681fdffffff02ef020000000000001976a914e4271ef9e9a03a89b981c73d3d6936d2f6fccc0688ace8030000000000001976a914120ad7854152901ebeb269acb6cef20e71b3cf5988acea190800',
+        },
+      ];
+      // hardcoding utxo so we wont have to call w.fetchUtxo() and w.getUtxo()
 
-    const { psbt } = await w.createTransaction(utxos, [{ address: '1QDCFcpnrZ4yrAQxmbvSgeUC9iZZ8ehcR5' }], 1, changeAddress);
+      const { psbt } = await w.createTransaction(utxos, [{ address: '1QDCFcpnrZ4yrAQxmbvSgeUC9iZZ8ehcR5' }], 1, changeAddress);
 
-    assert.strictEqual(
-      psbt.toBase64(),
-      'cHNidP8BAFUCAAAAAZaLfDcOPs2Jk1UefwZZOzPCdTJF+ugLOsYZYagnIEPQAQAAAAAAAACAASgDAAAAAAAAGXapFP6ZRvxlaU5S/9HQFr1i2lsgp58AiKwAAAAAAAEA4gEAAAABtjCsNkoEuDVImU3tRwW5gxay0f4Yuf/6Jie+nu8Rv2AAAAAAa0gwRQIhAJbmjZTTdOOmiO0uZgUon4EXJUCrqrX2zEMcIxkZhgdGAiB17k5kyGftnTadAamzXYsWiaghvo1yn/9/s9/MddFvZAEhAoHS5AumQi/Je2H9VkO+6D3XSdg2kzntx5XXs/AOlsaB/f///wLvAgAAAAAAABl2qRTkJx756aA6ibmBxz09aTbS9vzMBois6AMAAAAAAAAZdqkUEgrXhUFSkB6+smmsts7yDnGzz1mIrOoZCAAiBgPGm5BfckKzaIEi8GlRM5oe4A2mUvbsxlJ+pmMhRsrOYhgAAAAALAAAgAAAAIAAAACAAAAAAAAAAAAAAA==',
-    );
+      if (cleanupInternals) {
+        // these might be purged when preparing for serialization before saving to disk
+        w._hdWalletInstance._node0 = undefined;
+        w._hdWalletInstance._node1 = undefined;
+      }
+
+      assert.strictEqual(
+        psbt.toBase64(),
+        'cHNidP8BAFUCAAAAAZaLfDcOPs2Jk1UefwZZOzPCdTJF+ugLOsYZYagnIEPQAQAAAAAAAACAASgDAAAAAAAAGXapFP6ZRvxlaU5S/9HQFr1i2lsgp58AiKwAAAAAAAEA4gEAAAABtjCsNkoEuDVImU3tRwW5gxay0f4Yuf/6Jie+nu8Rv2AAAAAAa0gwRQIhAJbmjZTTdOOmiO0uZgUon4EXJUCrqrX2zEMcIxkZhgdGAiB17k5kyGftnTadAamzXYsWiaghvo1yn/9/s9/MddFvZAEhAoHS5AumQi/Je2H9VkO+6D3XSdg2kzntx5XXs/AOlsaB/f///wLvAgAAAAAAABl2qRTkJx756aA6ibmBxz09aTbS9vzMBois6AMAAAAAAAAZdqkUEgrXhUFSkB6+smmsts7yDnGzz1mIrOoZCAAiBgPGm5BfckKzaIEi8GlRM5oe4A2mUvbsxlJ+pmMhRsrOYhgAAAAALAAAgAAAAIAAAACAAAAAAAAAAAAAAA==',
+      );
+    }
   });
 
   it('can create PSBT base64 without signature for HW wallet ypub', async () => {
@@ -303,6 +311,29 @@ describe('Watch only wallet', () => {
     assert.ok(w.useWithHardwareWalletEnabled());
   });
 
+  it('can import taproot BIP86 from keystone with zpub instead of xpub', async () => {
+    const w = new WatchOnlyWallet();
+    w.setSecret(
+      JSON.stringify({
+        ExtPubKey: 'zpub6rxQT4vrGrdLmFicJZnLxx1odj1C8xNtHW5pW84hMSXdtoFnCbqBFJm3bF5PrwYL5ScxFhdzRuv3pb9beyoraQLMuQWkV9faGuxstBPgLw4',
+        MasterFingerprint: 'B68AF6E4',
+        AccountKeyPath: "m/86'/0'/0'",
+      }),
+    );
+    w.init();
+    assert.ok(w.valid());
+    assert.strictEqual(
+      w.getSecret(),
+      'zpub6rxQT4vrGrdLmFicJZnLxx1odj1C8xNtHW5pW84hMSXdtoFnCbqBFJm3bF5PrwYL5ScxFhdzRuv3pb9beyoraQLMuQWkV9faGuxstBPgLw4',
+    );
+    assert.strictEqual(w.getMasterFingerprintHex(), 'B68AF6E4'.toLowerCase());
+    assert.strictEqual(w.getLabel(), 'Wallet');
+    assert.strictEqual(w.getDerivationPath(), "m/86'/0'/0'");
+    assert.ok(w._getExternalAddressByIndex(0).startsWith('bc1p'), `not taproot address generated: ${w._getExternalAddressByIndex(0)}`);
+    assert.ok(w.allowMasterFingerprint());
+    // assert.ok(w.useWithHardwareWalletEnabled());
+  });
+
   it('can import zpub with master fingerprint and derivation path', async () => {
     const w = new WatchOnlyWallet();
     w.setSecret(require('fs').readFileSync('./tests/unit/fixtures/skeleton-walletdescriptor.txt', 'ascii'));
@@ -389,6 +420,72 @@ describe('Watch only wallet', () => {
       );
 
       assert.ok(w._getExternalAddressByIndex(0).startsWith('bc1p'), 'not taproot address, got: ' + w._getExternalAddressByIndex(0));
+      assert.ok(w.allowMasterFingerprint());
+      assert.ok(!w.useWithHardwareWalletEnabled());
+    }
+  });
+
+  it('can import BIP86 (taproot) wallet descriptor but with zpub instead of xpub', async () => {
+    const w = new WatchOnlyWallet();
+    w.setSecret(
+      "tr([b68af6e4/86'/0'/0']zpub6rxQT4vrGrdLmFicJZnLxx1odj1C8xNtHW5pW84hMSXdtoFnCbqBFJm3bF5PrwYL5ScxFhdzRuv3pb9beyoraQLMuQWkV9faGuxstBPgLw4)",
+    );
+    w.init();
+    assert.ok(w.valid());
+
+    assert.strictEqual(w.getMasterFingerprintHex(), 'b68af6e4');
+    assert.strictEqual(w.getDerivationPath(), "m/86'/0'/0'");
+
+    assert.strictEqual(
+      w.getSecret(),
+      'zpub6rxQT4vrGrdLmFicJZnLxx1odj1C8xNtHW5pW84hMSXdtoFnCbqBFJm3bF5PrwYL5ScxFhdzRuv3pb9beyoraQLMuQWkV9faGuxstBPgLw4',
+    );
+
+    assert.ok(w._getExternalAddressByIndex(0).startsWith('bc1p'), 'not taproot address, got: ' + w._getExternalAddressByIndex(0));
+
+    assert.ok(!w.useWithHardwareWalletEnabled());
+  });
+
+  it('can import BIP86 (taproot) wallet descriptor and create transaction', async () => {
+    for (const cleanupInternals of [false, true]) {
+      const w = new WatchOnlyWallet();
+      // MNEMONICS_KEYSTONE
+      w.setSecret(
+        "tr([b68af6e4/86'/0'/0']zpub6rxQT4vrGrdLmFicJZnLxx1odj1C8xNtHW5pW84hMSXdtoFnCbqBFJm3bF5PrwYL5ScxFhdzRuv3pb9beyoraQLMuQWkV9faGuxstBPgLw4)",
+      );
+      w.init();
+      assert.ok(w.valid());
+
+      assert.strictEqual(w.getMasterFingerprintHex(), 'b68af6e4');
+      assert.strictEqual(w.getDerivationPath(), "m/86'/0'/0'");
+
+      assert.strictEqual(
+        w.getSecret(),
+        'zpub6rxQT4vrGrdLmFicJZnLxx1odj1C8xNtHW5pW84hMSXdtoFnCbqBFJm3bF5PrwYL5ScxFhdzRuv3pb9beyoraQLMuQWkV9faGuxstBPgLw4',
+      );
+
+      assert.ok(w._getExternalAddressByIndex(0).startsWith('bc1p'), 'not taproot address, got: ' + w._getExternalAddressByIndex(0));
+
+      const utxos = [
+        {
+          height: 923789,
+          value: 10108,
+          address: 'bc1pyren45uwytsghuxelahgyjflrx9dhq9zhavangrcmw2avfre6spqtwxgm4',
+          txid: 'dd8a90cfef8b5966781cfaddf8a5e8f1e2dce12e7ceed25c6d329c1df2e17c4f',
+          vout: 0,
+          wif: false,
+          confirmations: 7,
+        },
+      ];
+
+      if (cleanupInternals) {
+        // these might be purged when preparing for serialization before saving to disk
+        w._hdWalletInstance._node0 = undefined;
+        w._hdWalletInstance._node1 = undefined;
+      }
+
+      const { psbt } = w.createTransaction(utxos, [{ address: '13HaCAB4jf7FYSZexJxoczyDDnutzZigjS' }], 1, w._getInternalAddressByIndex(0));
+      assert.ok(psbt);
 
       assert.ok(!w.useWithHardwareWalletEnabled());
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable Taproot (BIP86) watch-only flows using `zpub`/descriptors and fix `zpub` handling in Taproot wallet; add logs and update tests.
> 
> - **Wallets**:
>   - **Taproot**: In `class/wallets/hd-taproot-wallet.ts`, handle `zpub` by converting to traditional `xpub` before `bip32.fromBase58()` in `_getNodePubkeyByIndex`.
>   - **Watch-only**: In `class/wallets/watch-only-wallet.ts`, select `HDTaprootWallet` when path starts with `m/86'` (BIP86) regardless of `xpub/ypub/zpub`; broaden `allowMasterFingerprint()` to `xpub|ypub|zpub`.
> - **Send**:
>   - Add error logging in `screen/send/SendDetails.tsx` for PSBT creation/sign failures.
> - **Tests**:
>   - Update e2e expected receive address/URI.
>   - Add unit tests for importing BIP86 with `zpub` (Keystone JSON and descriptors), address generation, and transaction creation; extend xpub PSBT test to handle purged internals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3623d00a004217670015e5dadcd3714d1593801d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->