### PR TITLE
REF: bump bip32 and migrate buffers

### DIFF
--- a/blue_modules/noble_ecc.ts
+++ b/blue_modules/noble_ecc.ts
@@ -6,7 +6,7 @@
  * @see https://github.com/bitcoinjs/bitcoinjs-lib/issues/1781
  */
 import * as necc from '@noble/secp256k1';
-import { TinySecp256k1Interface as TinySecp256k1InterfaceBIP32 } from 'bip32/types/bip32';
+import { TinySecp256k1Interface as TinySecp256k1InterfaceBIP32 } from 'bip32';
 import { XOnlyPointAddTweakResult } from 'bitcoinjs-lib/src/types';
 import { hmac } from '@noble/hashes/hmac';
 import { sha256 } from '@noble/hashes/sha2';

--- a/class/wallets/abstract-hd-electrum-wallet.ts
+++ b/class/wallets/abstract-hd-electrum-wallet.ts
@@ -1098,9 +1098,9 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
   /**
    *
    * @param address {string} Address that belongs to this wallet
-   * @returns {Buffer|false} Either buffer with pubkey or false
+   * @returns {Uint8Array|false} Either Uint8Array with pubkey or false
    */
-  _getPubkeyByAddress(address: string): Buffer | false {
+  _getPubkeyByAddress(address: string): Uint8Array | false {
     for (let c = 0; c < this.next_free_address_index + this.gap_limit; c++) {
       if (this._getExternalAddressByIndex(c) === address) return this._getNodePubkeyByIndex(0, c);
     }

--- a/class/wallets/abstract-hd-wallet.ts
+++ b/class/wallets/abstract-hd-wallet.ts
@@ -315,7 +315,7 @@ export class AbstractHDWallet extends LegacyWallet {
     throw new Error('Not implemented');
   }
 
-  _getNodePubkeyByIndex(node: number, index: number): Buffer | undefined {
+  _getNodePubkeyByIndex(node: number, index: number): Uint8Array | undefined {
     throw new Error('Not implemented');
   }
 

--- a/class/wallets/hd-aezeed-wallet.ts
+++ b/class/wallets/hd-aezeed-wallet.ts
@@ -4,7 +4,7 @@ import * as bitcoin from 'bitcoinjs-lib';
 import b58 from 'bs58check';
 
 import ecc from '../../blue_modules/noble_ecc';
-import { concatUint8Arrays, hexToUint8Array } from '../../blue_modules/uint8array-extras';
+import { concatUint8Arrays, hexToUint8Array, uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
 import { AbstractHDElectrumWallet } from './abstract-hd-electrum-wallet';
 
 const bip32 = BIP32Factory(ecc);
@@ -172,7 +172,7 @@ export class HDAezeedWallet extends AbstractHDElectrumWallet {
     const root = bip32.fromSeed(this._getEntropyCached());
     const node = root.derivePath("m/1017'/0'/6'/0/0");
 
-    return node.publicKey.toString('hex');
+    return uint8ArrayToHex(node.publicKey);
   }
 
   // since its basically a bip84 wallet, we allow all other standard BIP84 features:

--- a/class/wallets/multisig-hd-wallet.ts
+++ b/class/wallets/multisig-hd-wallet.ts
@@ -13,7 +13,13 @@ import ecc from '../../blue_modules/noble_ecc';
 import { decodeUR } from '../../blue_modules/ur';
 import { AbstractHDElectrumWallet } from './abstract-hd-electrum-wallet';
 import { CreateTransactionResult, CreateTransactionTarget, CreateTransactionUtxo } from './types';
-import { uint8ArrayToHex, hexToUint8Array, concatUint8Arrays, uint8ArrayToString } from '../../blue_modules/uint8array-extras';
+import {
+  uint8ArrayToHex,
+  hexToUint8Array,
+  concatUint8Arrays,
+  uint8ArrayToString,
+  compareUint8Arrays,
+} from '../../blue_modules/uint8array-extras';
 
 const ECPair = ECPairFactory(ecc);
 const bip32 = BIP32Factory(ecc);
@@ -1057,8 +1063,8 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
   /**
    * @see https://github.com/bitcoin/bips/blob/master/bip-0067.mediawiki
    */
-  static sortBuffers(bufArr: Buffer[]): Buffer[] {
-    return bufArr.sort(Buffer.compare);
+  static sortBuffers(bufArr: Uint8Array[]): Uint8Array[] {
+    return bufArr.sort(compareUint8Arrays);
   }
 
   prepareForSerialization() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "bech32": "2.0.0",
         "bignumber.js": "9.3.1",
         "bip21": "2.0.3",
-        "bip32": "3.1.0",
+        "bip32": "5.0.0",
         "bip38": "github:BlueWallet/bip38",
         "bip39": "3.1.0",
         "bitcoinjs-lib": "^7.0.0-rc.0",
@@ -4951,6 +4951,23 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@spsina/bip47/node_modules/bip32": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-3.1.0.tgz",
+      "integrity": "sha512-eoeajYEzJ4d6yyVtby8C+XkCeKItiC4Mx56a0M9VaqTMC73SWOm4xVZG7SaR8e/yp4eSyky2XcBpH3DApPdu7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "^2.0.2",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@spsina/bip47/node_modules/bitcoinjs-lib": {
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.7.tgz",
@@ -6243,20 +6260,85 @@
       }
     },
     "node_modules/bip32": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bip32/-/bip32-3.1.0.tgz",
-      "integrity": "sha512-eoeajYEzJ4d6yyVtby8C+XkCeKItiC4Mx56a0M9VaqTMC73SWOm4xVZG7SaR8e/yp4eSyky2XcBpH3DApPdu7Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-5.0.0.tgz",
+      "integrity": "sha512-h043yQ9n3iU4WZ8KLRpEECMl3j1yx2DQ1kcPlzWg8VZC0PtukbDiyLDKbe6Jm79mL6Tfg+WFuZMYxnzVyr/Hyw==",
       "license": "MIT",
       "dependencies": {
-        "bs58check": "^2.1.1",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ripemd160": "^2.0.2",
-        "typeforce": "^1.11.5",
-        "wif": "^2.0.6"
+        "@noble/hashes": "^1.2.0",
+        "@scure/base": "^1.1.1",
+        "uint8array-tools": "^0.0.8",
+        "valibot": "^0.37.0",
+        "wif": "^5.0.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bip32/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/bip32/node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
+    "node_modules/bip32/node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/bip32/node_modules/bs58check": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^6.0.0"
+      }
+    },
+    "node_modules/bip32/node_modules/uint8array-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/bip32/node_modules/valibot": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.37.0.tgz",
+      "integrity": "sha512-FQz52I8RXgFgOHym3XHYSREbNtkgSjF9prvMFH1nBsRyfL6SfCzoT1GuSDTlbsuPubM7/6Kbw0ZMQb8A+V+VsQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bip32/node_modules/wif": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-5.0.0.tgz",
+      "integrity": "sha512-iFzrC/9ne740qFbNjTZ2FciSRJlHIXoxqk/Y5EnE08QOXu1WjJyCCswwDTYbohAOEnlCtLaAAQBhyaLRFh2hMA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58check": "^4.0.0"
       }
     },
     "node_modules/bip38": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "bech32": "2.0.0",
     "bignumber.js": "9.3.1",
     "bip21": "2.0.3",
-    "bip32": "3.1.0",
+    "bip32": "5.0.0",
     "bip38": "github:BlueWallet/bip38",
     "bip39": "3.1.0",
     "bitcoinjs-lib": "^7.0.0-rc.0",

--- a/tests/unit/hd-aezeed.test.js
+++ b/tests/unit/hd-aezeed.test.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
 
 import { HDAezeedWallet, WatchOnlyWallet } from '../../class';
+import { uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
 
 describe('HDAezeedWallet', () => {
   it('can import mnemonics and generate addresses and WIFs', async function () {
@@ -81,20 +82,20 @@ describe('HDAezeedWallet', () => {
 
     // we should not really test private methods, but oh well
     assert.strictEqual(
-      aezeed._getNodePubkeyByIndex(0, 0).toString('hex'),
+      uint8ArrayToHex(aezeed._getNodePubkeyByIndex(0, 0)),
       '03ed28668d446c6e2ac11e4848f7afd894761ad26569baa8a16adff723699f2c07',
     );
     assert.strictEqual(
-      aezeed._getNodePubkeyByIndex(1, 0).toString('hex'),
+      uint8ArrayToHex(aezeed._getNodePubkeyByIndex(1, 0)),
       '0210791263114fe72ab5a2131ca1986b84c62a93e30ee9d509266f1eadf4febaf2',
     );
     assert.strictEqual(
-      aezeed._getPubkeyByAddress(aezeed._getExternalAddressByIndex(1)).toString('hex'),
-      aezeed._getNodePubkeyByIndex(0, 1).toString('hex'),
+      uint8ArrayToHex(aezeed._getPubkeyByAddress(aezeed._getExternalAddressByIndex(1))),
+      uint8ArrayToHex(aezeed._getNodePubkeyByIndex(0, 1)),
     );
     assert.strictEqual(
-      aezeed._getPubkeyByAddress(aezeed._getInternalAddressByIndex(1)).toString('hex'),
-      aezeed._getNodePubkeyByIndex(1, 1).toString('hex'),
+      uint8ArrayToHex(aezeed._getPubkeyByAddress(aezeed._getInternalAddressByIndex(1))),
+      uint8ArrayToHex(aezeed._getNodePubkeyByIndex(1, 1)),
     );
   });
 

--- a/tests/unit/hd-legacy-breadwallet.test.js
+++ b/tests/unit/hd-legacy-breadwallet.test.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
 
 import { HDLegacyBreadwalletWallet } from '../../class';
+import { uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
 
 describe('HDLegacyBreadwalletWallet', () => {
   it('Legacy HD Breadwallet works', async () => {
@@ -25,11 +26,11 @@ describe('HDLegacyBreadwalletWallet', () => {
     assert.strictEqual(hdBread._getDerivationPathByAddress('bc1qk9hvkxqsqmps6ex3qawr79rvtg8es4ecjfu5v0'), "m/0'/1/2");
 
     assert.strictEqual(
-      hdBread._getPubkeyByAddress(hdBread._getExternalAddressByIndex(0)).toString('hex'),
+      uint8ArrayToHex(hdBread._getPubkeyByAddress(hdBread._getExternalAddressByIndex(0))),
       '029ba027f3f0a9fa69ce680a246198d56a3b047108f26791d1e4aa2d10e7e7a29a',
     );
     assert.strictEqual(
-      hdBread._getPubkeyByAddress(hdBread._getInternalAddressByIndex(0)).toString('hex'),
+      uint8ArrayToHex(hdBread._getPubkeyByAddress(hdBread._getInternalAddressByIndex(0))),
       '03074225b31a95af63de31267104e07863d892d291a33ef5b2b32d59c772d5c784',
     );
 

--- a/tests/unit/hd-legacy-electrum-seed-p2pkh-wallet.test.ts
+++ b/tests/unit/hd-legacy-electrum-seed-p2pkh-wallet.test.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 
 import { HDLegacyElectrumSeedP2PKHWallet } from '../../class';
+import { uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
 
 describe('HDLegacyElectrumSeedP2PKHWallet', () => {
   it('wont accept BIP39 seed', () => {
@@ -39,14 +40,12 @@ describe('HDLegacyElectrumSeedP2PKHWallet', () => {
     wif = hd._getInternalWIFByIndex(0);
     assert.strictEqual(wif, 'L52d26QmYGW8ctHo1omM5fZeJMgaonSkEWCGpnEekNvkVUoqTsNF');
 
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex'),
-      '02a6e6b674f82796cb4776673d824bf0673364fab24e62dcbfff4c1a5b69e3519b',
-    );
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex'),
-      '0344708260d2a832fd430285a0b915859d73e6ed4c6c6a9cb73e9069a9de56fb23',
-    );
+    let u8a = hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0));
+    assert(u8a);
+    assert.strictEqual(uint8ArrayToHex(u8a), '02a6e6b674f82796cb4776673d824bf0673364fab24e62dcbfff4c1a5b69e3519b');
+    u8a = hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0));
+    assert(u8a);
+    assert.strictEqual(uint8ArrayToHex(u8a), '0344708260d2a832fd430285a0b915859d73e6ed4c6c6a9cb73e9069a9de56fb23');
 
     hd.setSecret('bs');
     assert.ok(!hd.validateMnemonic());

--- a/tests/unit/hd-legacy-wallet.test.js
+++ b/tests/unit/hd-legacy-wallet.test.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import * as bitcoin from 'bitcoinjs-lib';
 
 import { HDLegacyP2PKHWallet } from '../../class';
+import { uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
 
 describe('Legacy HD (BIP44)', () => {
   it('works', async () => {
@@ -28,11 +29,11 @@ describe('Legacy HD (BIP44)', () => {
     assert.ok(!hd.getAllExternalAddresses().includes('1J9zoJz5LsAJ361SQHYnLTWg46Tc2AXUCj')); // not internal
 
     assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex'),
+      uint8ArrayToHex(hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0))),
       '0316e84a2556f30a199541633f5dda6787710ccab26771b7084f4c9e1104f47667',
     );
     assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex'),
+      uint8ArrayToHex(hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0))),
       '02ad7b2216f3a2b38d56db8a7ee5c540fd12c4bbb7013106eff78cc2ace65aa002',
     );
 

--- a/tests/unit/hd-segwit-bech32-wallet.test.js
+++ b/tests/unit/hd-segwit-bech32-wallet.test.js
@@ -34,11 +34,11 @@ describe('Bech32 Segwit HD (BIP84)', () => {
     assert.ok(!hd.addressIsChange('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu'));
 
     assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex'),
+      uint8ArrayToHex(hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0))),
       '0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c',
     );
     assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex'),
+      uint8ArrayToHex(hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0))),
       '03025324888e429ab8e3dbaf1f7802648b9cd01e9b418485c5fa4c1b9b5700e1a6',
     );
 

--- a/tests/unit/hd-segwit-electrum-seed-p2wpkh-wallet.test.ts
+++ b/tests/unit/hd-segwit-electrum-seed-p2wpkh-wallet.test.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 
 import { HDSegwitElectrumSeedP2WPKHWallet } from '../../class';
+import { uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
 
 describe('HDSegwitElectrumSeedP2WPKHWallet', () => {
   it('wont accept BIP39 seed', () => {
@@ -37,14 +38,12 @@ describe('HDSegwitElectrumSeedP2WPKHWallet', () => {
     wif = hd._getInternalWIFByIndex(0);
     assert.strictEqual(wif, 'KwsLfaB2y9QZRd5cxY3uM3L4r2fE7ZPzocwjkPbp1cSFMFfE9tBq');
 
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex'),
-      '023cb68c37a1ca627c414e63dfb23706091eafb50e50d7de4e2a1a56d7085d42e6',
-    );
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex'),
-      '02e7e6a8dc1fe62f7de88a7de3c5030f36ec6aec28c610bc1d573435fab18b9f94',
-    );
+    let u8a = hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0));
+    assert(u8a);
+    assert.strictEqual(uint8ArrayToHex(u8a), '023cb68c37a1ca627c414e63dfb23706091eafb50e50d7de4e2a1a56d7085d42e6');
+    u8a = hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0));
+    assert(u8a);
+    assert.strictEqual(uint8ArrayToHex(u8a), '02e7e6a8dc1fe62f7de88a7de3c5030f36ec6aec28c610bc1d573435fab18b9f94');
 
     hd.setSecret('bs');
     assert.ok(!hd.validateMnemonic());

--- a/tests/unit/hd-segwit-p2sh-wallet.test.ts
+++ b/tests/unit/hd-segwit-p2sh-wallet.test.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 
 import { HDLegacyP2PKHWallet, HDSegwitP2SHWallet, LegacyWallet, SegwitBech32Wallet, SegwitP2SHWallet } from '../../class';
+import { uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
 
 describe('P2SH Segwit HD (BIP49)', () => {
   it('can create a wallet', async () => {
@@ -16,14 +17,12 @@ describe('P2SH Segwit HD (BIP49)', () => {
     assert.ok(!hd.getAllExternalAddresses().includes('32yn5CdevZQLk3ckuZuA8fEKBco8mEkLei')); // not internal
     assert.strictEqual(true, hd.validateMnemonic());
 
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex'),
-      '0348192db90b753484601aaf1e6220644ffe37d83a9a5feff32b4da43739f736be',
-    );
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex'),
-      '03c107e6976d59e17490513fbed3fb321736b7231d24f3d09306c72714acf1859d',
-    );
+    let u8a = hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0));
+    assert(u8a);
+    assert.strictEqual(uint8ArrayToHex(u8a), '0348192db90b753484601aaf1e6220644ffe37d83a9a5feff32b4da43739f736be');
+    u8a = hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0));
+    assert(u8a);
+    assert.strictEqual(uint8ArrayToHex(u8a), '03c107e6976d59e17490513fbed3fb321736b7231d24f3d09306c72714acf1859d');
 
     assert.strictEqual(hd._getDerivationPathByAddress(hd._getExternalAddressByIndex(0)), "m/49'/0'/0'/0/0");
     assert.strictEqual(hd._getDerivationPathByAddress(hd._getInternalAddressByIndex(0)), "m/49'/0'/0'/1/0");

--- a/tests/unit/hd-taproot-wallet.test.ts
+++ b/tests/unit/hd-taproot-wallet.test.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 
 import { HDTaprootWallet, TaprootWallet } from '../../class';
+import { uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
 
 const utxos = [
   {
@@ -48,14 +49,12 @@ describe('Taproot HD (BIP86)', () => {
 
     assert.strictEqual(hd.getMasterFingerprintHex(), '73C5DA0A');
 
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0)).toString('hex'),
-      'cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115',
-    );
-    assert.strictEqual(
-      hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0)).toString('hex'),
-      '399f1b2f4393f29a18c937859c5dd8a77350103157eb880f02e8c08214277cef',
-    );
+    let u8a = hd._getPubkeyByAddress(hd._getExternalAddressByIndex(0));
+    assert(u8a);
+    assert.strictEqual(uint8ArrayToHex(u8a), 'cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115');
+    u8a = hd._getPubkeyByAddress(hd._getInternalAddressByIndex(0));
+    assert(u8a);
+    assert.strictEqual(uint8ArrayToHex(u8a), '399f1b2f4393f29a18c937859c5dd8a77350103157eb880f02e8c08214277cef');
   });
 
   it('can generate addresses only via zpub', function () {

--- a/tests/unit/multisig-hd-wallet.test.js
+++ b/tests/unit/multisig-hd-wallet.test.js
@@ -893,12 +893,12 @@ describe('multisig-wallet (native segwit)', () => {
 
     assert.strictEqual(uint8ArrayToHex(psbt2.data.inputs[0].bip32Derivation[0].masterFingerprint).toUpperCase(), fp1cobo);
     assert.strictEqual(
-      psbt2.data.inputs[0].bip32Derivation[0].pubkey.toString('hex').toUpperCase(),
+      uint8ArrayToHex(psbt2.data.inputs[0].bip32Derivation[0].pubkey).toUpperCase(),
       '02F73DC67739702AAE9006A7101F787F2D1A5228B124034231616CFF1120E651CB',
     );
     assert.strictEqual(uint8ArrayToHex(psbt2.data.inputs[0].bip32Derivation[1].masterFingerprint).toUpperCase(), fp2coldcard);
     assert.strictEqual(
-      psbt2.data.inputs[0].bip32Derivation[1].pubkey.toString('hex').toUpperCase(),
+      uint8ArrayToHex(psbt2.data.inputs[0].bip32Derivation[1].pubkey).toUpperCase(),
       '03D50975097F0D887DF1E948F6DA2BBC484C1EC079A1452CAA26D6E67F0FA0D75A',
     );
   });

--- a/tests/unit/watch-only-wallet.test.js
+++ b/tests/unit/watch-only-wallet.test.js
@@ -3,6 +3,7 @@ import { Psbt } from 'bitcoinjs-lib';
 
 import { BlueURDecoder, clearUseURv1, decodeUR, encodeUR, extractSingleWorkload, setUseURv1 } from '../../blue_modules/ur';
 import { WatchOnlyWallet } from '../../class';
+import { uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
 
 describe('Watch only wallet', () => {
   it('can validate address', async () => {
@@ -563,7 +564,7 @@ describe('Watch only wallet', () => {
     const { psbt } = w.createTransaction(utxos, [{ address: 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu', value: 5000 }], 1, changeAddress);
 
     assert.strictEqual(
-      psbt.data.outputs[1].bip32Derivation[0].pubkey.toString('hex'),
+      uint8ArrayToHex(psbt.data.outputs[1].bip32Derivation[0].pubkey),
       '03e060c9b5bb85476caa53e3b8cd3d40c9dc2c36a8a5e8ed87e48bfc9bbe1760ad',
     );
     assert.strictEqual(psbt.data.inputs[0].bip32Derivation[0].path, "m/49'/0'/0'/1/45");
@@ -584,7 +585,7 @@ describe('Watch only wallet', () => {
     );
 
     assert.strictEqual(
-      psbt2.data.outputs[1].bip32Derivation[0].pubkey.toString('hex'),
+      uint8ArrayToHex(psbt2.data.outputs[1].bip32Derivation[0].pubkey),
       '03e060c9b5bb85476caa53e3b8cd3d40c9dc2c36a8a5e8ed87e48bfc9bbe1760ad',
     );
     assert.strictEqual(psbt2.data.inputs[0].bip32Derivation[0].path, newPath + '/1/45');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrade bip32 to v5 and migrate Buffer-based wallet APIs/tests to Uint8Array, with supporting ECC and utility updates.
> 
> - **Dependencies**:
>   - Upgrade `bip32` from `3.x` to `5.0.0` (lockfile updated; new sub-deps added).
> - **Core changes (Buffer → Uint8Array)**:
>   - Wallet APIs now return/accept `Uint8Array` (e.g., `_getNodePubkeyByIndex`, `_getPubkeyByAddress`).
>   - Replace Buffer hex conversions with helpers like `uint8ArrayToHex`; update `getIdentityPubkey` to return hex from `Uint8Array`.
>   - Multisig: replace `Buffer.compare` with `compareUint8Arrays` in `sortBuffers`.
> - **ECC Integration**:
>   - Update `TinySecp256k1Interface` import for `bip32` compatibility in `noble_ecc`.
> - **Tests**:
>   - Adjust expectations to use `Uint8Array` and `uint8ArrayToHex`; update PSBT derivation pubkey assertions accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 476ec19b26c0151fe5da1e1784f15f23e70a192d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->