### PR TITLE
Support import watch-only from Unchained (#8251)

### DIFF
--- a/class/wallets/abstract-wallet.ts
+++ b/class/wallets/abstract-wallet.ts
@@ -339,6 +339,23 @@ export class AbstractWallet {
         if (parsedSecret.CoboVaultFirmwareVersion) this.use_with_hardware_wallet = true;
         return this;
       }
+      // It is an Unchained Capital JSON
+      if (parsedSecret && parsedSecret.xfp && (parsedSecret.p2wsh || parsedSecret.p2sh_p2wsh || parsedSecret.p2sh)) {
+        if (parsedSecret.p2wsh) {
+          this.secret = parsedSecret.p2wsh;
+          this._derivationPath = parsedSecret.p2wsh_deriv;
+        } else if (parsedSecret.p2sh_p2wsh) {
+          this.secret = parsedSecret.p2sh_p2wsh;
+          this._derivationPath = parsedSecret.p2sh_p2wsh_deriv;
+        } else {
+          this.secret = parsedSecret.p2sh;
+          this._derivationPath = parsedSecret.p2sh_deriv;
+        }
+
+        this.masterFingerprint = this.getMasterFingerprintFromHex(parsedSecret.xfp);
+        this._derivationPath = this._derivationPath?.replace(/h/g, "'");
+        return this;
+      }
     } catch (_) {}
 
     if (!this._derivationPath) {

--- a/tests/unit/watch-only-wallet.test.js
+++ b/tests/unit/watch-only-wallet.test.js
@@ -205,6 +205,21 @@ describe('Watch only wallet', () => {
     assert.ok(w.useWithHardwareWalletEnabled());
   });
 
+  it('can import Unchained Capital json', async () => {
+    const w = new WatchOnlyWallet();
+    w.setSecret(
+      '{"p2sh": "xpub6CQdfC3v9gU86eaSn7AhUFcBVxiGhdtYxdC5Cw2vLmFkfth2KXCMmYcPpvZviA89X6DXDs4PJDk5QVL2G2xaVjv7SM4roWHr1gR4xB3Z7Ps", "p2sh_deriv": "m/45h/0h/0h", "p2sh_p2wsh": "ypub6XRzrn3HB1tjhhvrHbk1vnXCecZEdXohGzCk3GXwwbDoJ3VBzZ34jNGWbC6WrS7idXrYjjXEzcPDX5VqnHEnuNf5VAXgLfSaytMkJ2rwVqy", "p2sh_p2wsh_deriv": "m/48h/0h/0h/1h", "p2wsh": "zpub6r7jhKKm7BAVx3b3nSnuadY1WnshZYkhK8gKFoRLwK9rF3Mzv28BrGcCGA3ugGtawi1WLb2vyjQAX9ZTDGU5gNk2bLdTc3iEXr6tzR1ipNP", "p2wsh_deriv": "m/48h/0h/0h/2h", "xfp": "73C5DA0A"}',
+    );
+    w.init();
+    assert.ok(w.valid());
+    assert.strictEqual(
+      w.getSecret(),
+      'zpub6r7jhKKm7BAVx3b3nSnuadY1WnshZYkhK8gKFoRLwK9rF3Mzv28BrGcCGA3ugGtawi1WLb2vyjQAX9ZTDGU5gNk2bLdTc3iEXr6tzR1ipNP',
+    );
+    assert.strictEqual(w.getMasterFingerprintHex(), '73c5da0a');
+    assert.strictEqual(w.getDerivationPath(), "m/48'/0'/0'/2'");
+  });
+
   it('can import Electrum compatible backup wallet, and create a tx with master fingerprint', async () => {
     const w = new WatchOnlyWallet();
     w.setSecret(require('fs').readFileSync('./tests/unit/fixtures/skeleton-electrum.txt', 'ascii'));


### PR DESCRIPTION
This PR adds support for importing watch-only wallets from Unchained Capital JSON exports. It includes parsing logic in AbstractWallet and a new unit test case.