### PR TITLE
feat: detox ios

### DIFF
--- a/.detoxrc.json
+++ b/.detoxrc.json
@@ -7,10 +7,15 @@
     }
   },
   "apps": {
-    "ios": {
+    "ios.debug": {
       "type": "ios.app",
-      "binaryPath": "SPECIFY_PATH_TO_YOUR_APP_BINARY",
-      "build": "xcodebuild clean build -workspace ios/BlueWallet.xcworkspace -scheme BlueWallet -configuration Release -derivedDataPath ios/build -sdk iphonesimulator13.2"
+      "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/BlueWallet.app",
+      "build": "xcodebuild -workspace ios/BlueWallet.xcworkspace -scheme BlueWallet -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build"
+    },
+    "ios.release": {
+      "type": "ios.app",
+      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/BlueWallet.app",
+      "build": "npx react-native codegen && xcodebuild -workspace ios/BlueWallet.xcworkspace -scheme BlueWallet -configuration Release -sdk iphonesimulator -derivedDataPath ios/build"
     },
     "android.debug": {
       "type": "android.apk",
@@ -28,7 +33,7 @@
     "simulator": {
       "type": "ios.simulator",
       "device": {
-        "type": "iPhone 11"
+        "type": "iPhone 16"
       }
     },
     "emulator": {
@@ -39,9 +44,9 @@
     }
   },
   "configurations": {
-    "ios": {
+    "ios.release": {
       "device": "simulator",
-      "app": "ios"
+      "app": "ios.release"
     },
     "android.debug": {
       "device": "emulator",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ name: Tests
 # https://medium.com/@reime005/the-best-ci-cd-for-react-native-with-e2e-support-4860b4aaab29
 
 env:
-  TRAVIS: 1
   HD_MNEMONIC: ${{ secrets.HD_MNEMONIC }}
   HD_MNEMONIC_BIP84: ${{ secrets.HD_MNEMONIC_BIP84 }}
 
@@ -16,6 +15,8 @@ jobs:
     steps:
     - name: Checkout project
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Specify node version
       uses: actions/setup-node@v4
@@ -35,6 +36,8 @@ jobs:
     steps:
     - name: Checkout project
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Specify node version
       uses: actions/setup-node@v4
@@ -64,6 +67,8 @@ jobs:
     steps:
     - name: Checkout project
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Specify node version
       uses: actions/setup-node@v4
@@ -88,92 +93,3 @@ jobs:
         MNEMONICS_COBO: ${{ secrets.MNEMONICS_COBO }}
         MNEMONICS_COLDCARD: ${{ secrets.MNEMONICS_COLDCARD }}
         RETRY: 1
-
-  e2e:
-    runs-on: ubuntu-latest
-    steps:
-    - name: checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
-
-    - name: Free Disk Space
-      uses: jlumbroso/free-disk-space@main
-      with:
-        tool-cache: true
-        android: false
-        dotnet: true
-        haskell: true
-        large-packages: true
-        docker-images: true
-        swap-storage: true
-
-    - name: npm and gradle caches in /mnt
-      run: |
-        rm -rf ~/.npm
-        rm -rf ~/.gradle
-        sudo mkdir -p /mnt/.npm
-        sudo mkdir -p /mnt/.gradle
-        sudo chown -R runner /mnt/.npm
-        sudo chown -R runner /mnt/.gradle
-        ln -s /mnt/.npm /home/runner/
-        ln -s /mnt/.gradle /home/runner/
-
-    - name: Create artifacts directory on /mnt
-      run: |
-        sudo mkdir -p /mnt/artifacts
-        sudo chown -R runner /mnt/artifacts
-
-    - name: Specify node version
-      uses: actions/setup-node@v4
-      with:
-        node-version: 22
-        cache: 'npm'
-        cache-dependency-path: package-lock.json
-
-    - name: Use gradle caches
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-
-    - name: Install node_modules
-      run: npm ci --omit=dev --yes
-
-    - name: Use specific Java version for sdkmanager to work
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
-
-    - name: Enable KVM group perms
-      run: |
-        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-        sudo udevadm control --reload-rules
-        sudo udevadm trigger --name-match=kvm
-
-    - name: Build
-      run: npm run e2e:release-build
-
-    - name: Install dev deps needed for tests
-      run: npm i
-
-    - name: Run tests
-      uses: reactivecircus/android-emulator-runner@v2
-      with:
-        api-level: 31
-        avd-name: Pixel_API_29_AOSP
-        force-avd-creation: false
-        emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none -camera-front none -partition-size 2047
-        arch: x86_64
-        script: npm run e2e:release-test --  --record-videos all --record-logs all --take-screenshots all --headless -d 200000 -R 5 --artifacts-location /mnt/artifacts
-
-    - uses: actions/upload-artifact@v4
-      if: failure()
-      with:
-        name: e2e-test-videos
-        path: /mnt/artifacts/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,246 @@
+name: Tests e2e
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  ios:
+    runs-on: macos-15
+    env:
+      BUILD_CONFIGURATION: Release
+      HD_MNEMONIC: ${{ secrets.HD_MNEMONIC }}
+      HD_MNEMONIC_BIP84: ${{ secrets.HD_MNEMONIC_BIP84 }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1.6"
+
+      - name: Cache Ruby gems
+        uses: actions/cache@v4
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-ruby-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-ruby-
+
+      - name: Install Ruby gems
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3 --quiet
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Install CocoaPods dependencies
+        run: bundle exec fastlane ios install_pods
+
+      - name: Delete Apple Watch target
+        run: |
+          bundle exec ruby <<'RUBY'
+          require 'xcodeproj'
+
+          project_path = 'ios/BlueWallet.xcodeproj'
+          project = Xcodeproj::Project.open(project_path)
+
+          target_names = %w[BlueWalletWatch]
+          removed_any = false
+
+          target_names.each do |target_name|
+            target = project.targets.find { |t| t.name == target_name }
+            next unless target
+
+            puts "Removing target #{target_name}"
+            target.dependencies.each(&:remove_from_project)
+            target.build_phases.each(&:remove_from_project)
+            project.targets.delete(target)
+            removed_any = true
+          end
+
+          main_target = project.targets.find { |t| t.name == 'BlueWallet' }
+          if main_target
+            main_target.build_phases.select { |phase| phase.display_name == 'Embed Watch Content' }.each do |phase|
+              puts "Removing build phase #{phase.display_name}"
+              phase.remove_from_project
+              main_target.build_phases.delete(phase)
+              removed_any = true
+            end
+          end
+
+          if removed_any
+            project.save
+            puts 'Apple Watch target references removed'
+          else
+            puts 'No Apple Watch targets found'
+          end
+          RUBY
+
+      - name: Remove Watch schemes
+        run: rm -f ios/BlueWallet.xcodeproj/xcshareddata/xcschemes/BlueWalletWatch.xcscheme
+
+      - name: Build iOS simulator app
+        working-directory: ios
+        env:
+          RCT_NO_LAUNCH_PACKAGER: "1"
+        run: |
+          set -eo pipefail
+          xcodebuild \
+            -workspace BlueWallet.xcworkspace \
+            -scheme BlueWallet \
+            -configuration "${BUILD_CONFIGURATION}" \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath build \
+            build
+
+      - name: Package simulator app
+        run: |
+          APP_DIR="ios/build/Build/Products/${BUILD_CONFIGURATION}-iphonesimulator/BlueWallet.app"
+          if [ ! -d "$APP_DIR" ]; then
+            echo "Simulator app not found at $APP_DIR"
+            find ios/build -maxdepth 5 -name '*.app' || true
+            exit 1
+          fi
+          OUTPUT_DIR="BlueWallet-simulator"
+          rm -rf "$OUTPUT_DIR"
+          mkdir -p "$OUTPUT_DIR"
+          cp -R "$APP_DIR" "$OUTPUT_DIR/BlueWallet.app"
+          echo "APP_EXPORT_PATH=$OUTPUT_DIR" >> "$GITHUB_ENV"
+
+      - name: Install applesimutils
+        run: |
+          brew tap wix/brew
+          brew install applesimutils
+
+      - name: Run detox tests
+        run: |
+          npm run e2e:test:ios-release -- \
+            --record-videos failing \
+            --record-logs failing \
+            --take-screenshots failing \
+            --headless \
+            --retries 3 \
+            --reuse \
+            --artifacts-location ./artifacts
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: e2e-test-videos
+          path: ./artifacts/
+
+
+  android:
+    runs-on: ubuntu-latest
+    env:
+      HD_MNEMONIC: ${{ secrets.HD_MNEMONIC }}
+      HD_MNEMONIC_BIP84: ${{ secrets.HD_MNEMONIC_BIP84 }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Free disk space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: true
+        android: false
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
+
+    - name: npm and gradle caches in /mnt
+      run: |
+        rm -rf ~/.npm
+        rm -rf ~/.gradle
+        sudo mkdir -p /mnt/.npm
+        sudo mkdir -p /mnt/.gradle
+        sudo chown -R runner /mnt/.npm
+        sudo chown -R runner /mnt/.gradle
+        ln -s /mnt/.npm /home/runner/
+        ln -s /mnt/.gradle /home/runner/
+
+    - name: Create artifacts directory on /mnt
+      run: |
+        sudo mkdir -p /mnt/artifacts
+        sudo chown -R runner /mnt/artifacts
+
+    - name: Specify node version
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        cache: 'npm'
+        cache-dependency-path: package-lock.json
+
+    - name: Use gradle caches
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    - name: Install node_modules
+      run: npm ci --omit=dev --yes
+
+    - name: Use specific Java version for sdkmanager to work
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+
+    - name: Enable KVM group perms
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
+    - name: Build
+      run: npm run e2e:release-build
+
+    - name: Install dev deps needed for tests
+      run: npm i
+
+    - name: Run tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 31
+        avd-name: Pixel_API_29_AOSP
+        force-avd-creation: false
+        emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none -camera-front none -partition-size 2047
+        arch: x86_64
+        script: npm run e2e:release-test -- --record-videos failing --record-logs failing --take-screenshots failing --headless --retries 3 --reuse --artifacts-location /mnt/artifacts
+
+    - uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: e2e-test-videos
+        path: /mnt/artifacts/

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
     "e2e:release-build": "detox build -c android.release",
     "e2e:release-test": "detox test -c android.release --loglevel error",
     "e2e:release-test-device": "detox test -c android.release.device  --loglevel info --record-videos all",
+    "e2e:build:ios-release": "detox build -c ios.release",
+    "e2e:test:ios-release": "detox test -c ios.release",
     "tslint": "tsc",
     "lint": " npm run tslint && node scripts/find-unused-loc.js && eslint --ext .js,.ts,.tsx '*.@(js|ts|tsx)' screen 'blue_modules/*.@(js|ts|tsx)' class models loc tests components navigation typings",
     "lint:fix": "npm run lint -- --fix",

--- a/screen/wallets/PleaseBackup.tsx
+++ b/screen/wallets/PleaseBackup.tsx
@@ -68,7 +68,7 @@ const PleaseBackup: React.FC = () => {
         <Text style={[styles.pleaseText, stylesHook.pleaseText]}>{loc.pleasebackup.text}</Text>
       </View>
       <View style={styles.list}>
-        <SeedWords seed={wallet.getSecret() ?? ''} />
+        <SeedWords seed={wallet.getSecret()} />
       </View>
       <View style={styles.bottom}>
         <Button testID="PleasebackupOk" onPress={handleBackButton} title={loc.pleasebackup.ok} />

--- a/tests/e2e/jest.config.js
+++ b/tests/e2e/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   maxWorkers: 1,
-  testTimeout: 333_000,
+  testTimeout: 600_000, // 10 minutes. iOS multisig and plausible deniability tests take a long time to run
   verbose: true,
   reporters: ['detox/runners/jest/reporter'],
   globalSetup: 'detox/runners/jest/globalSetup',


### PR DESCRIPTION
- new flow to compile for ios and run detox tests
- TRAVIS env removed with random `await sleep` in e2e tests. Feels that we don't need it anymore.
- I've moved android e2e to the new e2e.yml. Jobs are now called `Tests e2e / android` and `Tests ios / android` for consistency.
- refactored tests a bit. Got rid of swipes, replaced with scroll + wait for element - much more stable. Use `scanText` everywhere
- only record videos for failed tests
- e2e tests timeout now 10 minutes, instead of 6

Unfortunately ios e2e tests are slow. This is because simulator is slow on github macos runners (lack of HW acceleration). Approximately 2 hours to compile and run the tests.
We can try to optimize the build time "Build Release and Upload to TestFlight" compiles in ~12 minutes, this job ~19 minutes