### PR TITLE
Nickfarrow master

### DIFF
--- a/class/wallets/abstract-wallet.ts
+++ b/class/wallets/abstract-wallet.ts
@@ -31,9 +31,8 @@ export class AbstractWallet {
     return temp;
   }
 
-  segwitType?: 'p2wpkh' | 'p2sh(p2wpkh)' | 'p2tr';
+  segwitType?: 'p2wpkh' | 'p2sh(p2wpkh)' | 'p2tr' | 'p2pkh' /* not segwit but ok */;
   _derivationPath?: string;
-  _scriptType?: 'tr' | 'wpkh' | 'sh_wpkh' | 'pkh';
   label: string;
   secret: string;
   balance: number;
@@ -256,16 +255,16 @@ export class AbstractWallet {
 
       // Store the script type for later use
       if (this.secret.startsWith('tr(')) {
-        this._scriptType = 'tr';
+        this.segwitType = 'p2tr';
         this.secret = xpub;
       } else if (this.secret.startsWith('wpkh(')) {
-        this._scriptType = 'wpkh';
+        this.segwitType = 'p2wpkh';
         this.secret = this._xpubToZpub(xpub);
       } else if (this.secret.startsWith('sh(wpkh(')) {
-        this._scriptType = 'sh_wpkh';
+        this.segwitType = 'p2sh(p2wpkh)';
         this.secret = this._xpubToYpub(xpub);
       } else if (this.secret.startsWith('pkh(')) {
-        this._scriptType = 'pkh';
+        this.segwitType = 'p2pkh';
         this.secret = xpub;
       }
 

--- a/class/wallets/watch-only-wallet.ts
+++ b/class/wallets/watch-only-wallet.ts
@@ -77,13 +77,13 @@ export class WatchOnlyWallet extends LegacyWallet {
     let hdWalletInstance: THDWalletForWatchOnly;
 
     // Check script type first (most reliable - parsed from descriptor)
-    if (this._scriptType === 'tr') {
+    if (this.segwitType === 'p2tr') {
       hdWalletInstance = new HDTaprootWallet();
-    } else if (this._scriptType === 'wpkh') {
+    } else if (this.segwitType === 'p2wpkh') {
       hdWalletInstance = new HDSegwitBech32Wallet();
-    } else if (this._scriptType === 'sh_wpkh') {
+    } else if (this.segwitType === 'p2sh(p2wpkh)') {
       hdWalletInstance = new HDSegwitP2SHWallet();
-    } else if (this._scriptType === 'pkh') {
+    } else if (this.segwitType === 'p2pkh') {
       hdWalletInstance = new HDLegacyP2PKHWallet();
     }
     // Fallback to path-based detection (for bare [fingerprint/path]xpub without descriptor wrapper)
@@ -106,11 +106,6 @@ export class WatchOnlyWallet extends LegacyWallet {
     // if derivation path recovered from JSON file it should be moved to hdWalletInstance
     if (this._derivationPath) {
       hdWalletInstance._derivationPath = this._derivationPath;
-    }
-
-    // if script type recovered from JSON file it should be moved to hdWalletInstance
-    if (this._scriptType) {
-      hdWalletInstance._scriptType = this._scriptType;
     }
 
     if (this._hdWalletInstance) {

--- a/tests/unit/watch-only-wallet.test.js
+++ b/tests/unit/watch-only-wallet.test.js
@@ -452,13 +452,15 @@ describe('Watch only wallet', () => {
     // Previously, tr([fp/0/0]xpub...) would incorrectly create a Legacy wallet because
     // the path didn't start with m/86'
     const w = new WatchOnlyWallet();
-    w.setSecret('tr([97311f91/0/0]xpub6C85eQDGy5NKEqCPnrnf4QcvxQCzRiTZFTa6YfuDU1hSQGWQHf6QBHogKXaS8hUhtvk6ND4btTdiWic26UKrk1pWrU4CQGrQoGxd6DP33Sw/<0;1>/*)');
+    w.setSecret(
+      'tr([97311f91/0/0]xpub6C85eQDGy5NKEqCPnrnf4QcvxQCzRiTZFTa6YfuDU1hSQGWQHf6QBHogKXaS8hUhtvk6ND4btTdiWic26UKrk1pWrU4CQGrQoGxd6DP33Sw/<0;1>/*)',
+    );
     w.init();
     assert.ok(w.valid());
 
     assert.strictEqual(w.getMasterFingerprintHex(), '97311f91');
     assert.strictEqual(w.getDerivationPath(), 'm/0/0');
-    assert.strictEqual(w._scriptType, 'tr');
+    assert.strictEqual(w.segwitType, 'p2tr');
 
     // Critical: Should create Taproot wallet, not Legacy
     assert.strictEqual(w._hdWalletInstance.type, 'HDtaproot');
@@ -468,11 +470,13 @@ describe('Watch only wallet', () => {
   it('can import wpkh descriptor with custom path', async () => {
     // Test that wpkh() descriptors are identified by script type, not path
     const w = new WatchOnlyWallet();
-    w.setSecret('wpkh([97311f91/0/0]xpub6C85eQDGy5NKEqCPnrnf4QcvxQCzRiTZFTa6YfuDU1hSQGWQHf6QBHogKXaS8hUhtvk6ND4btTdiWic26UKrk1pWrU4CQGrQoGxd6DP33Sw)');
+    w.setSecret(
+      'wpkh([97311f91/0/0]xpub6C85eQDGy5NKEqCPnrnf4QcvxQCzRiTZFTa6YfuDU1hSQGWQHf6QBHogKXaS8hUhtvk6ND4btTdiWic26UKrk1pWrU4CQGrQoGxd6DP33Sw)',
+    );
     w.init();
     assert.ok(w.valid());
 
-    assert.strictEqual(w._scriptType, 'wpkh');
+    assert.strictEqual(w.segwitType, 'p2wpkh');
     assert.strictEqual(w._hdWalletInstance.type, 'HDsegwitBech32');
     assert.ok(w._getExternalAddressByIndex(0).startsWith('bc1q'), 'not segwit address, got: ' + w._getExternalAddressByIndex(0));
   });
@@ -480,11 +484,13 @@ describe('Watch only wallet', () => {
   it('can import pkh descriptor with custom path', async () => {
     // Test that pkh() descriptors are identified by script type, not path
     const w = new WatchOnlyWallet();
-    w.setSecret('pkh([97311f91/0/0]xpub6C85eQDGy5NKEqCPnrnf4QcvxQCzRiTZFTa6YfuDU1hSQGWQHf6QBHogKXaS8hUhtvk6ND4btTdiWic26UKrk1pWrU4CQGrQoGxd6DP33Sw)');
+    w.setSecret(
+      'pkh([97311f91/0/0]xpub6C85eQDGy5NKEqCPnrnf4QcvxQCzRiTZFTa6YfuDU1hSQGWQHf6QBHogKXaS8hUhtvk6ND4btTdiWic26UKrk1pWrU4CQGrQoGxd6DP33Sw)',
+    );
     w.init();
     assert.ok(w.valid());
 
-    assert.strictEqual(w._scriptType, 'pkh');
+    assert.strictEqual(w.segwitType, 'p2pkh');
     assert.strictEqual(w._hdWalletInstance.type, 'HDlegacyP2PKH');
     assert.ok(w._getExternalAddressByIndex(0).startsWith('1'), 'not legacy address, got: ' + w._getExternalAddressByIndex(0));
   });
@@ -492,11 +498,13 @@ describe('Watch only wallet', () => {
   it('can import sh(wpkh) descriptor with custom path', async () => {
     // Test that sh(wpkh()) descriptors are identified by script type, not path
     const w = new WatchOnlyWallet();
-    w.setSecret('sh(wpkh([97311f91/0/0]xpub6C85eQDGy5NKEqCPnrnf4QcvxQCzRiTZFTa6YfuDU1hSQGWQHf6QBHogKXaS8hUhtvk6ND4btTdiWic26UKrk1pWrU4CQGrQoGxd6DP33Sw))');
+    w.setSecret(
+      'sh(wpkh([97311f91/0/0]xpub6C85eQDGy5NKEqCPnrnf4QcvxQCzRiTZFTa6YfuDU1hSQGWQHf6QBHogKXaS8hUhtvk6ND4btTdiWic26UKrk1pWrU4CQGrQoGxd6DP33Sw))',
+    );
     w.init();
     assert.ok(w.valid());
 
-    assert.strictEqual(w._scriptType, 'sh_wpkh');
+    assert.strictEqual(w.segwitType, 'p2sh(p2wpkh)');
     assert.strictEqual(w._hdWalletInstance.type, 'HDsegwitP2SH');
     assert.ok(w._getExternalAddressByIndex(0).startsWith('3'), 'not wrapped segwit address, got: ' + w._getExternalAddressByIndex(0));
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves descriptor parsing and watch-only wallet initialization to rely on script type instead of derivation path, with broader script support and regression tests.
> 
> - Parse output descriptors to set `segwitType` (`p2tr`, `p2wpkh`, `p2sh(p2wpkh)`, `p2pkh`) in `AbstractWallet`; fix xpub extraction by removing all parentheses
> - `WatchOnlyWallet.init()` now selects HD wallet class primarily by `segwitType`, then falls back to derivation path (`m/86'`, `m/84'`, `m/49'`) and finally xpub/ypub/zpub prefixes
> - Add unit tests covering ambiguous/custom-path descriptors (`tr()`, `wpkh()`, `pkh()`, `sh(wpkh())`), persistence via storage save/load, and expected address/script types
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4245109bb5d6358316626199dd24695d69480ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->