### PR TITLE
Fix wrong address type for descriptors with custom paths

### DIFF
--- a/tests/unit/watch-only-wallet.test.js
+++ b/tests/unit/watch-only-wallet.test.js
@@ -447,6 +447,60 @@ describe('Watch only wallet', () => {
     assert.ok(!w.useWithHardwareWalletEnabled());
   });
 
+  it('can import taproot descriptor with non-BIP86 path', async () => {
+    // Regression test: tr() descriptors should be identified by script type, not just path
+    // Previously, tr([fp/0/0]xpub...) would incorrectly create a Legacy wallet because
+    // the path didn't start with m/86'
+    const w = new WatchOnlyWallet();
+    w.setSecret('tr([97311f91/0/0]xpub6C85eQDGy5NKEqCPnrnf4QcvxQCzRiTZFTa6YfuDU1hSQGWQHf6QBHogKXaS8hUhtvk6ND4btTdiWic26UKrk1pWrU4CQGrQoGxd6DP33Sw/<0;1>/*)');
+    w.init();
+    assert.ok(w.valid());
+
+    assert.strictEqual(w.getMasterFingerprintHex(), '97311f91');
+    assert.strictEqual(w.getDerivationPath(), 'm/0/0');
+    assert.strictEqual(w._scriptType, 'tr');
+
+    // Critical: Should create Taproot wallet, not Legacy
+    assert.strictEqual(w._hdWalletInstance.type, 'HDtaproot');
+    assert.ok(w._getExternalAddressByIndex(0).startsWith('bc1p'), 'not taproot address, got: ' + w._getExternalAddressByIndex(0));
+  });
+
+  it('can import wpkh descriptor with custom path', async () => {
+    // Test that wpkh() descriptors are identified by script type, not path
+    const w = new WatchOnlyWallet();
+    w.setSecret('wpkh([97311f91/0/0]xpub6C85eQDGy5NKEqCPnrnf4QcvxQCzRiTZFTa6YfuDU1hSQGWQHf6QBHogKXaS8hUhtvk6ND4btTdiWic26UKrk1pWrU4CQGrQoGxd6DP33Sw)');
+    w.init();
+    assert.ok(w.valid());
+
+    assert.strictEqual(w._scriptType, 'wpkh');
+    assert.strictEqual(w._hdWalletInstance.type, 'HDsegwitBech32');
+    assert.ok(w._getExternalAddressByIndex(0).startsWith('bc1q'), 'not segwit address, got: ' + w._getExternalAddressByIndex(0));
+  });
+
+  it('can import pkh descriptor with custom path', async () => {
+    // Test that pkh() descriptors are identified by script type, not path
+    const w = new WatchOnlyWallet();
+    w.setSecret('pkh([97311f91/0/0]xpub6C85eQDGy5NKEqCPnrnf4QcvxQCzRiTZFTa6YfuDU1hSQGWQHf6QBHogKXaS8hUhtvk6ND4btTdiWic26UKrk1pWrU4CQGrQoGxd6DP33Sw)');
+    w.init();
+    assert.ok(w.valid());
+
+    assert.strictEqual(w._scriptType, 'pkh');
+    assert.strictEqual(w._hdWalletInstance.type, 'HDlegacyP2PKH');
+    assert.ok(w._getExternalAddressByIndex(0).startsWith('1'), 'not legacy address, got: ' + w._getExternalAddressByIndex(0));
+  });
+
+  it('can import sh(wpkh) descriptor with custom path', async () => {
+    // Test that sh(wpkh()) descriptors are identified by script type, not path
+    const w = new WatchOnlyWallet();
+    w.setSecret('sh(wpkh([97311f91/0/0]xpub6C85eQDGy5NKEqCPnrnf4QcvxQCzRiTZFTa6YfuDU1hSQGWQHf6QBHogKXaS8hUhtvk6ND4btTdiWic26UKrk1pWrU4CQGrQoGxd6DP33Sw))');
+    w.init();
+    assert.ok(w.valid());
+
+    assert.strictEqual(w._scriptType, 'sh_wpkh');
+    assert.strictEqual(w._hdWalletInstance.type, 'HDsegwitP2SH');
+    assert.ok(w._getExternalAddressByIndex(0).startsWith('3'), 'not wrapped segwit address, got: ' + w._getExternalAddressByIndex(0));
+  });
+
   it('can import BIP86 (taproot) wallet descriptor and create transaction', async () => {
     for (const cleanupInternals of [false, true]) {
       const w = new WatchOnlyWallet();


### PR DESCRIPTION
Descriptors with non-standard derivation paths were creating incorrect wallet types. For example, 
```
tr([87a53c81/0/0]xpub661MyMwAqRbcFZ2qdrL7bkWFo5GUQgjkkW64SK6fEyRajRKRWcP6v1MhJcxw4Rz9ypXsECx7Px7JzD7nuFRLLEGunhMXNRyoAv7sNywTkS3/<0;1>/*)#rd8ehtyk
```
creates a Legacy wallet instead of a Taproot wallet!

This is because the wallet type was determined by checking if the derivation path started with `m/86'` (BIP86), rather than checking the actual descriptor script type (`tr`, `wpkh`, etc.).

This PR stores the descriptor script type during parsing and prioritizes it when determining wallet type:

1. **First check:** Script type from descriptor (`tr`, `wpkh`, `sh_wpkh`, `pkh`)
2. **Fallback:** Derivation path patterns (`m/86'`, `m/84'`, `m/49'`)
3. **Final fallback:** xpub/ypub/zpub prefix

Users with existing wallets imported using broken descriptors will need to manually re-import them. The stored wallet type won't automatically update since `_scriptType` will be undefined in saved data.

An alternative (and perhaps favorable) approach would be to lean on an external descriptor library.

I haven't tested this within the actual app yet but I did create some relevant tests.

Shoutout to @Specter2100 who found this issue while trying to load in a descriptor from Frostsnap.