### PR TITLE
FIX: multisig cosigner edit

### DIFF
--- a/screen/wallets/ViewEditMultisigCosigners.tsx
+++ b/screen/wallets/ViewEditMultisigCosigners.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { RouteProp, useFocusEffect, useRoute, usePreventRemove, StackActions } from '@react-navigation/native';
+import { RouteProp, useFocusEffect, useRoute, usePreventRemove } from '@react-navigation/native';
 import {
   ActivityIndicator,
   Alert,
@@ -58,7 +58,7 @@ const ViewEditMultisigCosigners: React.FC = () => {
   const { isBiometricUseCapableAndEnabled } = useBiometrics();
   const { isElectrumDisabled, isPrivacyBlurEnabled } = useSettings();
   const { enableScreenProtect, disableScreenProtect } = useScreenProtect();
-  const { dispatch, setParams, setOptions } = useExtendedNavigation<NavigationProp>();
+  const { dispatch, setParams, setOptions, navigateToWalletsList } = useExtendedNavigation<NavigationProp>();
   const route = useRoute<RouteParams>();
   const { walletID } = route.params;
   const w = useRef(wallets.find(wallet => wallet.getID() === walletID));
@@ -172,11 +172,7 @@ const ViewEditMultisigCosigners: React.FC = () => {
       setIsSaveButtonDisabled(true);
       setWalletsWithNewOrder(newWallets);
       setTimeout(() => {
-        const popTo = StackActions.popTo('WalletTransactions', {
-          walletID,
-          walletType: wallet.type,
-        });
-        dispatch(popTo);
+        navigateToWalletsList();
       }, 500);
     }, 100);
   };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small navigation behavior change after saving multisig cosigner edits; low risk aside from potential UX regression if the reset-to-list flow is unintended.
> 
> **Overview**
> Fixes the post-save navigation for multisig cosigner edits by replacing the `StackActions.popTo('WalletTransactions', ...)` dispatch with `navigateToWalletsList()` (a navigation reset to `WalletsList`).
> 
> Also removes the now-unused `StackActions` import and wires `navigateToWalletsList` through `useExtendedNavigation` on `ViewEditMultisigCosigners`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c86b38025d698c45aa4291e6dc7c662bc43e963. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->