### PR TITLE
FIX: better electrum fee estimation

### DIFF
--- a/models/networkTransactionFees.ts
+++ b/models/networkTransactionFees.ts
@@ -29,7 +29,11 @@ export default class NetworkTransactionFees {
         throw new Error('Electrum is disabled. Dont attempt to fetch fees');
       }
       const response = await BlueElectrum.estimateFees();
-      return new NetworkTransactionFee(response.fast + 5, response.medium + 2, response.slow);
+      if (response.fast === response.medium) {
+        // exception, if fees are equal lets bump priority fee + 1 so actual priority tx is above the rest
+        return new NetworkTransactionFee(response.fast + 1, response.medium, response.slow);
+      }
+      return new NetworkTransactionFee(response.fast, response.medium, response.slow);
     } catch (err) {
       console.warn(err);
       return new NetworkTransactionFee(2, 1, 1);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts recommended fee logic to remove constant uplifts and only add +1 to fast when it equals medium, otherwise use Electrum values as-is.
> 
> - **Fees**:
>   - `models/networkTransactionFees.ts`:
>     - Update `recommendedFees()` to remove fixed uplifts and instead bump `fast` by `+1` only when `fast === medium`; otherwise return Electrum-estimated fees unchanged.
>     - Keeps fallback to default fees on error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78beb8856905f513b395c9e4a99e8ef37ef85af7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->