### PR TITLE
OPS: update tests after compromised test seed

### DIFF
--- a/screen/settings/SelfTest.tsx
+++ b/screen/settings/SelfTest.tsx
@@ -298,9 +298,9 @@ export default class SelfTest extends Component {
         //
 
         const hd4 = new HDSegwitBech32Wallet();
-        hd4._xpub = 'zpub6r7jhKKm7BAVx3b3nSnuadY1WnshZYkhK8gKFoRLwK9rF3Mzv28BrGcCGA3ugGtawi1WLb2vyjQAX9ZTDGU5gNk2bLdTc3iEXr6tzR1ipNP';
+        hd4._xpub = 'zpub6rnbAtzupLPpSrsBKRsHupFvv1h6pwfRnZxX3qs6RL4LiLqKQ6kfBaDckn2apQWfyw1D2TdQMMDCfUDHMwtrcbGoy88xoKBLmADTFK9AhLe';
         await hd4.fetchBalance();
-        if (hd4.getBalance() !== 200000) throw new Error('Could not fetch HD Bech32 balance');
+        if (hd4.getBalance() !== 2400) throw new Error('Could not fetch HD Bech32 balance');
         await hd4.fetchTransactions();
         if (hd4.getTransactions().length !== 4) throw new Error('Could not fetch HD Bech32 transactions');
       } else {

--- a/tests/integration/BlueElectrum.test.js
+++ b/tests/integration/BlueElectrum.test.js
@@ -132,10 +132,10 @@ describe('BlueElectrum', () => {
   });
 
   it('BlueElectrum can do getTransactionsByAddress()', async function () {
-    const txs = await BlueElectrum.getTransactionsByAddress('bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
+    const txs = await BlueElectrum.getTransactionsByAddress('bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc');
     assert.strictEqual(txs.length, 1);
-    assert.strictEqual(txs[0].tx_hash, 'ad00a92409d8982a1d7f877056dbed0c4337d2ebab70b30463e2802279fb936d');
-    assert.strictEqual(txs[0].height, 563077);
+    assert.strictEqual(txs[0].tx_hash, '84b1a1b44726e5120533037edb8406ef46fa84c2f8dd50ada4ba72fa05af1dae');
+    assert.strictEqual(txs[0].height, 933626);
   });
 
   // skipped because requires fresh address with pending txs every time
@@ -152,7 +152,8 @@ describe('BlueElectrum', () => {
 
   it('BlueElectrum can do getTransactionsFullByAddress()', async function () {
     const txs = await BlueElectrum.getTransactionsFullByAddress('bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
-    for (const tx of txs) {
+    const tx = txs[0];
+    {
       assert.ok(tx.address === 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
       assert.ok(tx.txid);
       assert.ok(tx.confirmations);
@@ -179,23 +180,23 @@ describe('BlueElectrum', () => {
   it.each([false, true])('BlueElectrum can do multiGetBalanceByAddress(), disableBatching=%p', async function (diableBatching) {
     if (diableBatching) BlueElectrum.setBatchingDisabled();
     const balances = await BlueElectrum.multiGetBalanceByAddress([
-      'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh',
-      'bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p',
-      'bc1qwp58x4c9e5cplsnw5096qzdkae036ug7a34x3r',
+      'bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc',
+      'bc1qdsf8p4knu2u0h9cspflh0ftjp8qayve3r5nme8',
+      'bc1qzfmm8d9saalnjjnskj2mekycg73hecpajt8urp',
       '3GCvDBAktgQQtsbN6x5DYiQCMmgZ9Yk8BK',
-      'bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy',
+      'bc1qz28yun0lkkk2fk5ed2gdpnfra8970umtsd58gj',
     ]);
 
-    assert.strictEqual(balances.balance, 200000 + 51432);
+    assert.strictEqual(balances.balance, 2400 + 51432);
     assert.strictEqual(balances.unconfirmed_balance, 0);
-    assert.strictEqual(balances.addresses.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh.confirmed, 50000);
-    assert.strictEqual(balances.addresses.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh.unconfirmed, 0);
-    assert.strictEqual(balances.addresses.bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p.confirmed, 50000);
-    assert.strictEqual(balances.addresses.bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p.unconfirmed, 0);
-    assert.strictEqual(balances.addresses.bc1qwp58x4c9e5cplsnw5096qzdkae036ug7a34x3r.confirmed, 50000);
-    assert.strictEqual(balances.addresses.bc1qwp58x4c9e5cplsnw5096qzdkae036ug7a34x3r.unconfirmed, 0);
-    assert.strictEqual(balances.addresses.bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy.confirmed, 50000);
-    assert.strictEqual(balances.addresses.bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy.unconfirmed, 0);
+    assert.strictEqual(balances.addresses.bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc.confirmed, 600);
+    assert.strictEqual(balances.addresses.bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc.unconfirmed, 0);
+    assert.strictEqual(balances.addresses.bc1qdsf8p4knu2u0h9cspflh0ftjp8qayve3r5nme8.confirmed, 600);
+    assert.strictEqual(balances.addresses.bc1qdsf8p4knu2u0h9cspflh0ftjp8qayve3r5nme8.unconfirmed, 0);
+    assert.strictEqual(balances.addresses.bc1qzfmm8d9saalnjjnskj2mekycg73hecpajt8urp.confirmed, 600);
+    assert.strictEqual(balances.addresses.bc1qzfmm8d9saalnjjnskj2mekycg73hecpajt8urp.unconfirmed, 0);
+    assert.strictEqual(balances.addresses.bc1qz28yun0lkkk2fk5ed2gdpnfra8970umtsd58gj.confirmed, 600);
+    assert.strictEqual(balances.addresses.bc1qz28yun0lkkk2fk5ed2gdpnfra8970umtsd58gj.unconfirmed, 0);
     assert.strictEqual(balances.addresses['3GCvDBAktgQQtsbN6x5DYiQCMmgZ9Yk8BK'].confirmed, 51432);
     assert.strictEqual(balances.addresses['3GCvDBAktgQQtsbN6x5DYiQCMmgZ9Yk8BK'].unconfirmed, 0);
     if (diableBatching) BlueElectrum.setBatchingEnabled();
@@ -204,22 +205,22 @@ describe('BlueElectrum', () => {
   it('BlueElectrum can do multiGetUtxoByAddress()', async () => {
     const utxos = await BlueElectrum.multiGetUtxoByAddress(
       [
-        'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh',
-        'bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p',
-        'bc1qwp58x4c9e5cplsnw5096qzdkae036ug7a34x3r',
-        'bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy',
+        'bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc',
+        'bc1qdsf8p4knu2u0h9cspflh0ftjp8qayve3r5nme8',
+        'bc1qzfmm8d9saalnjjnskj2mekycg73hecpajt8urp',
+        'bc1qz28yun0lkkk2fk5ed2gdpnfra8970umtsd58gj',
       ],
       3,
     );
 
     assert.strictEqual(Object.keys(utxos).length, 4);
     assert.strictEqual(
-      utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].txid,
-      'ad00a92409d8982a1d7f877056dbed0c4337d2ebab70b30463e2802279fb936d',
+      utxos.bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc[0].txid,
+      '84b1a1b44726e5120533037edb8406ef46fa84c2f8dd50ada4ba72fa05af1dae',
     );
-    assert.strictEqual(utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].vout, 1);
-    assert.strictEqual(utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].value, 50000);
-    assert.strictEqual(utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].address, 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
+    assert.strictEqual(utxos.bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc[0].vout, 0);
+    assert.strictEqual(utxos.bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc[0].value, 600);
+    assert.strictEqual(utxos.bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc[0].address, 'bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc');
   });
 
   it.each([false, true])('ElectrumClient can do multiGetHistoryByAddress(), disableBatching=%p', async disableBatching => {

--- a/tests/integration/hd-segwit-bech32-wallet.test.js
+++ b/tests/integration/hd-segwit-bech32-wallet.test.js
@@ -29,18 +29,18 @@ describe('Bech32 Segwit HD (BIP84)', () => {
     assert.ok(hd.validateMnemonic());
 
     assert.strictEqual(
-      'zpub6r7jhKKm7BAVx3b3nSnuadY1WnshZYkhK8gKFoRLwK9rF3Mzv28BrGcCGA3ugGtawi1WLb2vyjQAX9ZTDGU5gNk2bLdTc3iEXr6tzR1ipNP',
+      'zpub6rnbAtzupLPpSrsBKRsHupFvv1h6pwfRnZxX3qs6RL4LiLqKQ6kfBaDckn2apQWfyw1D2TdQMMDCfUDHMwtrcbGoy88xoKBLmADTFK9AhLe',
       hd.getXpub(),
     );
 
-    assert.strictEqual(hd._getExternalAddressByIndex(0), 'bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p');
-    assert.strictEqual(hd._getExternalAddressByIndex(1), 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
-    assert.strictEqual(hd._getInternalAddressByIndex(0), 'bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy');
-    assert.strictEqual(hd._getInternalAddressByIndex(1), 'bc1qwp58x4c9e5cplsnw5096qzdkae036ug7a34x3r');
+    assert.strictEqual(hd._getExternalAddressByIndex(0), 'bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc');
+    assert.strictEqual(hd._getExternalAddressByIndex(1), 'bc1qdsf8p4knu2u0h9cspflh0ftjp8qayve3r5nme8');
+    assert.strictEqual(hd._getInternalAddressByIndex(0), 'bc1qzfmm8d9saalnjjnskj2mekycg73hecpajt8urp');
+    assert.strictEqual(hd._getInternalAddressByIndex(1), 'bc1qz28yun0lkkk2fk5ed2gdpnfra8970umtsd58gj');
 
-    assert.ok(hd.weOwnAddress('bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p'));
-    assert.ok(hd.weOwnAddress('BC1QVD6W54SYDC08Z3802SVKXR7297EZ7CUSD6266P'));
-    assert.ok(hd.weOwnAddress('bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh'));
+    assert.ok(hd.weOwnAddress('bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc'));
+    assert.ok(hd.weOwnAddress('BC1QE7Q08PRC2SPLN2L7QDVVLCGQXM9ZA9Z7MJNPZC'));
+    assert.ok(hd.weOwnAddress('bc1qz28yun0lkkk2fk5ed2gdpnfra8970umtsd58gj'));
     assert.ok(!hd.weOwnAddress('1HjsSTnrwWzzEV2oi4r5MsAYENkTkrCtwL'));
     assert.ok(!hd.weOwnAddress('garbage'));
     assert.ok(!hd.weOwnAddress(false));
@@ -50,7 +50,7 @@ describe('Bech32 Segwit HD (BIP84)', () => {
     assert.ok(hd._lastBalanceFetch === 0);
 
     await hd.fetchBalance();
-    assert.strictEqual(hd.getBalance(), 200000);
+    assert.strictEqual(hd.getBalance(), 2400);
     assert.strictEqual(await hd.getAddressAsync(), hd._getExternalAddressByIndex(2));
     assert.strictEqual(await hd.getChangeAddressAsync(), hd._getInternalAddressByIndex(2));
     assert.strictEqual(hd.next_free_address_index, 2);
@@ -66,13 +66,13 @@ describe('Bech32 Segwit HD (BIP84)', () => {
 
     for (const tx of hd.getTransactions()) {
       assert.ok(tx.hash);
-      assert.strictEqual(tx.value, 50000);
+      assert.strictEqual(tx.value, 600);
       assert.ok(tx.timestamp);
       assert.ok(tx.confirmations > 1);
     }
 
-    assert.ok(hd.weOwnTransaction('5e2fa84148a7389537434b3ad12fcae71ed43ce5fb0f016a7f154a9b99a973df'));
-    assert.ok(hd.weOwnTransaction('ad00a92409d8982a1d7f877056dbed0c4337d2ebab70b30463e2802279fb936d'));
+    assert.ok(hd.weOwnTransaction('bf45480715b2500d9ad4ed3388dcfc6bc5c5bb7b3097e65e5f4d4503763f5647'));
+    assert.ok(hd.weOwnTransaction('0e505ed3a88a47b02c858e35f977db1c0e092dd29fa40ac5aec750373c0b306a'));
     assert.ok(!hd.weOwnTransaction('825c12f277d1f84911ac15ad1f41a3de28e9d906868a930b0a7bca61b17c8881'));
 
     // now fetch UTXO

--- a/tests/integration/lightning-ark-wallet.test.ts
+++ b/tests/integration/lightning-ark-wallet.test.ts
@@ -109,11 +109,11 @@ jest.setTimeout(30_000);
 const w = new LightningArkWallet();
 
 beforeAll(async () => {
-  if (!process.env.HD_MNEMONIC) {
-    console.error('process.env.HD_MNEMONIC not set, skipped');
+  if (!process.env.HD_MNEMONIC_OLD) {
+    console.error('process.env.HD_MNEMONIC_OLD not set, skipped');
     return;
   }
-  w.setSecret('arkade://' + process.env.HD_MNEMONIC);
+  w.setSecret('arkade://' + process.env.HD_MNEMONIC_OLD);
   await w.init();
 });
 
@@ -135,8 +135,8 @@ describe('LightningArkWallet', () => {
   });
 
   it('can fetch balance', async () => {
-    if (!process.env.HD_MNEMONIC) {
-      console.error('process.env.HD_MNEMONIC not set, skipped');
+    if (!process.env.HD_MNEMONIC_OLD) {
+      console.error('process.env.HD_MNEMONIC_OLD not set, skipped');
       return;
     }
 
@@ -174,8 +174,8 @@ describe('LightningArkWallet', () => {
 
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('can create invoice', async () => {
-    if (!process.env.HD_MNEMONIC) {
-      console.error('process.env.HD_MNEMONIC not set, skipped');
+    if (!process.env.HD_MNEMONIC_OLD) {
+      console.error('process.env.HD_MNEMONIC_OLD not set, skipped');
       return;
     }
 
@@ -184,8 +184,8 @@ describe('LightningArkWallet', () => {
   });
 
   it('can fetch txs', async () => {
-    if (!process.env.HD_MNEMONIC) {
-      console.error('process.env.HD_MNEMONIC not set, skipped');
+    if (!process.env.HD_MNEMONIC_OLD) {
+      console.error('process.env.HD_MNEMONIC_OLD not set, skipped');
       return;
     }
 
@@ -235,8 +235,8 @@ describe('LightningArkWallet', () => {
 
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('can pay invoice', async () => {
-    if (!process.env.HD_MNEMONIC) {
-      console.error('process.env.HD_MNEMONIC not set, skipped');
+    if (!process.env.HD_MNEMONIC_OLD) {
+      console.error('process.env.HD_MNEMONIC_OLD not set, skipped');
       return;
     }
 

--- a/tests/integration/watch-only-wallet.test.js
+++ b/tests/integration/watch-only-wallet.test.js
@@ -85,19 +85,19 @@ describe('Watch only wallet', () => {
 
   it('can fetch balance & transactions from zpub HD', async () => {
     const w = new WatchOnlyWallet();
-    w.setSecret('zpub6r7jhKKm7BAVx3b3nSnuadY1WnshZYkhK8gKFoRLwK9rF3Mzv28BrGcCGA3ugGtawi1WLb2vyjQAX9ZTDGU5gNk2bLdTc3iEXr6tzR1ipNP');
+    w.setSecret('zpub6rnbAtzupLPpSrsBKRsHupFvv1h6pwfRnZxX3qs6RL4LiLqKQ6kfBaDckn2apQWfyw1D2TdQMMDCfUDHMwtrcbGoy88xoKBLmADTFK9AhLe');
     await w.fetchBalance();
-    assert.strictEqual(w.getBalance(), 200000);
+    assert.strictEqual(w.getBalance(), 2400);
     await w.fetchTransactions();
     assert.strictEqual(w.getTransactions().length, 4);
     const nextAddress = await w.getAddressAsync();
 
     assert.strictEqual(w.getNextFreeAddressIndex(), 2);
-    assert.strictEqual(nextAddress, 'bc1q6442dedpwvqldldnsyux3cuz27paqks0pf2kvf');
+    assert.strictEqual(nextAddress, 'bc1q9v6mvgpehtmh0qc3y24mq6auwt8my4l68k9xyj');
     assert.strictEqual(nextAddress, w._getExternalAddressByIndex(w.getNextFreeAddressIndex()));
 
     const nextChangeAddress = await w.getChangeAddressAsync();
-    assert.strictEqual(nextChangeAddress, 'bc1qgltdyjnertcyvdn9hlkfpgr6hc260rjrss49uy');
+    assert.strictEqual(nextChangeAddress, 'bc1q74tz7eflqc62v8utqlazcs3tqtwmvvzud5dmrz');
   });
 
   // skipped because its generally rare case

--- a/tests/unit/cosign.test.ts
+++ b/tests/unit/cosign.test.ts
@@ -9,13 +9,13 @@ import { hexToUint8Array } from '../../blue_modules/uint8array-extras/index';
 
 describe('AbstractHDElectrumWallet.cosign', () => {
   it('different descendants of AbstractHDElectrumWallet can cosign one transaction', async () => {
-    if (!process.env.HD_MNEMONIC || !process.env.HD_MNEMONIC_BIP49) {
-      console.error('process.env.HD_MNEMONIC or HD_MNEMONIC_BIP49 not set, skipped');
+    if (!process.env.HD_MNEMONIC_OLD || !process.env.HD_MNEMONIC_BIP49) {
+      console.error('process.env.HD_MNEMONIC_OLD or HD_MNEMONIC_BIP49 not set, skipped');
       return;
     }
 
     const w1 = new HDLegacyP2PKHWallet();
-    w1.setSecret(process.env.HD_MNEMONIC);
+    w1.setSecret(process.env.HD_MNEMONIC_OLD);
     assert.ok(w1.validateMnemonic());
     const w1Utxo = [
       {
@@ -32,7 +32,7 @@ describe('AbstractHDElectrumWallet.cosign', () => {
     ];
 
     const w2 = new HDSegwitBech32Wallet();
-    w2.setSecret(process.env.HD_MNEMONIC);
+    w2.setSecret(process.env.HD_MNEMONIC_OLD);
     assert.ok(w2.validateMnemonic());
     const w2Utxo = [
       {
@@ -194,7 +194,7 @@ describe('AbstractHDElectrumWallet.cosign', () => {
 
   it('HDSegwitBech32Wallet can cosign psbt with correct fingerprint', async () => {
     if (!process.env.MNEMONICS_COBO) {
-      console.error('process.env.HD_MNEMONIC or HD_MNEMONIC_BIP49 not set, skipped');
+      console.error('process.env.HD_MNEMONIC_OLD or HD_MNEMONIC_BIP49 not set, skipped');
       return;
     }
 

--- a/tests/unit/hd-legacy-wallet.test.js
+++ b/tests/unit/hd-legacy-wallet.test.js
@@ -6,12 +6,12 @@ import { uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
 
 describe('Legacy HD (BIP44)', () => {
   it('works', async () => {
-    if (!process.env.HD_MNEMONIC) {
-      console.error('process.env.HD_MNEMONIC not set, skipped');
+    if (!process.env.HD_MNEMONIC_OLD) {
+      console.error('process.env.HD_MNEMONIC_OLD not set, skipped');
       return;
     }
     const hd = new HDLegacyP2PKHWallet();
-    hd.setSecret(process.env.HD_MNEMONIC);
+    hd.setSecret(process.env.HD_MNEMONIC_OLD);
     assert.ok(hd.validateMnemonic());
 
     assert.strictEqual(
@@ -42,12 +42,12 @@ describe('Legacy HD (BIP44)', () => {
   });
 
   it('can create TX', async () => {
-    if (!process.env.HD_MNEMONIC) {
-      console.error('process.env.HD_MNEMONIC not set, skipped');
+    if (!process.env.HD_MNEMONIC_OLD) {
+      console.error('process.env.HD_MNEMONIC_OLD not set, skipped');
       return;
     }
     const hd = new HDLegacyP2PKHWallet();
-    hd.setSecret(process.env.HD_MNEMONIC);
+    hd.setSecret(process.env.HD_MNEMONIC_OLD);
     assert.ok(hd.validateMnemonic());
 
     const utxo = [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Rotates compromised test seed across SelfTest and integration/unit suites and updates all dependent expectations.
> 
> - Switches to new `zpub` and bech32 addresses; updates expected balances (e.g., `2400`), txids/heights, and UTXOs
> - Refreshes BlueElectrum tests: new addresses in queries, adjusted balance sums, and UTXO assertions
> - Updates Bech32 HD wallet tests: expected addresses, `weOwn*` checks, tx values (`600`), and UTXO/counts
> - Watch-only wallet: replaces `zpub` and next external/change address expectations; balance now `2400`
> - LightningArkWallet: uses `HD_MNEMONIC_OLD` env var and updated secret initialization
> - Cosign and HD legacy tests: switch to `HD_MNEMONIC_OLD` where applicable
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df5f1dd9c11d25db0a02838851612bac603a74c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->