### PR TITLE
FIX: rate app button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,6 @@
         "react-native-push-notification": "8.1.1",
         "react-native-qrcode-svg": "6.3.21",
         "react-native-quick-actions": "0.3.13",
-        "react-native-rate-app": "github:BlueWallet/react-native-rate-app#160a0b8",
         "react-native-reanimated": "3.18.0",
         "react-native-safe-area-context": "5.5.2",
         "react-native-screens": "4.17.0",
@@ -16511,23 +16510,6 @@
     "node_modules/react-native-quick-actions": {
       "version": "0.3.13",
       "license": "MIT"
-    },
-    "node_modules/react-native-rate-app": {
-      "version": "1.4.7",
-      "resolved": "git+ssh://git@github.com/BlueWallet/react-native-rate-app.git#160a0b85aabba972bdd3a9c0b65c10b4c16b52af",
-      "license": "MIT",
-      "workspaces": [
-        "example"
-      ],
-      "peerDependencies": {
-        "react": "*",
-        "react-native": ">=0.76"
-      },
-      "peerDependenciesMeta": {
-        "expo": {
-          "optional": true
-        }
-      }
     },
     "node_modules/react-native-ratings": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,6 @@
     "react-native-push-notification": "8.1.1",
     "react-native-qrcode-svg": "6.3.21",
     "react-native-quick-actions": "0.3.13",
-    "react-native-rate-app": "github:BlueWallet/react-native-rate-app#160a0b8",
     "react-native-reanimated": "3.18.0",
     "react-native-safe-area-context": "5.5.2",
     "react-native-screens": "4.17.0",

--- a/screen/settings/About.tsx
+++ b/screen/settings/About.tsx
@@ -1,8 +1,7 @@
 import Clipboard from '@react-native-clipboard/clipboard';
 import React, { useCallback } from 'react';
-import { Alert, Image, Linking, Platform, StyleSheet, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
+import { Alert, Image, Linking, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { getApplicationName, getBuildNumber, getBundleId, getUniqueIdSync, getVersion, hasGmsSync } from 'react-native-device-info';
-import RateApp, { AndroidMarket } from 'react-native-rate-app';
 import Icon from 'react-native-vector-icons/FontAwesome5';
 
 import A from '../../blue_modules/analytics';
@@ -34,7 +33,6 @@ interface AboutItem extends SettingsListItemProps {
 
 const About: React.FC = () => {
   const { navigate } = useExtendedNavigation();
-  const { width, height } = useWindowDimensions();
   const { isElectrumDisabled } = useSettings();
   const { colors } = useTheme();
 
@@ -67,23 +65,14 @@ const About: React.FC = () => {
   }, []);
 
   const handleOnRatePress = useCallback(async () => {
-    const storeOptions = {
-      iOSAppId: '1376878040',
-      androidPackageName: 'io.bluewallet.bluewallet',
-      androidMarket: AndroidMarket.GOOGLE,
-    };
-
     try {
-      const inAppSuccess = await RateApp.requestReview({ androidMarket: AndroidMarket.GOOGLE });
-      if (!inAppSuccess) {
-        await RateApp.openStoreForReview(storeOptions);
+      if (Platform.OS === 'ios') {
+        await Linking.openURL('https://itunes.apple.com/app/bluewallet-bitcoin-wallet/id1376878040');
+      } else {
+        await Linking.openURL('https://play.google.com/store/apps/details?id=io.bluewallet.bluewallet');
       }
-    } catch (error) {
-      try {
-        await RateApp.openStoreForReview(storeOptions);
-      } catch (openError) {
-        console.error('Rate app failed.', openError);
-      }
+    } catch (error: any) {
+      console.error('Rate app failed:', error.message);
     }
   }, []);
 
@@ -94,7 +83,7 @@ const About: React.FC = () => {
 
     const start = Date.now();
     let num;
-    for (num = 0; num < 1000; num++) {
+    for (num = 0; num < 10000; num++) {
       w._getExternalAddressByIndex(num);
       if (Date.now() - start > 10 * 1000) {
         break;
@@ -160,7 +149,6 @@ const About: React.FC = () => {
               <BlueSpacing20 />
               <BlueTextCentered>React Native</BlueTextCentered>
               <BlueTextCentered>bitcoinjs-lib</BlueTextCentered>
-              <BlueTextCentered>Nodejs</BlueTextCentered>
               <BlueTextCentered>Electrum server</BlueTextCentered>
             </SettingsCard>
           </SettingsSection>
@@ -219,9 +207,6 @@ const About: React.FC = () => {
               {new Date(Number(getBuildNumber()) * 1000).toUTCString()}
             </Text>
             <Text style={[styles.footerText, { color: colors.alternativeTextColor }]}>{getBundleId()}</Text>
-            <Text style={[styles.footerText, { color: colors.alternativeTextColor }]}>
-              w, h = {width}, {height}
-            </Text>
             <Text style={[styles.footerText, { color: colors.alternativeTextColor }]}>Unique ID: {getUniqueIdSync()}</Text>
             <View style={styles.copyToClipboard}>
               <TouchableOpacity
@@ -253,8 +238,6 @@ const About: React.FC = () => {
     handleOnLicensingPress,
     handleOnSelfTestPress,
     handlePerformanceTest,
-    width,
-    height,
   ]);
 
   const renderItem = useCallback(


### PR DESCRIPTION
* droping a dependency to just rate the app (opening appstore  url directly should suffice)
* minor cleaup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated settings-screen behavior change plus a dependency removal; main risk is the review-link flow relying on external URLs and the performance test doing more work when manually triggered.
> 
> **Overview**
> The About screen’s **“Review”** action now bypasses `react-native-rate-app` and directly opens the App Store / Google Play URLs via `Linking`, simplifying the flow and error handling.
> 
> This PR also drops the `react-native-rate-app` dependency from `package.json`/`package-lock.json`, removes About-screen debug UI (window dimensions) and a “Built with” entry, and increases the manual performance test loop from `1000` to `10000` iterations (still capped by the 10s timeout).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9213491a0f79b38ab2640ead2e198b621578d6be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->