### PR TITLE
REF: wallets gradients

### DIFF
--- a/class/wallet-gradient.ts
+++ b/class/wallet-gradient.ts
@@ -83,67 +83,7 @@ export default class WalletGradient {
     return gradient;
   }
 
-  static linearGradientProps(type: string) {
-    let props: any;
-    switch (type) {
-      case MultisigHDWallet.type:
-        /* Example
-        props = { start: { x: 0, y: 0 } };
-        https://github.com/react-native-linear-gradient/react-native-linear-gradient
-        */
-        break;
-      default:
-        break;
-    }
-    return props;
-  }
-
   static headerColorFor(type: string): string {
-    let gradient: string[];
-    switch (type) {
-      case WatchOnlyWallet.type:
-        gradient = WalletGradient.watchOnlyWallet;
-        break;
-      case LegacyWallet.type:
-        gradient = WalletGradient.legacyWallet;
-        break;
-      case TaprootWallet.type:
-        gradient = WalletGradient.taprootWallet;
-        break;
-      case HDLegacyP2PKHWallet.type:
-      case HDLegacyElectrumSeedP2PKHWallet.type:
-      case SLIP39LegacyP2PKHWallet.type:
-        gradient = WalletGradient.hdLegacyP2PKHWallet;
-        break;
-      case HDLegacyBreadwalletWallet.type:
-        gradient = WalletGradient.hdLegacyBreadWallet;
-        break;
-      case HDSegwitP2SHWallet.type:
-      case SLIP39SegwitP2SHWallet.type:
-        gradient = WalletGradient.hdSegwitP2SHWallet;
-        break;
-      case HDSegwitBech32Wallet.type:
-      case HDSegwitElectrumSeedP2WPKHWallet.type:
-      case SLIP39SegwitBech32Wallet.type:
-        gradient = WalletGradient.hdSegwitBech32Wallet;
-        break;
-      case SegwitBech32Wallet.type:
-        gradient = WalletGradient.segwitBech32Wallet;
-        break;
-      case MultisigHDWallet.type:
-        gradient = WalletGradient.multisigHdWallet;
-        break;
-      case HDAezeedWallet.type:
-        gradient = WalletGradient.aezeedWallet;
-        break;
-      case LightningArkWallet.type:
-      case LightningCustodianWallet.type:
-        gradient = WalletGradient.lightningCustodianWallet;
-        break;
-      default:
-        gradient = WalletGradient.defaultGradients;
-        break;
-    }
-    return gradient[0];
+    return WalletGradient.gradientsFor(type)[0];
   }
 }

--- a/components/TransactionsNavigationHeader.tsx
+++ b/components/TransactionsNavigationHeader.tsx
@@ -166,11 +166,7 @@ const TransactionsNavigationHeader: React.FC<TransactionsNavigationHeaderProps> 
   useAnimateOnChange(wallet.getID?.());
 
   return (
-    <LinearGradient
-      colors={WalletGradient.gradientsFor(wallet.type)}
-      style={styles.lineaderGradient}
-      {...WalletGradient.linearGradientProps(wallet.type)}
-    >
+    <LinearGradient colors={WalletGradient.gradientsFor(wallet.type)} style={styles.lineaderGradient}>
       <ImageBackground source={imageSource} style={styles.chainIcon} />
 
       <Text testID="WalletLabel" numberOfLines={1} style={[styles.walletLabel, { writingDirection: direction }]}>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Simplifies wallet gradient handling by removing linearGradientProps, delegating headerColorFor to gradientsFor, and updating TransactionsNavigationHeader to use only gradient colors.
> 
> - **Wallet gradients (`class/wallet-gradient.ts`)**:
>   - Remove `linearGradientProps` helper.
>   - Refactor `headerColorFor` to return `gradientsFor(type)[0]` instead of maintaining its own switch.
> - **UI header (`components/TransactionsNavigationHeader.tsx`)**:
>   - Simplify `LinearGradient` usage to only pass `colors={WalletGradient.gradientsFor(wallet.type)}`; drop spread of `WalletGradient.linearGradientProps(wallet.type)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9550959a77754da291afb726f13fad2e831825a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->