### PR TITLE
FIX: Show loading indicator during wallet discovery

### DIFF
--- a/screen/wallets/ImportWalletDiscovery.tsx
+++ b/screen/wallets/ImportWalletDiscovery.tsx
@@ -215,10 +215,26 @@ const ImportWalletDiscovery: React.FC = () => {
     [loading, progress],
   );
 
+  const ListFooterComponent = useMemo(
+    () => (
+      loading && wallets.length > 0 ? (
+        <View style={styles.noWallets}>
+          <BlueSpacing20 />
+          <ActivityIndicator />
+          <BlueSpacing10 />
+          <BlueFormLabel>{progress}</BlueFormLabel>
+          <BlueSpacing20 />
+        </View>
+      ) : null
+    ),
+    [loading, wallets.length, progress],
+  );
+
   return (
     <SafeArea style={[styles.root, stylesHook.root]}>
       <FlatList
         ListHeaderComponent={ListHeaderComponent}
+        ListFooterComponent={ListFooterComponent}
         contentContainerStyle={styles.flatListContainer}
         data={wallets}
         ListEmptyComponent={ListEmptyComponent}


### PR DESCRIPTION
Fixes: #8201

How it looks now: 
<tr>
<td><img width="180" src="https://github.com/user-attachments/assets/f528c4ad-22ce-4c68-891d-73d4237d1baf" /></td>
<td><img width="180" src="https://github.com/user-attachments/assets/7a98c076-c089-4c69-827b-26852aa15ed5" /></td>
<td><img width="180" src="https://github.com/user-attachments/assets/38cbc727-a741-4334-b744-a0e4f0b5f1c2" /></td>
</tr>