### PR TITLE
FIX: Button padding on receive with amount screen

### DIFF
--- a/screen/receive/ReceiveDetails.tsx
+++ b/screen/receive/ReceiveDetails.tsx
@@ -695,7 +695,8 @@ const styles = StyleSheet.create({
   },
   modalButton: {
     paddingVertical: 14,
-    width: 100,
+    minWidth: 100,
+    paddingHorizontal: 16,
     borderRadius: 50,
     fontWeight: '700',
     flex: 0.5,


### PR DESCRIPTION
This PR fixes #8204 
The choice for using a width over padding is since there are buttons at both ends of the screen I think it's best they both have a specific width so there is a balance in the sizing.

Pictorial reference:

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-12-14 at 16 29 32" src="https://github.com/user-attachments/assets/475c0669-ab60-40c8-88cc-1fe758507ecb" />
