### PR TITLE
Adam sha256 feature show max sendable amount

### DIFF
--- a/components/AmountInput.tsx
+++ b/components/AmountInput.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Badge, Icon, Text } from '@rneui/themed';
+import Clipboard from '@react-native-clipboard/clipboard';
 import BigNumber from 'bignumber.js';
 import dayjs from 'dayjs';
 import {
@@ -24,6 +25,7 @@ import {
   satoshiToBTC,
   updateExchangeRate,
 } from '../blue_modules/currency';
+import triggerHapticFeedback, { HapticFeedbackTypes } from '../blue_modules/hapticFeedback';
 import { BlueText } from '../BlueComponents';
 import confirm from '../helpers/confirm';
 import loc, { formatBalancePlain, formatBalanceWithoutSuffix, removeTrailingZeros } from '../loc';
@@ -68,13 +70,31 @@ type AmountInputProps = Omit<TextInputProps, 'onChangeText' | 'value'> & {
    * Returns a BitcoinUnit value
    */
   onAmountUnitChange: (unit: BitcoinUnit) => void;
+  /**
+   * Estimated sendable amount in satoshis when MAX is selected.
+   * Displayed below the MAX label. Pass null to hide.
+   */
+  maxSendableAmount?: number | null;
+  /**
+   * When true, shows ≈ prefix for maxSendableAmount (indicates estimate).
+   */
+  isMaxAmountEstimate?: boolean;
 };
 
 export const AmountInput: React.FC<AmountInputProps> = props => {
   const textInputRef = useRef<TextInput>(null);
   const { colors } = useTheme();
   const amount = props.amount || '0'; // internally amount is aways a string with a correct number
-  const { onChangeText, unit, onAmountUnitChange, disabled = false, isLoading = false, ...otherProps } = props;
+  const {
+    onChangeText,
+    unit,
+    onAmountUnitChange,
+    disabled = false,
+    isLoading = false,
+    maxSendableAmount,
+    isMaxAmountEstimate,
+    ...otherProps
+  } = props;
   const [isRateBeingUpdatedLocal, setIsRateBeingUpdatedLocal] = useState(false);
   const [outdatedRefreshRate, setOutdatedRefreshRate] = useState<CurrencyRate | undefined>();
 
@@ -239,6 +259,13 @@ export const AmountInput: React.FC<AmountInputProps> = props => {
     }
   }, [onChangeText]);
 
+  const copyMaxEstimate = useCallback(() => {
+    if (maxSendableAmount == null) return;
+    const btcValue = removeTrailingZeros(new BigNumber(maxSendableAmount).dividedBy(100000000).toFixed(8));
+    Clipboard.setString(btcValue);
+    triggerHapticFeedback(HapticFeedbackTypes.Selection);
+  }, [maxSendableAmount]);
+
   const handleSelectionChange = useCallback(
     (event: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => {
       const { selection } = event.nativeEvent;
@@ -281,8 +308,16 @@ export const AmountInput: React.FC<AmountInputProps> = props => {
                 {...otherProps}
               />
             ) : (
-              <Pressable onPress={resetAmount}>
+              <Pressable onPress={resetAmount} style={styles.maxPressable}>
                 <Text style={[styles.input, stylesHook.input]}>{BitcoinUnit.MAX}</Text>
+                {maxSendableAmount != null && (
+                  <Text style={[styles.maxEstimate, stylesHook.localCurrency]} onLongPress={copyMaxEstimate}>
+                    {(isMaxAmountEstimate ? '≈ ' : '') +
+                      removeTrailingZeros(new BigNumber(maxSendableAmount).dividedBy(100000000).toFixed(8)) +
+                      ' ' +
+                      loc.units[BitcoinUnit.BTC]}
+                  </Text>
+                )}
               </Pressable>
             )}
             {unit !== BitcoinUnit.LOCAL_CURRENCY && amount !== BitcoinUnit.MAX && (
@@ -386,6 +421,14 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: '#9BA0A9',
     fontWeight: '600',
+  },
+  maxEstimate: {
+    fontSize: 16,
+    textAlign: 'center',
+    marginTop: 4,
+  },
+  maxPressable: {
+    alignItems: 'center',
   },
   changeAmountUnit: {
     alignSelf: 'center',

--- a/screen/send/SendDetails.tsx
+++ b/screen/send/SendDetails.tsx
@@ -110,7 +110,8 @@ const SendDetails = () => {
   // if utxo is limited we use it to calculate available balance
   const balance: number = utxos ? utxos.reduce((prev, curr) => prev + curr.value, 0) : (wallet?.getBalance() ?? 0);
   const allBalance = formatBalanceWithoutSuffix(balance, BitcoinUnit.BTC, true);
-
+  // estimated sendable amount when MAX is selected (null if not applicable)
+  const [maxSendableAmount, setMaxSendableAmount] = useState<number | null>(null);
   // if cutomFee is not set, we need to choose highest possible fee for wallet balance
   // if there are no funds for even Slow option, use 1 sat/vbyte fee
   const feeRate = useMemo(() => {
@@ -316,8 +317,12 @@ const SendDetails = () => {
     let targets = [];
     for (const transaction of addresses) {
       if (transaction.amount === BitcoinUnit.MAX) {
-        // single output with MAX
-        targets = [{ address: transaction.address }];
+        // single output with MAX — use P2TR dummy (43-byte output) for conservative estimate
+        const addr =
+          transaction.address && wallet.isAddressValid(transaction.address)
+            ? transaction.address
+            : 'bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0';
+        targets = [{ address: addr }];
         break;
       }
       const value = transaction.amountSats;
@@ -364,6 +369,15 @@ const SendDetails = () => {
     }
 
     setFeePrecalc(newFeePrecalc);
+
+    // Calculate maxSendableAmount (only for single recipient with MAX)
+    if (addresses.length === 1 && addresses[0].amount === BitcoinUnit.MAX && newFeePrecalc.current !== null) {
+      const sendable = balance - newFeePrecalc.current;
+      setMaxSendableAmount(sendable > 0 ? sendable : null);
+    } else {
+      setMaxSendableAmount(null);
+    }
+
     setParams({ frozenBalance: frozen });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [wallet, networkTransactionFees, utxos, addresses, feeRate, dumb]);
@@ -586,7 +600,12 @@ const SendDetails = () => {
     for (const transaction of addresses) {
       if (transaction.amount === BitcoinUnit.MAX) {
         // output with MAX
-        targets.push({ address: transaction.address });
+        if (maxSendableAmount != null && addresses.length === 1) {
+          // Force the exact displayed amount — remainder goes to fee
+          targets.push({ address: transaction.address, value: maxSendableAmount });
+        } else {
+          targets.push({ address: transaction.address });
+        }
         continue;
       }
       const value = parseInt(String(transaction.amountSats), 10);
@@ -1399,6 +1418,8 @@ const SendDetails = () => {
             editable={isEditable}
             disabled={!isEditable}
             inputAccessoryViewID={InputAccessoryAllFundsAccessoryViewID}
+            maxSendableAmount={index === scrollIndex.current ? maxSendableAmount : null}
+            isMaxAmountEstimate={!(item.address && wallet?.isAddressValid(item.address))}
           />
         </View>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches fee/coin selection inputs for `MAX` sends and changes how transaction targets are constructed, which could affect final sent amount/fee behavior if estimates diverge from actual coin selection.
> 
> **Overview**
> When an amount is set to `MAX`, the UI now optionally displays a computed *max sendable* BTC value beneath the `MAX` label, with long-press copy-to-clipboard plus haptic feedback.
> 
> `SendDetails` now calculates this `maxSendableAmount` (balance minus current fee estimate) for single-recipient `MAX` sends, uses a conservative P2TR dummy output when the recipient address is missing/invalid to estimate fees, and (when available) forces the transaction target value to match the displayed max amount so any remainder is absorbed by the fee.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9313830f0a41343cc808b22dcc0e0dfb00aa9dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->