### PR TITLE
fix: bump camera to v16.2.0 with qrcode eci support

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1635,7 +1635,7 @@ PODS:
     - React-logger (= 0.78.2)
     - React-perflogger (= 0.78.2)
     - React-utils (= 0.78.2)
-  - ReactNativeCameraKit (16.1.3-1):
+  - ReactNativeCameraKit (16.2.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2348,7 +2348,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: b48473fe434569ff8f6cb6ed4421217ebcbda878
   ReactCodegen: 78b64f0ad96ef733616f54d0c20923f6c67287fd
   ReactCommon: 547db015202a80a5b3e7e041586ea54c4a087180
-  ReactNativeCameraKit: e43f767c2fed2a38ae16e7daea4e7b4f0d8ca66d
+  ReactNativeCameraKit: a357c57696bfd1f124aebf3a27bce3bc3adf5bdc
   RealmJS: 389361669e771fe4d13a86be48928d560d214294
   RNCAsyncStorage: 23e56519cc41d3bade3c8d4479f7760cb1c11996
   RNCClipboard: dfeb43751adff21e588657b5b6c888c72f3aa68e

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "react-native": "0.78.2",
         "react-native-biometrics": "3.0.1",
         "react-native-blue-crypto": "github:BlueWallet/react-native-blue-crypto#3cb5442",
-        "react-native-camera-kit-no-google": "16.1.3-1",
+        "react-native-camera-kit-no-google": "16.2.0",
         "react-native-capture-protection": "github:BlueWallet/react-native-capture-protection#d299992",
         "react-native-default-preference": "https://github.com/BlueWallet/react-native-default-preference.git#6338a1f1235e4130b8cfc2dd3b53015eeff2870c",
         "react-native-device-info": "14.1.1",
@@ -16365,9 +16365,9 @@
       }
     },
     "node_modules/react-native-camera-kit-no-google": {
-      "version": "16.1.3-1",
-      "resolved": "https://registry.npmjs.org/react-native-camera-kit-no-google/-/react-native-camera-kit-no-google-16.1.3-1.tgz",
-      "integrity": "sha512-uAe8fVidM+hT5JnKm5JrLcO3LVL2n++EVNvIkYAKxsOM7XhAVStaVPO0cYSBGn/0tsCXZfTDOXADhqruBTwW9g==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-camera-kit-no-google/-/react-native-camera-kit-no-google-16.2.0.tgz",
+      "integrity": "sha512-GcjritBUAL8EkUnbmoka9LjkDMb/fTl+RksBMb0WsGK3LV5E/ZwWPTUkFayKM7qKV172lS8jb3Iy0fSxVjc3Ww==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "react-native": "0.78.2",
     "react-native-biometrics": "3.0.1",
     "react-native-blue-crypto": "github:BlueWallet/react-native-blue-crypto#3cb5442",
-    "react-native-camera-kit-no-google": "16.1.3-1",
+    "react-native-camera-kit-no-google": "16.2.0",
     "react-native-capture-protection": "github:BlueWallet/react-native-capture-protection#d299992",
     "react-native-default-preference": "https://github.com/BlueWallet/react-native-default-preference.git#6338a1f1235e4130b8cfc2dd3b53015eeff2870c",
     "react-native-device-info": "14.1.1",


### PR DESCRIPTION
This test ECI qrcode now works for me

![telegram-cloud-photo-size-2-5402084121611275715-m](https://github.com/user-attachments/assets/a7efea36-fec4-4b1f-881a-3d489af202ea)

