### PR TITLE
FIX: error in scanQR decoding breaks the whole scanning flow (closes …

### DIFF
--- a/loc/en.json
+++ b/loc/en.json
@@ -18,7 +18,6 @@
     "seed": "Seed",
     "success": "Success",
     "wallet_key": "Wallet key",
-    "invalid_animated_qr_code_fragment": "Invalid animated QR Code fragment. Please try again.",
     "close": "Close",
     "change_input_currency": "Change input currency",
     "refresh": "Refresh",

--- a/screen/send/ScanQRCode.tsx
+++ b/screen/send/ScanQRCode.tsx
@@ -15,7 +15,6 @@ import loc from '../../loc';
 import { useExtendedNavigation } from '../../hooks/useExtendedNavigation';
 import CameraScreen from '../../components/CameraScreen';
 import SafeArea from '../../components/SafeArea';
-import presentAlert from '../../components/Alert';
 import { SendDetailsStackParamList } from '../../navigation/SendDetailsStackParamList.ts';
 import { BlueSpacing40 } from '../../components/BlueSpacing';
 import { BlueLoading } from '../../components/BlueLoading.tsx';
@@ -117,12 +116,8 @@ const ScanQRCode = () => {
         setUrTotal(100);
         setUrHave(Math.floor(decoder.estimatedPercentComplete() * 100));
       }
-    } catch (error) {
-      setIsLoading(true);
-      presentAlert({
-        title: loc.errors.error,
-        message: loc._.invalid_animated_qr_code_fragment,
-      });
+    } catch (error: any) {
+      console.log('Invalid animated qr code fragment: ' + error.message + ' (continuing scanning)');
     }
   };
 
@@ -159,13 +154,8 @@ const ScanQRCode = () => {
       } else {
         setAnimatedQRCodeData(animatedQRCodeData);
       }
-    } catch (error) {
-      setIsLoading(true);
-
-      presentAlert({
-        title: loc.errors.error,
-        message: loc._.invalid_animated_qr_code_fragment,
-      });
+    } catch (error: any) {
+      console.log('Invalid animated qr code fragment: ' + error.message + ' (continuing scanning)');
     }
   };
 


### PR DESCRIPTION
…#8180)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle invalid animated QR fragments by logging and continuing scanning; remove unused localization string.
> 
> - **Scan/QR (`screen/send/ScanQRCode.tsx`)**:
>   - Replace alert-based error handling for UR v1/v2 with console logging and continue scanning instead of interrupting flow.
>   - Remove `presentAlert` usage and related loading state changes in catch blocks.
> - **Localization (`loc/en.json`)**:
>   - Remove unused key `_.invalid_animated_qr_code_fragment`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18920d6efee556b2e797096f669315b22dc15158. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->