### PR TITLE
FIX: Enable New Architecture for Android

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -32,7 +32,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
-newArchEnabled=false
+newArchEnabled=true
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.


### PR DESCRIPTION
## Without this, the app crashes on startup (Android) with:
TurboModuleRegistry.getEnforcing(...): 'RateApp' could not be found.

react-native-rate-app@1.4.7 added in r8c60cc0ed requires TurboModules which only work with New Architecture enabled.