### PR TITLE
feat: only build x64 android for github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,6 @@ jobs:
         cache: 'npm'
         cache-dependency-path: package-lock.json
 
-
     - name: Use gradle caches
       uses: actions/cache@v4
       with:

--- a/tests/e2e/detox-build-release-apk.sh
+++ b/tests/e2e/detox-build-release-apk.sh
@@ -7,8 +7,8 @@ find android | grep '\.apk' --color=never | xargs -l rm
 rm detox.keystore
 keytool -genkeypair -v -keystore detox.keystore -alias detox  -keyalg RSA -keysize 2048 -validity 10000 -storepass 123456 -keypass 123456 -dname  'cn=Unknown, ou=Unknown, o=Unknown, c=Unknown'
 
-# building release APK
-cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..
+# building release APK. Only build for x86_64 architecture because we are running on x86_64 emulator on github actions
+cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release -PreactNativeArchitectures=x86_64 && cd ..
 
 # signing
 echo wheres waldo?


### PR DESCRIPTION
When we build for e2e detox we can only build for x86_64, minus 4 minutes build time 