### PR TITLE
Anabelle fix transaction status update on confirmation

### DIFF
--- a/screen/transactions/TransactionStatus.tsx
+++ b/screen/transactions/TransactionStatus.tsx
@@ -25,6 +25,7 @@ import { useSettings } from '../../hooks/context/useSettings';
 import { useExtendedNavigation } from '../../hooks/useExtendedNavigation';
 import { BlueSpacing10, BlueSpacing20 } from '../../components/BlueSpacing';
 import { BlueLoading } from '../../components/BlueLoading';
+import useWalletSubscribe from '../../hooks/useWalletSubscribe';
 
 enum ButtonStatus {
   Possible,
@@ -113,6 +114,7 @@ const TransactionStatus: React.FC<TransactionStatusProps> = ({ transaction, txid
   const { isCPFPPossible, isRBFBumpFeePossible, isRBFCancelPossible, tx, isLoading, eta, intervalMs, wallet, loadingError } = state;
   const { wallets, txMetadata, counterpartyMetadata, fetchAndSaveWalletTransactions } = useStorage();
   const { hash, walletID } = useRoute<RouteProps>().params;
+  const subscribedWallet = useWalletSubscribe(walletID!);
   const { navigate, setOptions, goBack } = useExtendedNavigation<NavigationProps>();
   const { colors } = useTheme();
   const { selectedBlockExplorer } = useSettings();
@@ -188,19 +190,18 @@ const TransactionStatus: React.FC<TransactionStatusProps> = ({ transaction, txid
   }, [DetailsButton, colors, hash, setOptions]);
 
   useEffect(() => {
-    if (wallet) {
-      const transactions = wallet.getTransactions();
+    if (subscribedWallet) {
+      const transactions = subscribedWallet.getTransactions();
       const newTx = transactions.find((t: Transaction) => t.hash === hash);
       if (newTx) {
         setTX(newTx);
       }
     }
-  }, [hash, wallet]);
+  }, [hash, subscribedWallet]);
 
   useEffect(() => {
-    const foundWallet = wallets.find(w => w.getID() === walletID) || null;
-    dispatch({ type: ActionType.SetWallet, payload: foundWallet });
-  }, [walletID, wallets]);
+    dispatch({ type: ActionType.SetWallet, payload: subscribedWallet });
+  }, [subscribedWallet]);
 
   // re-fetching tx status periodically
   useEffect(() => {

--- a/tests/unit/transaction-status.test.tsx
+++ b/tests/unit/transaction-status.test.tsx
@@ -1,0 +1,237 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+
+import TransactionStatus from '../../screen/transactions/TransactionStatus';
+
+type MockStorage = {
+  wallets: any[];
+  txMetadata: Record<string, any>;
+  counterpartyMetadata: Record<string, any>;
+  fetchAndSaveWalletTransactions: jest.Mock;
+};
+
+const mockFetchAndSaveWalletTransactions = jest.fn();
+let mockStorageState: MockStorage = {
+  wallets: [],
+  txMetadata: {},
+  counterpartyMetadata: {},
+  fetchAndSaveWalletTransactions: mockFetchAndSaveWalletTransactions,
+};
+
+jest.mock('../../hooks/context/useStorage', () => ({
+  useStorage: () => mockStorageState,
+}));
+
+let mockWalletSubscribe: any = null;
+
+jest.mock('../../hooks/useWalletSubscribe', () => ({
+  __esModule: true,
+  default: () => mockWalletSubscribe,
+}));
+
+const routeParams = { hash: 'mock-tx', walletID: 'mock-wallet' };
+
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useRoute: () => ({ params: routeParams }),
+    useNavigation: () => ({
+      navigate: jest.fn(),
+      setOptions: jest.fn(),
+      goBack: jest.fn(),
+      addListener: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('../../hooks/useExtendedNavigation', () => ({
+  useExtendedNavigation: () => ({
+    navigate: jest.fn(),
+    setOptions: jest.fn(),
+    goBack: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/context/useSettings', () => ({
+  useSettings: () => ({
+    selectedBlockExplorer: { url: 'https://block.explorer' },
+  }),
+}));
+
+jest.mock('../../components/themes', () => ({
+  useTheme: () => ({
+    colors: {
+      alternativeTextColor2: '#fff',
+      success: '#0f0',
+      successCheck: '#0f0',
+      feeText: '#888',
+      lightButton: '#222',
+      buttonTextColor: '#000',
+      elevated: '#111',
+      buttonDisabledBackgroundColor: '#333',
+      background: '#000',
+      lightBorder: '#333',
+      customHeader: '#000',
+    },
+  }),
+}));
+
+jest.mock('../../BlueComponents', () => {
+  const React = require('react');
+  const { Text, View } = require('react-native');
+  return {
+    BlueCard: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+    BlueText: ({ children }: { children: React.ReactNode }) => <Text>{children}</Text>,
+  };
+});
+
+jest.mock('../../components/Button', () => 'Button');
+jest.mock('../../components/HandOffComponent', () => 'HandOffComponent');
+jest.mock('../../components/HeaderRightButton', () => 'HeaderRightButton');
+jest.mock('../../components/BlueSpacing', () => ({
+  BlueSpacing10: 'BlueSpacing10',
+  BlueSpacing20: 'BlueSpacing20',
+}));
+jest.mock('../../components/BlueLoading', () => ({ BlueLoading: 'BlueLoading' }));
+jest.mock('../../components/SafeArea', () => ({ children }: { children: React.ReactNode }) => <>{children}</>);
+
+jest.mock('../../components/icons/TransactionIncomingIcon', () => 'TransactionIncomingIcon');
+jest.mock('../../components/icons/TransactionOutgoingIcon', () => 'TransactionOutgoingIcon');
+jest.mock('../../components/icons/TransactionPendingIcon', () => 'TransactionPendingIcon');
+
+jest.mock('@rneui/themed', () => ({
+  Icon: 'Icon',
+}));
+
+jest.mock('../../blue_modules/hapticFeedback', () => ({
+  default: jest.fn(),
+  HapticFeedbackTypes: {},
+}));
+
+jest.mock('../../blue_modules/BlueElectrum', () => ({
+  multiGetTransactionByTxid: jest.fn(),
+  getMempoolTransactionsByAddress: jest.fn(),
+  estimateFees: jest.fn(),
+}));
+
+jest.mock('../../loc', () => ({
+  __esModule: true,
+  default: {
+    formatString: (template: string, params: Record<string, any>) => {
+      return Object.entries(params).reduce((acc, [key, value]) => acc.replace(`{${key}}`, String(value)), template);
+    },
+    transactions: {
+      eta_10m: '10 minutes',
+      eta_3h: '3 hours',
+      eta_1d: '1 day',
+      status_bump: 'Bump Fee',
+      status_cancel: 'Cancel',
+      details_title: 'Transaction Details',
+      confirmations_lowercase: 'confirmations: {confirmations}',
+      transaction_loading_error: 'loading error',
+      transaction_not_available: 'not available',
+      copy_link: 'copy link',
+      to: 'to {counterparty}',
+      from: 'from {counterparty}',
+      details_to: 'To',
+      details_from: 'From',
+      txid: 'txid',
+      details_received: 'received',
+      details_inputs: 'inputs',
+      details_outputs: 'outputs',
+      details_view_in_browser: 'view in browser',
+    },
+    send: {
+      create_details: 'Details',
+      create_fee: 'Fee',
+    },
+    _: {
+      ok: 'OK',
+      cancel: 'Cancel',
+    },
+  },
+  formatBalanceWithoutSuffix: (value: number | string) => String(value),
+}));
+
+const mockTxBase = {
+  hash: 'mock-tx',
+  value: 1200,
+  fee: 10,
+  counterparty: undefined,
+};
+
+const setup = (confirmations: number, lastFetch: number) => {
+  let currentConfirmations = confirmations;
+  let currentLastFetch = lastFetch;
+
+  const walletMock = {
+    getID: () => 'mock-wallet',
+    getTransactions: jest.fn(() => [{ ...mockTxBase, confirmations: currentConfirmations }]),
+    getLastTxFetch: jest.fn(() => currentLastFetch),
+    allowRBF: jest.fn(() => false),
+    preferredBalanceUnit: 'BTC',
+  } as any;
+
+  mockStorageState = {
+    ...mockStorageState,
+    wallets: [walletMock],
+  };
+
+  mockWalletSubscribe = walletMock;
+
+  const view = render(<TransactionStatus />);
+
+  const update = async (nextConfirmations: number, nextFetch: number) => {
+    currentConfirmations = nextConfirmations;
+    currentLastFetch = nextFetch;
+
+    // Create a new proxy to simulate what useWalletSubscribe does when lastTxFetch changes
+    mockWalletSubscribe = new Proxy(walletMock, {});
+
+    mockStorageState = {
+      ...mockStorageState,
+      wallets: [walletMock],
+    };
+    view.rerender(<TransactionStatus />);
+    await waitFor(() => {
+      expect(walletMock.getTransactions).toHaveBeenCalled();
+    });
+    return view;
+  };
+
+  return { walletMock, view, update };
+};
+
+describe('TransactionStatus regression', () => {
+  beforeEach(() => {
+    mockStorageState = {
+      wallets: [],
+      txMetadata: {},
+      counterpartyMetadata: {},
+      fetchAndSaveWalletTransactions: mockFetchAndSaveWalletTransactions,
+    };
+    mockWalletSubscribe = null;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('re-fetches wallet transactions when lastTxFetch changes', async () => {
+    const { view, update, walletMock } = setup(1, 1000);
+
+    await waitFor(() => {
+      expect(view.getByText('confirmations: 1')).toBeTruthy();
+    });
+
+    const initialCalls = walletMock.getTransactions.mock.calls.length;
+
+    await update(4, 2000);
+
+    await waitFor(() => {
+      expect(walletMock.getTransactions).toHaveBeenCalledTimes(initialCalls + 1);
+      expect(view.getByText('confirmations: 4')).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> `TransactionStatus` now uses `useWalletSubscribe` to reactively update the transaction/wallet and includes a unit test verifying re-fetch on wallet changes.
> 
> - **Transactions UI**:
>   - Switch `screen/transactions/TransactionStatus.tsx` to use `useWalletSubscribe(walletID)` for reactive wallet/tx updates.
>   - Replace manual wallet lookup and effects to derive `tx` from `subscribedWallet.getTransactions()` and set `wallet` from `subscribedWallet`.
>   - Update effect dependencies from `wallet` to `subscribedWallet` to reflect live changes (e.g., confirmations).
> - **Tests**:
>   - Add `tests/unit/transaction-status.test.tsx` regression test to assert re-fetching transactions and confirmation updates when `lastTxFetch` changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fb09696b051aa62352aa1cf8a24fae8b5d2ebce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->