### PR TITLE
FIX: import psbt files

### DIFF
--- a/class/deeplink-schema-match.ts
+++ b/class/deeplink-schema-match.ts
@@ -99,7 +99,7 @@ class DeeplinkSchemaMatch {
           }
         }
       }
-    } else if (DeeplinkSchemaMatch.isPossiblySignedPSBTFile(event.url)) {
+    } else if (DeeplinkSchemaMatch.isPossiblyPSBTFile(event.url)) {
       readFileOutsideSandbox(decodeURI(event.url))
         .then(file => {
           if (file) {
@@ -264,31 +264,15 @@ class DeeplinkSchemaMatch {
   }
 
   static isTXNFile(filePath: string): boolean {
-    return (
-      (filePath.toLowerCase().startsWith('file:') || filePath.toLowerCase().startsWith('content:')) &&
-      filePath.toLowerCase().endsWith('.txn')
-    );
-  }
-
-  static isPossiblySignedPSBTFile(filePath: string): boolean {
-    return (
-      (filePath.toLowerCase().startsWith('file:') || filePath.toLowerCase().startsWith('content:')) &&
-      filePath.toLowerCase().endsWith('-signed.psbt')
-    );
+    return filePath.toLowerCase().endsWith('.txn');
   }
 
   static isPossiblyPSBTFile(filePath: string): boolean {
-    return (
-      (filePath.toLowerCase().startsWith('file:') || filePath.toLowerCase().startsWith('content:')) &&
-      filePath.toLowerCase().endsWith('.psbt')
-    );
+    return filePath.toLowerCase().endsWith('.psbt');
   }
 
   static isPossiblyCosignerFile(filePath: string): boolean {
-    return (
-      (filePath.toLowerCase().startsWith('file:') || filePath.toLowerCase().startsWith('content:')) &&
-      filePath.toLowerCase().endsWith('.bwcosigner')
-    );
+    return filePath.toLowerCase().endsWith('.bwcosigner');
   }
 
   static isBothBitcoinAndLightningOnWalletSelect(wallet: TWallet, uri: any): TCompletionHandlerParams {

--- a/tests/unit/deeplink-schema-match.test.js
+++ b/tests/unit/deeplink-schema-match.test.js
@@ -410,22 +410,8 @@ describe.each(['', '//'])('unit - DeepLinkSchemaMatch', function (suffix) {
   it('recognizes files', () => {
     // txn files:
     assert.ok(DeeplinkSchemaMatch.isTXNFile('file://com.android.externalstorage.documents/document/081D-1403%3Atxhex.txn'));
-    assert.ok(!DeeplinkSchemaMatch.isPossiblySignedPSBTFile('file://com.android.externalstorage.documents/document/081D-1403%3Atxhex.txn'));
 
     assert.ok(DeeplinkSchemaMatch.isTXNFile('content://com.android.externalstorage.documents/document/081D-1403%3Atxhex.txn'));
-    assert.ok(
-      !DeeplinkSchemaMatch.isPossiblySignedPSBTFile('content://com.android.externalstorage.documents/document/081D-1403%3Atxhex.txn'),
-    );
-
-    // psbt files (signed):
-    assert.ok(
-      DeeplinkSchemaMatch.isPossiblySignedPSBTFile(
-        'content://com.android.externalstorage.documents/document/081D-1403%3Atxhex-signed.psbt',
-      ),
-    );
-    assert.ok(
-      DeeplinkSchemaMatch.isPossiblySignedPSBTFile('file://com.android.externalstorage.documents/document/081D-1403%3Atxhex-signed.psbt'),
-    );
 
     assert.ok(!DeeplinkSchemaMatch.isTXNFile('content://com.android.externalstorage.documents/document/081D-1403%3Atxhex-signed.psbt'));
     assert.ok(!DeeplinkSchemaMatch.isTXNFile('file://com.android.externalstorage.documents/document/081D-1403%3Atxhex-signed.psbt'));


### PR DESCRIPTION
i noticed that `uri` from `fs` now returns some crap, not real filename, so to check file extension you have to check `.name`

along the way refactored signed psbt detection

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use filename-based extension checks and runtime PSBT finalization to detect signed vs unsigned, removing signed-PSBT-specific handling and simplifying deeplink/file parsing.
> 
> - **Send flow (`screen/send/SendDetails.tsx`)**:
>   - Import now checks file extensions via `res.name` (not `uri`).
>   - For `.psbt`, tries `finalizeAllInputs()` and `extractTransaction()` to detect signed TX; navigates with `txhex` if signed, otherwise passes `psbt`.
>   - For `.txn`, reads as hex and navigates with `txhex`.
>   - Adds error logging on transaction pick failures.
> - **Deeplink/file detection (`class/deeplink-schema-match.ts`)**:
>   - Remove `isPossiblySignedPSBTFile`; use `isPossiblyPSBTFile` universally.
>   - Simplify `isTXNFile`, `isPossiblyPSBTFile`, `isPossiblyCosignerFile` to extension-only checks.
> - **Tests (`tests/unit/deeplink-schema-match.test.js`)**:
>   - Update file recognition tests to align with extension-only checks and removal of signed-PSBT detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fe1f67805f99c4cbe8e573009378199c5f49b58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->