### PR TITLE
Fix syntax error: cannot convert string/decimal to bigint (#8268)

### DIFF
--- a/class/wallets/abstract-hd-electrum-wallet.ts
+++ b/class/wallets/abstract-hd-electrum-wallet.ts
@@ -1283,27 +1283,27 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
         address: output.address,
         // @ts-ignore types from bitcoinjs are not exported so we cant define outputData separately and add fields conditionally (either address or script should be present)
         script: output.script?.hex ? hexToUint8Array(output.script.hex) : undefined,
-        value: BigInt(output.value),
+        value: BigInt(Math.round(Number(output.value))),
         bip32Derivation:
           change && path && pubkey && this.segwitType !== 'p2tr'
             ? [
-                {
-                  masterFingerprint: masterFingerprintBuffer,
-                  path,
-                  pubkey,
-                },
-              ]
+              {
+                masterFingerprint: masterFingerprintBuffer,
+                path,
+                pubkey,
+              },
+            ]
             : [],
         tapBip32Derivation:
           this.segwitType === 'p2tr' && pubkey && path && change
             ? [
-                {
-                  pubkey: new Uint8Array(pubkey),
-                  masterFingerprint: new Uint8Array(masterFingerprintBuffer),
-                  path,
-                  leafHashes: [],
-                },
-              ]
+              {
+                pubkey: new Uint8Array(pubkey),
+                masterFingerprint: new Uint8Array(masterFingerprintBuffer),
+                path,
+                leafHashes: [],
+              },
+            ]
             : [],
         ...(this.segwitType === 'p2tr' && pubkey ? { tapInternalKey: new Uint8Array(pubkey) } : {}),
       });
@@ -1358,7 +1358,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
       ],
       witnessUtxo: {
         script: p2wpkh.output,
-        value: BigInt(input.value),
+        value: BigInt(Math.round(Number(input.value))),
       },
     });
 
@@ -1533,7 +1533,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     for (let cc = 0; cc < psbt.inputCount; cc++) {
       try {
         psbt.signInputHD(cc, hdRoot);
-      } catch (e) {} // protects agains duplicate cosignings
+      } catch (e) { } // protects agains duplicate cosignings
 
       if (!psbt.inputHasHDKey(cc, hdRoot)) {
         for (const derivation of psbt.data.inputs[cc].bip32Derivation || []) {
@@ -1547,7 +1547,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
           const keyPair = ECPair.fromWIF(wif);
           try {
             psbt.signInput(cc, keyPair);
-          } catch (e) {} // protects agains duplicate cosignings or if this output can't be signed with current wallet
+          } catch (e) { } // protects agains duplicate cosignings or if this output can't be signed with current wallet
         }
       }
     }

--- a/class/wallets/hd-segwit-p2sh-wallet.ts
+++ b/class/wallets/hd-segwit-p2sh-wallet.ts
@@ -107,7 +107,7 @@ export class HDSegwitP2SHWallet extends AbstractHDElectrumWallet {
       ],
       witnessUtxo: {
         script: p2sh.output,
-        value: BigInt(input.value),
+        value: BigInt(Math.round(Number(input.value))),
       },
       redeemScript: p2wpkh.output,
     });

--- a/class/wallets/hd-taproot-wallet.ts
+++ b/class/wallets/hd-taproot-wallet.ts
@@ -113,7 +113,7 @@ export class HDTaprootWallet extends AbstractHDElectrumWallet {
       sequence,
       witnessUtxo: {
         script: p2tr.output!,
-        value: BigInt(input.value),
+        value: BigInt(Math.round(Number(input.value))),
       },
       tapBip32Derivation: [
         {

--- a/class/wallets/legacy-wallet.ts
+++ b/class/wallets/legacy-wallet.ts
@@ -482,7 +482,7 @@ export class LegacyWallet extends AbstractWallet {
     sanitizedOutputs.forEach(output => {
       const outputData = {
         address: output.address,
-        value: BigInt(output.value),
+        value: BigInt(Math.round(Number(output.value))),
       };
 
       psbt.addOutput(outputData);

--- a/class/wallets/multisig-hd-wallet.ts
+++ b/class/wallets/multisig-hd-wallet.ts
@@ -37,18 +37,18 @@ type TBip32Derivation = {
 
 type TOutputData =
   | {
-      bip32Derivation: TBip32Derivation;
-      redeemScript: Uint8Array;
-    }
+    bip32Derivation: TBip32Derivation;
+    redeemScript: Uint8Array;
+  }
   | {
-      bip32Derivation: TBip32Derivation;
-      witnessScript: Uint8Array;
-    }
+    bip32Derivation: TBip32Derivation;
+    witnessScript: Uint8Array;
+  }
   | {
-      bip32Derivation: TBip32Derivation;
-      redeemScript: Uint8Array;
-      witnessScript: Uint8Array;
-    };
+    bip32Derivation: TBip32Derivation;
+    redeemScript: Uint8Array;
+    witnessScript: Uint8Array;
+  };
 
 const electrumSegwit = (passphrase?: string): SeedOpts => ({
   prefix: mn.PREFIXES.segwit,
@@ -185,7 +185,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
       xpub = tempWallet._zpubToXpub(key);
       bip32.fromBase58(xpub);
       return true;
-    } catch (_) {}
+    } catch (_) { }
 
     return false;
   }
@@ -530,7 +530,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
     let json;
     try {
       json = JSON.parse(secret);
-    } catch (_) {}
+    } catch (_) { }
     if (json && json.xfp && json.p2wsh_deriv && json.p2wsh) {
       this.addCosigner(json.p2wsh, json.xfp); // technically we dont need deriv (json.p2wsh_deriv), since cosigner is already an xpub
       return this;
@@ -789,7 +789,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
         bip32Derivation,
         witnessUtxo: {
           script: p2wsh.output,
-          value: BigInt(input.value),
+          value: BigInt(Math.round(Number(input.value))),
         },
         witnessScript,
         // hw wallets now require passing the whole previous tx as Buffer, as if it was non-segwit input, to mitigate
@@ -816,7 +816,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
         bip32Derivation,
         witnessUtxo: {
           script: p2shP2wsh.output,
-          value: BigInt(input.value),
+          value: BigInt(Math.round(Number(input.value))),
         },
         witnessScript,
         redeemScript,
@@ -1003,7 +1003,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
 
       let outputData: Parameters<typeof psbt.addOutput>[0] = {
         address,
-        value: BigInt(output.value),
+        value: BigInt(Math.round(Number(output.value))),
       };
 
       if (change) {
@@ -1078,7 +1078,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
     try {
       root.derivePath(path);
       return true;
-    } catch (_) {}
+    } catch (_) { }
     return false;
   }
 
@@ -1182,7 +1182,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
 
         try {
           psbt.signInputHD(cc, hdRoot);
-        } catch (_) {} // protects agains duplicate cosignings
+        } catch (_) { } // protects agains duplicate cosignings
 
         if (!psbt.inputHasHDKey(cc, hdRoot)) {
           // failed signing as HD. probably bitcoinjs-lib could not match provided hdRoot's
@@ -1209,7 +1209,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
               const keyPair = ECPair.fromPrivateKey(child.privateKey);
               try {
                 psbt.signInput(cc, keyPair);
-              } catch (_) {}
+              } catch (_) { }
             }
           }
         }

--- a/class/wallets/segwit-bech32-wallet.ts
+++ b/class/wallets/segwit-bech32-wallet.ts
@@ -105,7 +105,7 @@ export class SegwitBech32Wallet extends LegacyWallet {
         sequence,
         witnessUtxo: {
           script: p2wpkh.output,
-          value: BigInt(input.value),
+          value: BigInt(Math.round(Number(input.value))),
         },
       });
     });
@@ -118,7 +118,7 @@ export class SegwitBech32Wallet extends LegacyWallet {
 
       const outputData = {
         address: output.address,
-        value: BigInt(output.value),
+        value: BigInt(Math.round(Number(output.value))),
       };
 
       psbt.addOutput(outputData);

--- a/class/wallets/taproot-wallet.ts
+++ b/class/wallets/taproot-wallet.ts
@@ -105,7 +105,7 @@ export class TaprootWallet extends SegwitBech32Wallet {
         sequence,
         witnessUtxo: {
           script: p2tr.output!,
-          value: BigInt(input.value),
+          value: BigInt(Math.round(Number(input.value))),
         },
         // tell PSBT it’s a key-path Taproot spend
         tapInternalKey: xOnlyPub,
@@ -118,7 +118,7 @@ export class TaprootWallet extends SegwitBech32Wallet {
       if (!output.address) output.address = changeAddress;
       psbt.addOutput({
         address: output.address!,
-        value: BigInt(output.value),
+        value: BigInt(Math.round(Number(output.value))),
       });
     });
 


### PR DESCRIPTION
This PR fixes a syntax error in self-tests and transaction creation where non-integer strings or decimals were passed to BigInt(). It implements a safe conversion using Math.round(Number(value)) across all wallet classes.