### PR TITLE
chore: bump camera to v17

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1635,7 +1635,7 @@ PODS:
     - React-logger (= 0.78.2)
     - React-perflogger (= 0.78.2)
     - React-utils (= 0.78.2)
-  - ReactNativeCameraKit (16.2.0):
+  - ReactNativeCameraKit (17.0.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2348,7 +2348,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: b48473fe434569ff8f6cb6ed4421217ebcbda878
   ReactCodegen: 78b64f0ad96ef733616f54d0c20923f6c67287fd
   ReactCommon: 547db015202a80a5b3e7e041586ea54c4a087180
-  ReactNativeCameraKit: a357c57696bfd1f124aebf3a27bce3bc3adf5bdc
+  ReactNativeCameraKit: d75917233a431acac5d165568eca130263968e72
   RealmJS: 389361669e771fe4d13a86be48928d560d214294
   RNCAsyncStorage: 23e56519cc41d3bade3c8d4479f7760cb1c11996
   RNCClipboard: dfeb43751adff21e588657b5b6c888c72f3aa68e

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "react-native": "0.78.2",
         "react-native-biometrics": "3.0.1",
         "react-native-blue-crypto": "github:BlueWallet/react-native-blue-crypto#3cb5442",
-        "react-native-camera-kit-no-google": "16.2.0",
+        "react-native-camera-kit-no-google": "17.0.1",
         "react-native-capture-protection": "github:BlueWallet/react-native-capture-protection#d299992",
         "react-native-default-preference": "https://github.com/BlueWallet/react-native-default-preference.git#6338a1f1235e4130b8cfc2dd3b53015eeff2870c",
         "react-native-device-info": "14.1.1",
@@ -16376,9 +16376,9 @@
       }
     },
     "node_modules/react-native-camera-kit-no-google": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react-native-camera-kit-no-google/-/react-native-camera-kit-no-google-16.2.0.tgz",
-      "integrity": "sha512-GcjritBUAL8EkUnbmoka9LjkDMb/fTl+RksBMb0WsGK3LV5E/ZwWPTUkFayKM7qKV172lS8jb3Iy0fSxVjc3Ww==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react-native-camera-kit-no-google/-/react-native-camera-kit-no-google-17.0.1.tgz",
+      "integrity": "sha512-xUgeFfeHbP+ZUl+21IECs2aIGWNKxdHOYvzGufJp/4Qaj5YARAbJki5Sp2NwQrDGevZ2C673savEENMEsmr52g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "react-native": "0.78.2",
     "react-native-biometrics": "3.0.1",
     "react-native-blue-crypto": "github:BlueWallet/react-native-blue-crypto#3cb5442",
-    "react-native-camera-kit-no-google": "16.2.0",
+    "react-native-camera-kit-no-google": "17.0.1",
     "react-native-capture-protection": "github:BlueWallet/react-native-capture-protection#d299992",
     "react-native-default-preference": "https://github.com/BlueWallet/react-native-default-preference.git#6338a1f1235e4130b8cfc2dd3b53015eeff2870c",
     "react-native-device-info": "14.1.1",


### PR DESCRIPTION
New release react-native-camera-kit-no-google synched with react-native-camera-kit v17