### PR TITLE
REF: bump arkade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.2.15",
-        "@arkade-os/sdk": "0.3.9",
+        "@arkade-os/boltz-swap": "0.2.16",
+        "@arkade-os/sdk": "0.3.10",
         "@babel/preset-env": "7.27.2",
         "@bugsnag/react-native": "8.4.0",
         "@bugsnag/source-maps": "2.3.3",
@@ -169,12 +169,12 @@
       }
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.15.tgz",
-      "integrity": "sha512-F3sraS7fDUP3I4Rbv3vlnUeukPUUKiSUGShm2RMQ93fqx7rfE3fi8mtN9PQJ22bK6RueGGOlcMUgPEJKkZu2KA==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.16.tgz",
+      "integrity": "sha512-42vIGlDCvJry1UOifi8jKxfcD3jBjf5Ldfwjs+bz5jfjUZGflCBS2cqZxujtB3vlbANTNUIwP9qI0maE2cFV2A==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.3.9",
+        "@arkade-os/sdk": "0.3.10",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.0.1",
@@ -198,9 +198,9 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.9.tgz",
-      "integrity": "sha512-n9yQrhrgcZh4xxgJAyr11RiOjCGkil3WLqEBuSu6o1dNX9utyscvRduXgr6E+qmyi8If1wxKI91Ks0PRGnf+2A==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.10.tgz",
+      "integrity": "sha512-3O/ftt5h9equtbMuzBmWEbw2M8AeDrokoLSMQDvoQF4Lz9y8A0azZyVZjLZJlvNhQFL2ZVH+Y8urSI8YoHpJWg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -83,8 +83,8 @@
     "unit": "jest -b -w tests/unit/*"
   },
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.2.15",
-    "@arkade-os/sdk": "0.3.9",
+    "@arkade-os/boltz-swap": "0.2.16",
+    "@arkade-os/sdk": "0.3.10",
     "@babel/preset-env": "7.27.2",
     "@bugsnag/react-native": "8.4.0",
     "@bugsnag/source-maps": "2.3.3",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Arkade dependencies to latest versions.
> 
> - Bumps `@arkade-os/boltz-swap` to `0.2.16` and `@arkade-os/sdk` to `0.3.10` in `package.json` (and lockfile)
> - `@arkade-os/boltz-swap@0.2.16` now depends on `@arkade-os/sdk@0.3.10`, adds `bip68`, and declares Node `>=22` in its engines
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84b45250344878b0ef8afdb7e536a3b2656d21c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->