### PR TITLE
fix: ark

### DIFF
--- a/class/wallets/lightning-ark-wallet.ts
+++ b/class/wallets/lightning-ark-wallet.ts
@@ -241,9 +241,8 @@ export class LightningArkWallet extends LightningCustodianWallet {
       if (this._claimedSwaps[swap.id]) {
         ispaid = true;
       }
-
       // @ts-ignore properties do exist
-      value = value || swap.request.invoiceAmount || swap.response.expectedAmount || swap.response.onchainAmount || 0;
+      value = swap.response.expectedAmount || value || swap.request.invoiceAmount || swap.response.onchainAmount || 0;
       value = value * direction;
 
       ret.push({

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,9 @@ module.exports = {
   },
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
   transformIgnorePatterns: ['node_modules/(?!((jest-)?react-native(-.*)?|@react-native(-community)?)|@rneui|silent-payments|@arkade-os)/'],
+  moduleNameMapper: {
+    '^expo/fetch$': '<rootDir>/util/expo-fetch.js',
+  },
   setupFiles: ['./tests/setup.js'],
   watchPathIgnorePatterns: ['<rootDir>/node_modules'],
 };

--- a/tests/integration/lightning-ark-wallet.test.ts
+++ b/tests/integration/lightning-ark-wallet.test.ts
@@ -192,7 +192,7 @@ describe('LightningArkWallet', () => {
     const receiveTx = txs.find(t => t.value! > 0);
     assert.ok(receiveTx, 'Should have at least one receive transaction');
     assert.strictEqual(receiveTx.memo, 'test invoice');
-    assert.strictEqual(receiveTx.value, 9999);
+    assert.strictEqual(receiveTx.value, 10000);
     assert.strictEqual(receiveTx.timestamp, 1761224952);
     assert.strictEqual(receiveTx.ispaid, true);
     assert.ok(receiveTx.payment_hash);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes Boltz ARK fee parsing and transaction amount calculation, adds Jest moduleNameMapper for expo/fetch, and updates integration test expectation.
> 
> - **Lightning Ark wallet (`class/wallets/lightning-ark-wallet.ts`)**:
>   - Parse Boltz fees from `feesResponseJson.ARK.BTC` and log a warning on unexpected responses.
>   - In `getTransactions()`, prefer decoded invoice `num_satoshis` and adjust amount priority: `expectedAmount || decodedValue || request.invoiceAmount || onchainAmount`.
> - **Testing/Config**:
>   - `jest.config.js`: add `moduleNameMapper` for `expo/fetch -> util/expo-fetch.js`.
>   - Update integration test expected receive amount to `10000` in `tests/integration/lightning-ark-wallet.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 956d937467bce031ca01a1bc3cfbb93ffe811af3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->