### PR TITLE
ADD: native ark-to-ark transfers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.2.16",
-        "@arkade-os/sdk": "0.3.10",
+        "@arkade-os/boltz-swap": "0.2.19",
+        "@arkade-os/sdk": "0.3.12",
         "@babel/preset-env": "7.27.2",
         "@bugsnag/react-native": "8.4.0",
         "@bugsnag/source-maps": "2.3.3",
@@ -176,12 +176,12 @@
       }
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.16.tgz",
-      "integrity": "sha512-42vIGlDCvJry1UOifi8jKxfcD3jBjf5Ldfwjs+bz5jfjUZGflCBS2cqZxujtB3vlbANTNUIwP9qI0maE2cFV2A==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.2.19.tgz",
+      "integrity": "sha512-oEgAUye/yrt/EylT7jQ+lXT7of0IUpJe8NxoNHE48/llHtlkWsI65AsHr1xbElO8oCn3zM41l/eHRZBe5z2GMg==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.3.10",
+        "@arkade-os/sdk": "0.3.12",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",
         "@scure/btc-signer": "2.0.1",
@@ -205,12 +205,13 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.10.tgz",
-      "integrity": "sha512-3O/ftt5h9equtbMuzBmWEbw2M8AeDrokoLSMQDvoQF4Lz9y8A0azZyVZjLZJlvNhQFL2ZVH+Y8urSI8YoHpJWg==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.3.12.tgz",
+      "integrity": "sha512-/zE8XiDo6yOCaspMcO3Gua/gLGYmYLRFbqaD1ORkaGI7hH/Gq+m0tkIwArVlwtK50loHK4jvS8clovcaV9CARg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@marcbachmann/cel-js": "7.0.0",
         "@noble/curves": "2.0.0",
         "@noble/secp256k1": "3.0.0",
         "@scure/base": "2.0.0",
@@ -3670,6 +3671,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/@marcbachmann/cel-js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@marcbachmann/cel-js/-/cel-js-7.0.0.tgz",
+      "integrity": "sha512-sbtR8pvTAsDPiyigebwLyqweLnocmBS9MG5tTnVUL2PZ9Hc2Dj2e4tnvTcZ1s463Og9NKD59TaPvTK9CEZQhiQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@ngraveio/bc-ur": {

--- a/package.json
+++ b/package.json
@@ -83,8 +83,8 @@
     "unit": "jest -b -w tests/unit/*"
   },
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.2.16",
-    "@arkade-os/sdk": "0.3.10",
+    "@arkade-os/boltz-swap": "0.2.19",
+    "@arkade-os/sdk": "0.3.12",
     "@babel/preset-env": "7.27.2",
     "@bugsnag/react-native": "8.4.0",
     "@bugsnag/source-maps": "2.3.3",

--- a/screen/lnd/ScanLNDInvoice.tsx
+++ b/screen/lnd/ScanLNDInvoice.tsx
@@ -26,6 +26,7 @@ import { LightningCustodianWallet } from '../../class/wallets/lightning-custodia
 import { DecodedInvoice, TWallet } from '../../class/wallets/types';
 import { useKeyboard } from '../../hooks/useKeyboard';
 import { BlueLoading } from '../../components/BlueLoading';
+import { LightningArkWallet } from '../../class';
 
 type RouteProps = RouteProp<LNDStackParamsList, 'ScanLNDInvoice'>;
 type NavigationProps = NativeStackNavigationProp<LNDStackParamsList, 'ScanLNDInvoice'>;
@@ -110,6 +111,19 @@ const ScanLNDInvoice = () => {
 
       data = data.replace('LIGHTNING:', '').replace('lightning:', '');
       console.log(data);
+
+      if (data.toLowerCase().startsWith('ark1')) {
+        const arkw = new LightningArkWallet();
+        if (arkw.isAddressValid(data)) {
+          setParams({ uri: undefined, invoice: data });
+          // @ts-ignore we need it to be set to something
+          setDecoded({});
+          setIsAmountInitiallyEmpty(true);
+          setDestination(data);
+          setIsLoading(false);
+          return;
+        }
+      }
 
       let newDecoded: DecodedInvoice;
       try {
@@ -233,6 +247,7 @@ const ScanLNDInvoice = () => {
     if (
       (text && text.toLowerCase().startsWith('lnb')) ||
       text.toLowerCase().startsWith('lightning:lnb') ||
+      text.toLowerCase().startsWith('ark1') ||
       Lnurl.isLnurl(text) ||
       Lnurl.isLightningAddress(text)
     ) {

--- a/tests/integration/lightning-ark-wallet.test.ts
+++ b/tests/integration/lightning-ark-wallet.test.ts
@@ -244,4 +244,33 @@ describe('LightningArkWallet', () => {
       'lnbc80u1p5052hwpp5z4ln6hyq4wcck809pt7f0q54ag5he6ce797flm7gl9vuccm9lx2sdqqcqzysxqyz5vqsp5nh9fl4g36606tvxswtnfxzy55yze2656cw2fya7dhl8r6u0czyds9qxpqysgq83sw25g9d9ltr05nkfzejnvvunzkrk4qeuxhszuvvsguk5m6vmg3a7n5nd67l9frru3kjzpt8x6jfusjyc7ezh49jeeh900kt3v30qsqzq7fst',
     );
   });
+
+  it('can validate ark native address', async () => {
+    assert.ok(
+      w.isAddressValid(
+        'ark1qq4hfssprtcgnjzf8qlw2f78yvjau5kldfugg29k34y7j96q2w4t5z8sz5n95k570z5r004szc9h2q3qprkzdd5zveujdpx24srcrqg8hf6j4v',
+      ),
+    );
+    assert.ok(
+      w.isAddressValid(
+        'ark1qqellv77udfmr20tun8dvju5vgudpf9vxe8jwhthrkn26fz96pawqfdy8nk05rsmrf8h94j26905e7n6sng8y059z8ykn2j5xcuw4xt8ngt9rw',
+      ),
+    );
+
+    assert.ok(
+      !w.isAddressValid(
+        'ark1qqellv77udfmr20tun8dvju5vgudpf9vxe8jwhthrkn26fz96pawqfdy8nk05rsmrf8h94j26905e7n6sng8y059z8ykn2j5xcuw4xt8ngt9r',
+      ),
+    );
+    assert.ok(
+      !w.isAddressValid('ark1qqellv77udfmr20tun8dvju5vgudpf9vxe8jwhthrkn26fz96pawqfdy8nk05rsmrf8h94j26905e7n6sng8y059z8ykn2j5xcuw4xt8ngt9'),
+    );
+    assert.ok(
+      w.isAddressValid(
+        'ark1qq4hfssprtcgnjzf8qlw2f78yvjau5kldfugg29k34y7j96q2w4t4sedhdvfcgaky2qk2p55wj4ut38v9tnpuvjr8ee8hv6htp23pzjpwx5esw',
+      ),
+    );
+    assert.ok(!w.isAddressValid('ark1sfhshhehehwer'));
+    assert.ok(!w.isAddressValid('test'));
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes payment routing to conditionally perform on-chain-like Ark sends instead of Lightning payments and updates SDK/boarding behavior, which could affect send correctness and fee handling.
> 
> **Overview**
> Enables *native Ark-to-Ark transfers* by detecting valid `ark1...` addresses: `LightningArkWallet.payInvoice` now validates Ark bech32m addresses and, when present, sends via `wallet.sendBitcoin` instead of attempting Lightning invoice decoding/payment.
> 
> Updates the send flow UI (`ScanLNDInvoice`) to accept/recognize `ark1...` inputs and bypass Lightning invoice decoding when an Ark address is scanned/entered.
> 
> Adjusts Ark boarding to pass fee info into `Ramps.onboard(...)`, adds integration tests for Ark address validation, and bumps `@arkade-os/sdk`/`@arkade-os/boltz-swap` dependencies (including new transitive `@marcbachmann/cel-js`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 020d19ffa0ddf2b99b08a44a12788a183af911dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->