### PR TITLE
Implement support for testnet4 and signet

### DIFF
--- a/blue_modules/BlueElectrum.ts
+++ b/blue_modules/BlueElectrum.ts
@@ -13,6 +13,7 @@ import { ElectrumServerItem } from '../screen/settings/ElectrumSettings';
 import { triggerWarningHapticFeedback } from './hapticFeedback';
 import { AlertButton } from 'react-native';
 import { uint8ArrayToHex, stringToUint8Array, hexToUint8Array } from './uint8array-extras/index';
+import { getNetwork, NetworkType } from '../models/network';
 
 const ElectrumClient = require('electrum-client');
 const net = require('net');
@@ -84,6 +85,7 @@ export const ELECTRUM_SERVER_HISTORY = 'electrum_server_history';
 const ELECTRUM_CONNECTION_DISABLED = 'electrum_disabled';
 const storageKey = 'ELECTRUM_PEERS';
 const defaultPeer = { host: 'electrum1.bluewallet.io', ssl: 443 };
+
 export const hardcodedPeers: Peer[] = [
   { host: 'mainnet.foundationdevices.com', ssl: 50002 },
   { host: 'bitcoin.lu.ke', ssl: 50002 },
@@ -92,9 +94,36 @@ export const hardcodedPeers: Peer[] = [
   { host: 'electrum.acinq.co', ssl: 50002 },
 ];
 
+function getHardcodedPeersForNetwork(network: NetworkType): Peer[] {
+  switch (network) {
+    case 'testnet':
+      return [
+        { host: 'testnet4-electrumx.wakiyamap.dev', ssl: 51002 },
+        { host: 'mempool.space', ssl: 40002 },
+      ];
+    case 'signet':
+      return [
+        { host: 'signet-electrumx.wakiyamap.dev', ssl: 50002 },
+        { host: 'electrum.emzy.de', ssl: 53002 },
+        { host: 'mempool.space', ssl: 60602 },
+      ];
+    case 'mainnet':
+    default:
+      return hardcodedPeers;
+  }
+}
+
 export const suggestedServers: Peer[] = hardcodedPeers.map(peer => ({
   ...peer,
 }));
+
+export function getHardcodedPeersForCurrentNetwork(): Peer[] {
+  return getHardcodedPeersForNetwork(currentNetwork);
+}
+
+export function getSuggestedServersForCurrentNetwork(): Peer[] {
+  return getHardcodedPeersForNetwork(currentNetwork).map(peer => ({ ...peer }));
+}
 
 let mainClient: typeof ElectrumClient | undefined;
 let mainConnected: boolean = false;
@@ -102,6 +131,7 @@ let wasConnectedAtLeastOnce: boolean = false;
 let serverName: string | false = false;
 let disableBatching: boolean = false;
 let connectionAttempt: number = 0;
+let currentNetwork: NetworkType = 'mainnet';
 let currentPeerIndex = hardcodedPeers.findIndex(peer => peer.host === defaultPeer.host && peer.ssl === defaultPeer.ssl);
 if (currentPeerIndex < 0) currentPeerIndex = 0;
 let latestBlock: { height: number; time: number } | { height: undefined; time: undefined } = { height: undefined, time: undefined };
@@ -205,16 +235,19 @@ export async function setDisabled(disabled = true) {
 }
 
 function getCurrentPeer() {
-  return hardcodedPeers[currentPeerIndex];
+  const peers = getHardcodedPeersForNetwork(currentNetwork);
+  if (currentPeerIndex >= peers.length) currentPeerIndex = 0;
+  return peers[currentPeerIndex];
 }
 
 /**
  * Returns NEXT hardcoded electrum server (increments index after use)
  */
 function getNextPeer() {
+  const peers = getHardcodedPeersForNetwork(currentNetwork);
   const peer = getCurrentPeer();
   currentPeerIndex++;
-  if (currentPeerIndex >= hardcodedPeers.length) currentPeerIndex = 0;
+  if (currentPeerIndex >= peers.length) currentPeerIndex = 0;
   return peer;
 }
 
@@ -246,10 +279,14 @@ async function getSavedPeer(): Promise<Peer | null> {
   }
 }
 
-export async function connectMain(): Promise<void> {
+export async function connectMain(network: NetworkType = 'mainnet'): Promise<void> {
   if (await isDisabled()) {
     console.log('Electrum connection disabled by user. Skipping connectMain call');
     return;
+  }
+  if (network !== currentNetwork) {
+    currentNetwork = network;
+    currentPeerIndex = 0;
   }
   let usingPeer = getNextPeer();
   const savedPeer = await getSavedPeer();
@@ -275,7 +312,7 @@ export async function connectMain(): Promise<void> {
         // dropping `mainConnected` flag ensures there wont be reconnection race condition if several
         // errors triggered
         console.log('reconnecting after socket error');
-        setTimeout(connectMain, usingPeer.host.endsWith('.onion') ? 4000 : 500);
+        setTimeout(() => connectMain(currentNetwork), usingPeer.host.endsWith('.onion') ? 4000 : 500);
       }
     };
     const ver = await mainClient.initElectrum({ client: 'bluewallet', version: '1.4' });
@@ -332,7 +369,7 @@ export async function connectMain(): Promise<void> {
     } else {
       console.log('reconnection attempt #', connectionAttempt);
       await new Promise(resolve => setTimeout(resolve, 500)); // sleep
-      return connectMain();
+      return connectMain(currentNetwork);
     }
   }
 }
@@ -420,7 +457,7 @@ const presentNetworkErrorAlert = async (usingPeer?: Peer) => {
           connectionAttempt = 0;
           mainClient?.close();
           mainClient = undefined;
-          setTimeout(connectMain, 500);
+          setTimeout(() => connectMain(currentNetwork), 500);
         },
         style: 'default',
       },
@@ -432,7 +469,7 @@ const presentNetworkErrorAlert = async (usingPeer?: Peer) => {
               connectionAttempt = 0;
               mainClient?.close();
               mainClient = undefined;
-              setTimeout(connectMain, 500);
+              setTimeout(() => connectMain(currentNetwork), 500);
             }
           });
         },
@@ -490,7 +527,7 @@ async function getRandomDynamicPeer(): Promise<Peer> {
 export const getBalanceByAddress = async function (address: string): Promise<{ confirmed: number; unconfirmed: number }> {
   try {
     if (!mainClient) throw new Error('Electrum client is not connected');
-    const script = bitcoin.address.toOutputScript(address);
+    const script = bitcoin.address.toOutputScript(address, getNetwork());
     const hash = bitcoinjs_crypto_sha256(script);
     const reversedHash = new Uint8Array(hash).reverse();
     const balance = await mainClient.blockchainScripthash_getBalance(uint8ArrayToHex(reversedHash));
@@ -518,7 +555,7 @@ export const getSecondsSinceLastRequest = function () {
 
 export const getTransactionsByAddress = async function (address: string): Promise<ElectrumHistory[]> {
   if (!mainClient) throw new Error('Electrum client is not connected');
-  const script = bitcoin.address.toOutputScript(address);
+  const script = bitcoin.address.toOutputScript(address, getNetwork());
   const hash = bitcoinjs_crypto_sha256(script);
   const reversedHash = new Uint8Array(hash).reverse();
   const history = await mainClient.blockchainScripthash_getHistory(uint8ArrayToHex(reversedHash));
@@ -531,7 +568,7 @@ export const getTransactionsByAddress = async function (address: string): Promis
 
 export const getMempoolTransactionsByAddress = async function (address: string): Promise<MempoolTransaction[]> {
   if (!mainClient) throw new Error('Electrum client is not connected');
-  const script = bitcoin.address.toOutputScript(address);
+  const script = bitcoin.address.toOutputScript(address, getNetwork());
   const hash = bitcoinjs_crypto_sha256(script);
   const reversedHash = new Uint8Array(hash).reverse();
   return mainClient.blockchainScripthash_getMempool(uint8ArrayToHex(reversedHash));
@@ -717,7 +754,7 @@ export const multiGetBalanceByAddress = async (addresses: string[], batchsize: n
     const scripthashes = [];
     const scripthash2addr: Record<string, string> = {};
     for (const addr of chunk) {
-      const script = bitcoin.address.toOutputScript(addr);
+      const script = bitcoin.address.toOutputScript(addr, getNetwork());
       const hash = bitcoinjs_crypto_sha256(script);
       const reversedHash = uint8ArrayToHex(new Uint8Array(hash).reverse());
       scripthashes.push(reversedHash);
@@ -761,7 +798,7 @@ export const multiGetUtxoByAddress = async function (addresses: string[], batchs
     const scripthashes = [];
     const scripthash2addr: Record<string, string> = {};
     for (const addr of chunk) {
-      const script = bitcoin.address.toOutputScript(addr);
+      const script = bitcoin.address.toOutputScript(addr, getNetwork());
       const hash = bitcoinjs_crypto_sha256(script);
       const reversedHash = uint8ArrayToHex(new Uint8Array(hash).reverse());
       scripthashes.push(reversedHash);
@@ -811,7 +848,7 @@ export const multiGetHistoryByAddress = async function (
     const scripthashes = [];
     const scripthash2addr: Record<string, string> = {};
     for (const addr of chunk) {
-      const script = bitcoin.address.toOutputScript(addr);
+      const script = bitcoin.address.toOutputScript(addr, getNetwork());
       const hash = bitcoinjs_crypto_sha256(script);
       const reversedHash = uint8ArrayToHex(new Uint8Array(hash).reverse());
       scripthashes.push(reversedHash);

--- a/class/contact-list.ts
+++ b/class/contact-list.ts
@@ -5,6 +5,7 @@ import { SilentPayment } from 'silent-payments';
 import ecc from '../blue_modules/noble_ecc';
 import { concatUint8Arrays } from '../blue_modules/uint8array-extras';
 import * as bitcoin from 'bitcoinjs-lib';
+import { getNetwork } from '../models/network';
 
 export class ContactList {
   isBip47PaymentCodeValid(pc: string) {
@@ -26,9 +27,10 @@ export class ContactList {
 
   isAddressValid(address: string): boolean {
     try {
-      bitcoin.address.toOutputScript(address); // throws, no?
+      bitcoin.address.toOutputScript(address, getNetwork()); // throws, no?
 
-      if (!address.toLowerCase().startsWith('bc1')) return true;
+      const lowerAddr = address.toLowerCase();
+      if (!lowerAddr.startsWith('bc1') && !lowerAddr.startsWith('tb1')) return true;
       const decoded = bitcoin.address.fromBech32(address);
       if (decoded.version === 0) return true;
       if (decoded.version === 1 && decoded.data.length !== 32) return false;

--- a/class/deeplink-schema-match.ts
+++ b/class/deeplink-schema-match.ts
@@ -3,6 +3,7 @@ import * as bitcoin from 'bitcoinjs-lib';
 import URL from 'url';
 import { readFileOutsideSandbox } from '../blue_modules/fs';
 import { Chain } from '../models/bitcoinUnits';
+import { getNetwork } from '../models/network';
 import { WatchOnlyWallet } from './';
 import Azteco from './azteco';
 import Lnurl from './lnurl';
@@ -305,7 +306,7 @@ class DeeplinkSchemaMatch {
     address = address.replace('://', ':').replace('bitcoin:', '').replace('BITCOIN:', '').replace('bitcoin=', '').split('?')[0];
     let isValidBitcoinAddress = false;
     try {
-      bitcoin.address.toOutputScript(address);
+      bitcoin.address.toOutputScript(address, getNetwork());
       isValidBitcoinAddress = true;
     } catch (err) {
       isValidBitcoinAddress = false;
@@ -397,7 +398,7 @@ class DeeplinkSchemaMatch {
 
   static bip21encode(address: string, options?: TOptions): string {
     // uppercase address if bech32 to satisfy BIP_0173
-    const isBech32 = address.startsWith('bc1');
+    const isBech32 = address.startsWith('bc1') || address.startsWith('tb1');
     if (isBech32) {
       address = address.toUpperCase();
     }

--- a/class/multisig-cosigner.ts
+++ b/class/multisig-cosigner.ts
@@ -2,6 +2,7 @@ import BIP32Factory from 'bip32';
 import b58 from 'bs58check';
 
 import ecc from '../blue_modules/noble_ecc';
+import { getNetwork } from '../models/network';
 import { MultisigHDWallet } from './wallets/multisig-hd-wallet';
 import assert from 'assert';
 const bip32 = BIP32Factory(ecc);
@@ -173,7 +174,7 @@ export class MultisigCosigner {
     try {
       const tempWallet = new MultisigHDWallet();
       xpub = tempWallet._zpubToXpub(key);
-      bip32.fromBase58(xpub);
+      bip32.fromBase58(xpub, getNetwork());
       return true;
     } catch (_) {}
 

--- a/class/payjoin-transaction.ts
+++ b/class/payjoin-transaction.ts
@@ -7,6 +7,7 @@ import presentAlert from '../components/Alert';
 import { HDSegwitBech32Wallet } from './wallets/hd-segwit-bech32-wallet';
 import assert from 'assert';
 import { uint8ArrayToHex } from '../blue_modules/uint8array-extras';
+import { getNetwork } from '../models/network';
 const ECPair = ECPairFactory(ecc);
 
 const delay = (milliseconds: number) => new Promise(resolve => setTimeout(resolve, milliseconds));
@@ -33,9 +34,9 @@ export default class PayjoinTransaction {
       delete input.finalScriptWitness;
 
       assert(input.witnessUtxo, 'Internal error: input.witnessUtxo is not set');
-      const address = bitcoin.address.fromOutputScript(input.witnessUtxo.script);
+      const address = bitcoin.address.fromOutputScript(input.witnessUtxo.script, getNetwork());
       const wif = this._wallet._getWifForAddress(address);
-      const keyPair = ECPair.fromWIF(wif);
+      const keyPair = ECPair.fromWIF(wif, getNetwork());
 
       unfinalized.signInput(index, keyPair);
     }
@@ -77,10 +78,10 @@ export default class PayjoinTransaction {
 
     for (const [index, input] of payjoinPsbt.data.inputs.entries()) {
       assert(input.witnessUtxo, 'Internal error: input.witnessUtxo is not set');
-      const address = bitcoin.address.fromOutputScript(input.witnessUtxo.script);
+      const address = bitcoin.address.fromOutputScript(input.witnessUtxo.script, getNetwork());
       try {
         const wif = this._wallet._getWifForAddress(address);
-        const keyPair = ECPair.fromWIF(wif);
+        const keyPair = ECPair.fromWIF(wif, getNetwork());
         payjoinPsbt.signInput(index, keyPair).finalizeInput(index);
       } catch (e) {}
     }

--- a/class/wallets/abstract-hd-electrum-wallet.ts
+++ b/class/wallets/abstract-hd-electrum-wallet.ts
@@ -19,6 +19,7 @@ import { AbstractHDWallet } from './abstract-hd-wallet';
 import { CreateTransactionResult, CreateTransactionTarget, CreateTransactionUtxo, Transaction, Utxo } from './types';
 import { SilentPayment, UTXOType as SPUTXOType, UTXO as SPUTXO } from 'silent-payments';
 import { isValidBech32Address } from '../../util/isValidBech32Address.ts';
+import { getNetwork, isTestnet } from '../../models/network';
 
 const ECPair = ECPairFactory(ecc);
 const bip32 = BIP32Factory(ecc);
@@ -41,6 +42,8 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
   public readonly type = AbstractHDElectrumWallet.type;
   // @ts-ignore: override
   public readonly typeReadable = AbstractHDElectrumWallet.typeReadable;
+
+  public readonly network?: bitcoin.networks.Network;
 
   _balances_by_external_index: Record<number, BalanceByIndex>;
   _balances_by_internal_index: Record<number, BalanceByIndex>;
@@ -188,7 +191,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
   _getWIFByIndex(internal: boolean, index: number): string | false {
     if (!this.secret) return false;
     const seed = this._getSeed();
-    const root = bip32.fromSeed(seed);
+    const root = bip32.fromSeed(seed, getNetwork());
     const path = `${this.getDerivationPath()}/${internal ? 1 : 0}/${index}`;
     const child = root.derivePath(path);
 
@@ -207,13 +210,13 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
 
     if (node === 0 && !this._node0) {
       const xpub = this._zpubToXpub(this.getXpub());
-      const hdNode = bip32.fromBase58(xpub);
+      const hdNode = bip32.fromBase58(xpub, getNetwork());
       this._node0 = hdNode.derive(node);
     }
 
     if (node === 1 && !this._node1) {
       const xpub = this._zpubToXpub(this.getXpub());
-      const hdNode = bip32.fromBase58(xpub);
+      const hdNode = bip32.fromBase58(xpub, getNetwork());
       this._node1 = hdNode.derive(node);
     }
 
@@ -240,13 +243,13 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
 
     if (node === 0 && !this._node0) {
       const xpub = this._zpubToXpub(this.getXpub());
-      const hdNode = bip32.fromBase58(xpub);
+      const hdNode = bip32.fromBase58(xpub, getNetwork());
       this._node0 = hdNode.derive(node);
     }
 
     if (node === 1 && !this._node1) {
       const xpub = this._zpubToXpub(this.getXpub());
-      const hdNode = bip32.fromBase58(xpub);
+      const hdNode = bip32.fromBase58(xpub, getNetwork());
       this._node1 = hdNode.derive(node);
     }
 
@@ -281,7 +284,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     }
     // first, getting xpub
     const seed = this._getSeed();
-    const root = bip32.fromSeed(seed);
+    const root = bip32.fromSeed(seed, getNetwork());
 
     const path = this.getDerivationPath();
     if (!path) {
@@ -290,10 +293,12 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     const child = root.derivePath(path).neutered();
     const xpub = child.toBase58();
 
-    // bitcoinjs does not support zpub yet, so we just convert it from xpub
+    // bitcoinjs does not support zpub yet, so we just convert it from xpub/tpub
     let data = b58.decode(xpub);
     data = data.slice(4);
-    const concatenated = concatUint8Arrays([hexToUint8Array('04b24746'), data]);
+    // mainnet zpub prefix: 04b24746, testnet vpub prefix: 045f1cf6
+    const prefix = isTestnet() ? '045f1cf6' : '04b24746';
+    const concatenated = concatUint8Arrays([hexToUint8Array(prefix), data]);
     this._xpub = b58.encode(concatenated);
 
     return this._xpub;
@@ -1214,7 +1219,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     }
 
     sequence = sequence || AbstractHDElectrumWallet.defaultRBFSequence;
-    let psbt = new bitcoin.Psbt();
+    let psbt = new bitcoin.Psbt({ network: getNetwork() });
     let c = 0;
     const keypairs: Record<number, ECPairInterface> = {};
     const values: Record<number, number> = {};
@@ -1223,7 +1228,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
       let keyPair;
       if (!skipSigning) {
         // skiping signing related stuff
-        keyPair = ECPair.fromWIF(this._getWifForAddress(String(input.address)));
+        keyPair = ECPair.fromWIF(this._getWifForAddress(String(input.address)), getNetwork());
         keypairs[c] = keyPair;
       }
       values[c] = input.value;
@@ -1340,7 +1345,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     if (!pubkey || !path) {
       throw new Error('Internal error: pubkey or path are invalid');
     }
-    const p2wpkh = bitcoin.payments.p2wpkh({ pubkey });
+    const p2wpkh = bitcoin.payments.p2wpkh({ pubkey, network: getNetwork() });
     if (!p2wpkh.output) {
       throw new Error('Internal error: could not create p2wpkh output during _addPsbtInput');
     }
@@ -1395,6 +1400,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
   _nodeToBech32SegwitAddress(hdNode: BIP32Interface): string {
     const { address } = bitcoin.payments.p2wpkh({
       pubkey: hdNode.publicKey,
+      network: getNetwork(),
     });
 
     if (!address) {
@@ -1407,6 +1413,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
   _nodeToLegacyAddress(hdNode: BIP32Interface): string {
     const { address } = bitcoin.payments.p2pkh({
       pubkey: hdNode.publicKey,
+      network: getNetwork(),
     });
 
     if (!address) {
@@ -1421,7 +1428,8 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
    */
   _nodeToP2shSegwitAddress(hdNode: BIP32Interface): string {
     const { address } = bitcoin.payments.p2sh({
-      redeem: bitcoin.payments.p2wpkh({ pubkey: hdNode.publicKey }),
+      redeem: bitcoin.payments.p2wpkh({ pubkey: hdNode.publicKey, network: getNetwork() }),
+      network: getNetwork(),
     });
 
     if (!address) {
@@ -1464,7 +1472,11 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
       return false;
     }
     // only check BIP47 if derivation path is regular, otherwise too many wallets will be found
-    if (!["m/84'/0'/0'", "m/44'/0'/0'", "m/49'/0'/0'"].includes(this.getDerivationPath() as string)) {
+    if (
+      !["m/84'/0'/0'", "m/44'/0'/0'", "m/49'/0'/0'", "m/84'/1'/0'", "m/44'/1'/0'", "m/49'/1'/0'"].includes(
+        this.getDerivationPath() as string,
+      )
+    ) {
       return false;
     }
 
@@ -1528,7 +1540,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
    */
   cosignPsbt(psbt: Psbt) {
     const seed = this._getSeed();
-    const hdRoot = bip32.fromSeed(seed);
+    const hdRoot = bip32.fromSeed(seed, getNetwork());
 
     for (let cc = 0; cc < psbt.inputCount; cc++) {
       try {
@@ -1544,7 +1556,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
           if (!wif) {
             throw new Error('Internal error: cant get WIF by index during cosingPsbt');
           }
-          const keyPair = ECPair.fromWIF(wif);
+          const keyPair = ECPair.fromWIF(wif, getNetwork());
           try {
             psbt.signInput(cc, keyPair);
           } catch (e) {} // protects agains duplicate cosignings or if this output can't be signed with current wallet
@@ -1565,7 +1577,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
    * @returns {string} Hex string of fingerprint derived from mnemonics. Always has length of 8 chars and correct leading zeroes. All caps
    */
   static seedToFingerprint(seed: Uint8Array) {
-    const root = bip32.fromSeed(seed);
+    const root = bip32.fromSeed(seed, getNetwork());
     let hex = uint8ArrayToHex(root.fingerprint);
     while (hex.length < 8) hex = '0' + hex; // leading zeroes
     return hex.toUpperCase();
@@ -1711,7 +1723,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
 
     // utxo selected. lets create op_return payload using the correct (first!) utxo and correct targets with that payload
 
-    const keyPair = ECPair.fromWIF(inputsTemp[0].wif);
+    const keyPair = ECPair.fromWIF(inputsTemp[0].wif, getNetwork());
     const outputNumber = new Uint8Array(4); // 00000000 in hex
     new DataView(outputNumber.buffer).setUint32(0, inputsTemp[0].vout, true); // little-endian
     const blindedPaymentCode = aliceBip47.getBlindedPaymentCode(

--- a/class/wallets/abstract-hd-wallet.ts
+++ b/class/wallets/abstract-hd-wallet.ts
@@ -3,6 +3,7 @@ import * as bip39 from 'bip39';
 
 import * as bip39custom from '../../blue_modules/bip39';
 import * as BlueElectrum from '../../blue_modules/BlueElectrum';
+import { isTestnet } from '../../models/network';
 import { LegacyWallet } from './legacy-wallet';
 import { Transaction } from './types';
 
@@ -32,6 +33,7 @@ export class AbstractHDWallet extends LegacyWallet {
   passphrase?: string;
   _node0?: BIP32Interface;
   _node1?: BIP32Interface;
+  _cachedForNetwork?: string;
 
   constructor() {
     super();
@@ -45,6 +47,7 @@ export class AbstractHDWallet extends LegacyWallet {
     this._address_to_wif_cache = {};
     this.gap_limit = 20;
     this._derivationPath = Constructor.derivationPath;
+    this._cachedForNetwork = isTestnet() ? 'testnet' : 'mainnet';
   }
 
   getNextFreeAddressIndex(): number {
@@ -53,6 +56,24 @@ export class AbstractHDWallet extends LegacyWallet {
 
   getNextFreeChangeAddressIndex(): number {
     return this.next_free_change_address_index;
+  }
+
+  static fromJson(obj: string): AbstractHDWallet {
+    const wallet = super.fromJson(obj) as AbstractHDWallet;
+    const currentNetworkKey = isTestnet() ? 'testnet' : 'mainnet';
+    if (wallet._cachedForNetwork !== currentNetworkKey) {
+      // Network changed since wallet was last saved — clear all derived caches
+      // so addresses and xpubs are re-derived for the correct network.
+      wallet.external_addresses_cache = {};
+      wallet.internal_addresses_cache = {};
+      wallet._address_to_wif_cache = {};
+      wallet._address = false;
+      delete wallet._node0;
+      delete wallet._node1;
+      wallet._xpub = '';
+      wallet._cachedForNetwork = currentNetworkKey;
+    }
+    return wallet;
   }
 
   prepareForSerialization(): void {
@@ -322,7 +343,12 @@ export class AbstractHDWallet extends LegacyWallet {
   /**
    * @returns {string} Root derivation path for wallet if any
    */
-  getDerivationPath() {
+  getDerivationPath(): string {
+    if (!this._derivationPath) return this._derivationPath || '';
+    // On testnet/signet, swap coin type 0 to 1 (e.g. m/84'/0'/0' -> m/84'/1'/0')
+    if (isTestnet()) {
+      return this._derivationPath.replace(/^(m\/\d+')\/0'\//, "$1/1'/");
+    }
     return this._derivationPath;
   }
 

--- a/class/wallets/abstract-wallet.ts
+++ b/class/wallets/abstract-wallet.ts
@@ -3,6 +3,7 @@ import { sha256 } from '@noble/hashes/sha256';
 import wif from 'wif';
 
 import { BitcoinUnit, Chain } from '../../models/bitcoinUnits';
+import { isTestnet } from '../../models/network';
 import { CreateTransactionResult, CreateTransactionUtxo, Transaction, Utxo } from './types';
 import { hexToUint8Array, concatUint8Arrays, uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
 
@@ -456,7 +457,9 @@ export class AbstractWallet {
   _zpubToXpub(zpub: string): string {
     let data = b58.decode(zpub);
     data = data.slice(4);
-    const concatenated = concatUint8Arrays([hexToUint8Array('0488b21e'), data]);
+    // mainnet xpub prefix: 0488b21e, testnet tpub prefix: 043587cf
+    const prefix = isTestnet() ? '043587cf' : '0488b21e';
+    const concatenated = concatUint8Arrays([hexToUint8Array(prefix), data]);
 
     return b58.encode(concatenated);
   }

--- a/class/wallets/hd-aezeed-wallet.ts
+++ b/class/wallets/hd-aezeed-wallet.ts
@@ -5,6 +5,7 @@ import b58 from 'bs58check';
 
 import ecc from '../../blue_modules/noble_ecc';
 import { concatUint8Arrays, hexToUint8Array, uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
+import { getNetwork } from '../../models/network';
 import { AbstractHDElectrumWallet } from './abstract-hd-electrum-wallet';
 
 const bip32 = BIP32Factory(ecc);
@@ -48,9 +49,9 @@ export class HDAezeedWallet extends AbstractHDElectrumWallet {
 
   getXpub() {
     // first, getting xpub
-    const root = bip32.fromSeed(this._getEntropyCached());
+    const root = bip32.fromSeed(this._getEntropyCached(), getNetwork());
 
-    const path = "m/84'/0'/0'";
+    const path = this.getDerivationPath();
     const child = root.derivePath(path).neutered();
     const xpub = child.toBase58();
 
@@ -94,14 +95,16 @@ export class HDAezeedWallet extends AbstractHDElectrumWallet {
   }
 
   _getNode0() {
-    const root = bip32.fromSeed(this._getEntropyCached());
-    const node = root.derivePath("m/84'/0'/0'");
+    const root = bip32.fromSeed(this._getEntropyCached(), getNetwork());
+    const path = this.getDerivationPath();
+    const node = root.derivePath(path);
     return node.derive(0);
   }
 
   _getNode1() {
-    const root = bip32.fromSeed(this._getEntropyCached());
-    const node = root.derivePath("m/84'/0'/0'");
+    const root = bip32.fromSeed(this._getEntropyCached(), getNetwork());
+    const path = this.getDerivationPath();
+    const node = root.derivePath(path);
     return node.derive(1);
   }
 
@@ -113,6 +116,7 @@ export class HDAezeedWallet extends AbstractHDElectrumWallet {
 
     const address = bitcoin.payments.p2wpkh({
       pubkey: this._node1.derive(index).publicKey,
+      network: getNetwork(),
     }).address;
     if (!address) {
       throw new Error('Internal error: no address in _getInternalAddressByIndex');
@@ -129,6 +133,7 @@ export class HDAezeedWallet extends AbstractHDElectrumWallet {
 
     const address = bitcoin.payments.p2wpkh({
       pubkey: this._node0.derive(index).publicKey,
+      network: getNetwork(),
     }).address;
     if (!address) {
       throw new Error('Internal error: no address in _getExternalAddressByIndex');
@@ -139,8 +144,9 @@ export class HDAezeedWallet extends AbstractHDElectrumWallet {
 
   _getWIFByIndex(internal: boolean, index: number): string | false {
     if (!this.secret) return false;
-    const root = bip32.fromSeed(this._getEntropyCached());
-    const path = `m/84'/0'/0'/${internal ? 1 : 0}/${index}`;
+    const root = bip32.fromSeed(this._getEntropyCached(), getNetwork());
+    const derivationPath = this.getDerivationPath();
+    const path = `${derivationPath}/${internal ? 1 : 0}/${index}`;
     const child = root.derivePath(path);
 
     return child.toWIF();
@@ -169,7 +175,7 @@ export class HDAezeedWallet extends AbstractHDElectrumWallet {
   }
 
   getIdentityPubkey() {
-    const root = bip32.fromSeed(this._getEntropyCached());
+    const root = bip32.fromSeed(this._getEntropyCached(), getNetwork());
     const node = root.derivePath("m/1017'/0'/6'/0/0");
 
     return uint8ArrayToHex(node.publicKey);

--- a/class/wallets/hd-legacy-breadwallet-wallet.ts
+++ b/class/wallets/hd-legacy-breadwallet-wallet.ts
@@ -8,6 +8,7 @@ import { ElectrumHistory } from '../../blue_modules/BlueElectrum';
 import ecc from '../../blue_modules/noble_ecc';
 import { AbstractHDElectrumWallet } from './abstract-hd-electrum-wallet';
 import { HDLegacyP2PKHWallet } from './hd-legacy-p2pkh-wallet';
+import { getNetwork } from '../../models/network';
 
 const bip32 = BIP32Factory(ecc);
 
@@ -32,10 +33,10 @@ export class HDLegacyBreadwalletWallet extends HDLegacyP2PKHWallet {
   _calcNodeAddressByIndex(node: number, index: number, p2wpkh: boolean = false) {
     let _node: BIP32Interface | undefined;
     if (node === 0) {
-      _node = this._node0 || (this._node0 = bip32.fromBase58(this.getXpub()).derive(node));
+      _node = this._node0 || (this._node0 = bip32.fromBase58(this.getXpub(), getNetwork()).derive(node));
     }
     if (node === 1) {
-      _node = this._node1 || (this._node1 = bip32.fromBase58(this.getXpub()).derive(node));
+      _node = this._node1 || (this._node1 = bip32.fromBase58(this.getXpub(), getNetwork()).derive(node));
     }
 
     if (!_node) {
@@ -43,7 +44,9 @@ export class HDLegacyBreadwalletWallet extends HDLegacyP2PKHWallet {
     }
 
     const pubkey = _node.derive(index).publicKey;
-    const address = p2wpkh ? bitcoinjs.payments.p2wpkh({ pubkey }).address : bitcoinjs.payments.p2pkh({ pubkey }).address;
+    const address = p2wpkh
+      ? bitcoinjs.payments.p2wpkh({ pubkey, network: getNetwork() }).address
+      : bitcoinjs.payments.p2pkh({ pubkey, network: getNetwork() }).address;
 
     if (!address) {
       throw new Error('Internal error: no address in _calcNodeAddressByIndex');

--- a/class/wallets/hd-legacy-electrum-seed-p2pkh-wallet.ts
+++ b/class/wallets/hd-legacy-electrum-seed-p2pkh-wallet.ts
@@ -4,6 +4,7 @@ import * as mn from 'electrum-mnemonic';
 
 import ecc from '../../blue_modules/noble_ecc';
 import { HDLegacyP2PKHWallet } from './hd-legacy-p2pkh-wallet';
+import { getNetwork } from '../../models/network';
 
 const bip32 = BIP32Factory(ecc);
 const PREFIX = mn.PREFIXES.standard;
@@ -46,7 +47,7 @@ export class HDLegacyElectrumSeedP2PKHWallet extends HDLegacyP2PKHWallet {
     }
     const args: SeedOpts = { prefix: PREFIX };
     if (this.passphrase) args.passphrase = this.passphrase;
-    const root = bip32.fromSeed(mn.mnemonicToSeedSync(this.secret, args));
+    const root = bip32.fromSeed(mn.mnemonicToSeedSync(this.secret, args), getNetwork());
     this._xpub = root.neutered().toBase58();
     return this._xpub;
   }
@@ -55,9 +56,10 @@ export class HDLegacyElectrumSeedP2PKHWallet extends HDLegacyP2PKHWallet {
     index = index * 1; // cast to int
     if (this.internal_addresses_cache[index]) return this.internal_addresses_cache[index]; // cache hit
 
-    const node = bip32.fromBase58(this.getXpub());
+    const node = bip32.fromBase58(this.getXpub(), getNetwork());
     const address = bitcoin.payments.p2pkh({
       pubkey: node.derive(1).derive(index).publicKey,
+      network: getNetwork(),
     }).address;
     if (!address) {
       throw new Error('Internal error: no address in _getInternalAddressByIndex');
@@ -70,9 +72,10 @@ export class HDLegacyElectrumSeedP2PKHWallet extends HDLegacyP2PKHWallet {
     index = index * 1; // cast to int
     if (this.external_addresses_cache[index]) return this.external_addresses_cache[index]; // cache hit
 
-    const node = bip32.fromBase58(this.getXpub());
+    const node = bip32.fromBase58(this.getXpub(), getNetwork());
     const address = bitcoin.payments.p2pkh({
       pubkey: node.derive(0).derive(index).publicKey,
+      network: getNetwork(),
     }).address;
     if (!address) {
       throw new Error('Internal error: no address in _getExternalAddressByIndex');
@@ -85,7 +88,7 @@ export class HDLegacyElectrumSeedP2PKHWallet extends HDLegacyP2PKHWallet {
     if (!this.secret) return false;
     const args: SeedOpts = { prefix: PREFIX };
     if (this.passphrase) args.passphrase = this.passphrase;
-    const root = bip32.fromSeed(mn.mnemonicToSeedSync(this.secret, args));
+    const root = bip32.fromSeed(mn.mnemonicToSeedSync(this.secret, args), getNetwork());
     const path = `m/${internal ? 1 : 0}/${index}`;
     const child = root.derivePath(path);
 
@@ -97,13 +100,13 @@ export class HDLegacyElectrumSeedP2PKHWallet extends HDLegacyP2PKHWallet {
 
     if (node === 0 && !this._node0) {
       const xpub = this.getXpub();
-      const hdNode = bip32.fromBase58(xpub);
+      const hdNode = bip32.fromBase58(xpub, getNetwork());
       this._node0 = hdNode.derive(node);
     }
 
     if (node === 1 && !this._node1) {
       const xpub = this.getXpub();
-      const hdNode = bip32.fromBase58(xpub);
+      const hdNode = bip32.fromBase58(xpub, getNetwork());
       this._node1 = hdNode.derive(node);
     }
 

--- a/class/wallets/hd-legacy-p2pkh-wallet.ts
+++ b/class/wallets/hd-legacy-p2pkh-wallet.ts
@@ -6,6 +6,7 @@ import * as BlueElectrum from '../../blue_modules/BlueElectrum';
 import ecc from '../../blue_modules/noble_ecc';
 import { AbstractHDElectrumWallet } from './abstract-hd-electrum-wallet';
 import { hexToUint8Array } from '../../blue_modules/uint8array-extras';
+import { getNetwork } from '../../models/network';
 
 const bip32 = BIP32Factory(ecc);
 
@@ -52,7 +53,7 @@ export class HDLegacyP2PKHWallet extends AbstractHDElectrumWallet {
       return this._xpub; // cache hit
     }
     const seed = this._getSeed();
-    const root = bip32.fromSeed(seed);
+    const root = bip32.fromSeed(seed, getNetwork());
 
     const path = this.getDerivationPath();
     if (!path) {

--- a/class/wallets/hd-segwit-electrum-seed-p2wpkh-wallet.ts
+++ b/class/wallets/hd-segwit-electrum-seed-p2wpkh-wallet.ts
@@ -6,6 +6,7 @@ import * as mn from 'electrum-mnemonic';
 import ecc from '../../blue_modules/noble_ecc';
 import { concatUint8Arrays, hexToUint8Array } from '../../blue_modules/uint8array-extras';
 import { HDSegwitBech32Wallet } from './hd-segwit-bech32-wallet';
+import { getNetwork } from '../../models/network';
 
 const bip32 = BIP32Factory(ecc);
 const PREFIX = mn.PREFIXES.segwit;
@@ -48,7 +49,7 @@ export class HDSegwitElectrumSeedP2WPKHWallet extends HDSegwitBech32Wallet {
     }
     const args: SeedOpts = { prefix: PREFIX };
     if (this.passphrase) args.passphrase = this.passphrase;
-    const root = bip32.fromSeed(mn.mnemonicToSeedSync(this.secret, args));
+    const root = bip32.fromSeed(mn.mnemonicToSeedSync(this.secret, args), getNetwork());
     const xpub = root.derivePath("m/0'").neutered().toBase58();
 
     // bitcoinjs does not support zpub yet, so we just convert it from xpub
@@ -65,9 +66,10 @@ export class HDSegwitElectrumSeedP2WPKHWallet extends HDSegwitBech32Wallet {
     if (this.internal_addresses_cache[index]) return this.internal_addresses_cache[index]; // cache hit
 
     const xpub = this._zpubToXpub(this.getXpub());
-    const node = bip32.fromBase58(xpub);
+    const node = bip32.fromBase58(xpub, getNetwork());
     const address = bitcoin.payments.p2wpkh({
       pubkey: node.derive(1).derive(index).publicKey,
+      network: getNetwork(),
     }).address;
     if (!address) {
       throw new Error('Internal error: no address in _getInternalAddressByIndex');
@@ -81,9 +83,10 @@ export class HDSegwitElectrumSeedP2WPKHWallet extends HDSegwitBech32Wallet {
     if (this.external_addresses_cache[index]) return this.external_addresses_cache[index]; // cache hit
 
     const xpub = this._zpubToXpub(this.getXpub());
-    const node = bip32.fromBase58(xpub);
+    const node = bip32.fromBase58(xpub, getNetwork());
     const address = bitcoin.payments.p2wpkh({
       pubkey: node.derive(0).derive(index).publicKey,
+      network: getNetwork(),
     }).address;
     if (!address) {
       throw new Error('Internal error: no address in _getExternalAddressByIndex');
@@ -96,7 +99,7 @@ export class HDSegwitElectrumSeedP2WPKHWallet extends HDSegwitBech32Wallet {
     if (!this.secret) return false;
     const args: SeedOpts = { prefix: PREFIX };
     if (this.passphrase) args.passphrase = this.passphrase;
-    const root = bip32.fromSeed(mn.mnemonicToSeedSync(this.secret, args));
+    const root = bip32.fromSeed(mn.mnemonicToSeedSync(this.secret, args), getNetwork());
     const path = `m/0'/${internal ? 1 : 0}/${index}`;
     const child = root.derivePath(path);
 
@@ -108,13 +111,13 @@ export class HDSegwitElectrumSeedP2WPKHWallet extends HDSegwitBech32Wallet {
 
     if (node === 0 && !this._node0) {
       const xpub = this._zpubToXpub(this.getXpub());
-      const hdNode = bip32.fromBase58(xpub);
+      const hdNode = bip32.fromBase58(xpub, getNetwork());
       this._node0 = hdNode.derive(node);
     }
 
     if (node === 1 && !this._node1) {
       const xpub = this._zpubToXpub(this.getXpub());
-      const hdNode = bip32.fromBase58(xpub);
+      const hdNode = bip32.fromBase58(xpub, getNetwork());
       this._node1 = hdNode.derive(node);
     }
 

--- a/class/wallets/hd-segwit-p2sh-wallet.ts
+++ b/class/wallets/hd-segwit-p2sh-wallet.ts
@@ -7,6 +7,7 @@ import { CoinSelectReturnInput } from 'coinselect';
 import ecc from '../../blue_modules/noble_ecc';
 import { concatUint8Arrays, hexToUint8Array } from '../../blue_modules/uint8array-extras';
 import { AbstractHDElectrumWallet } from './abstract-hd-electrum-wallet';
+import { getNetwork } from '../../models/network';
 
 const bip32 = BIP32Factory(ecc);
 
@@ -61,7 +62,7 @@ export class HDSegwitP2SHWallet extends AbstractHDElectrumWallet {
     }
     // first, getting xpub
     const seed = this._getSeed();
-    const root = bip32.fromSeed(seed);
+    const root = bip32.fromSeed(seed, getNetwork());
 
     const path = this.getDerivationPath();
     if (!path) {
@@ -88,8 +89,8 @@ export class HDSegwitP2SHWallet extends AbstractHDElectrumWallet {
     if (!pubkey || !path) {
       throw new Error('Internal error: pubkey or path are invalid');
     }
-    const p2wpkh = bitcoin.payments.p2wpkh({ pubkey });
-    const p2sh = bitcoin.payments.p2sh({ redeem: p2wpkh });
+    const p2wpkh = bitcoin.payments.p2wpkh({ pubkey, network: getNetwork() });
+    const p2sh = bitcoin.payments.p2sh({ redeem: p2wpkh, network: getNetwork() });
     if (!p2sh.output) {
       throw new Error('Internal error: no p2sh.output during _addPsbtInput()');
     }

--- a/class/wallets/hd-taproot-wallet.ts
+++ b/class/wallets/hd-taproot-wallet.ts
@@ -4,6 +4,7 @@ import ecc from '../../blue_modules/noble_ecc';
 import * as bitcoin from 'bitcoinjs-lib';
 import { Psbt } from 'bitcoinjs-lib';
 import { CoinSelectReturnInput } from 'coinselect';
+import { getNetwork } from '../../models/network';
 
 const bip32 = BIP32Factory(ecc);
 
@@ -25,7 +26,7 @@ export class HDTaprootWallet extends AbstractHDElectrumWallet {
       return this._xpub; // cache hit
     }
     const seed = this._getSeed();
-    const root = bip32.fromSeed(seed);
+    const root = bip32.fromSeed(seed, getNetwork());
 
     const path = this.getDerivationPath();
     if (!path) {
@@ -49,6 +50,7 @@ export class HDTaprootWallet extends AbstractHDElectrumWallet {
 
     const { address } = bitcoin.payments.p2tr({
       internalPubkey: xOnlyPubkey,
+      network: getNetwork(),
     });
 
     if (!address) {
@@ -67,7 +69,7 @@ export class HDTaprootWallet extends AbstractHDElectrumWallet {
         // bip32.fromBase58() wont work with zpub prefix, need to swap it for the traditional one
         xpub = this._zpubToXpub(xpub);
       }
-      const hdNode = bip32.fromBase58(xpub);
+      const hdNode = bip32.fromBase58(xpub, getNetwork());
       this._node0 = hdNode.derive(node);
     }
 
@@ -77,7 +79,7 @@ export class HDTaprootWallet extends AbstractHDElectrumWallet {
         // bip32.fromBase58() wont work with zpub prefix, need to swap it for the traditional one
         xpub = this._zpubToXpub(xpub);
       }
-      const hdNode = bip32.fromBase58(xpub);
+      const hdNode = bip32.fromBase58(xpub, getNetwork());
       this._node1 = hdNode.derive(node);
     }
 
@@ -104,6 +106,7 @@ export class HDTaprootWallet extends AbstractHDElectrumWallet {
 
     const p2tr = bitcoin.payments.p2tr({
       internalPubkey: pubkey,
+      network: getNetwork(),
     });
     if (!p2tr.output) throw new Error('Could not build p2tr.output');
 

--- a/class/wallets/legacy-wallet.ts
+++ b/class/wallets/legacy-wallet.ts
@@ -12,6 +12,7 @@ import { HDSegwitBech32Wallet } from '..';
 import { randomBytes } from '../rng';
 import { AbstractWallet } from './abstract-wallet';
 import { CreateTransactionResult, CreateTransactionTarget, CreateTransactionUtxo, Transaction, Utxo } from './types';
+import { getNetwork } from '../../models/network';
 const ECPair: ECPairAPI = ECPairFactory(ecc);
 bitcoin.initEccLib(ecc);
 
@@ -60,23 +61,24 @@ export class LegacyWallet extends AbstractWallet {
 
   async generate(): Promise<void> {
     const buf = await randomBytes(32);
-    this.secret = ECPair.makeRandom({ rng: () => buf }).toWIF();
+    this.secret = ECPair.makeRandom({ rng: () => buf, network: getNetwork() }).toWIF();
   }
 
   async generateFromEntropy(user: Uint8Array): Promise<void> {
     if (user.length !== 32) {
       throw new Error('Entropy should be 32 bytes');
     }
-    this.secret = ECPair.fromPrivateKey(user).toWIF();
+    this.secret = ECPair.fromPrivateKey(user, { network: getNetwork() }).toWIF();
   }
 
   getAddress(): string | false {
     if (this._address) return this._address;
     let address;
     try {
-      const keyPair = ECPair.fromWIF(this.secret);
+      const keyPair = ECPair.fromWIF(this.secret, getNetwork());
       address = bitcoin.payments.p2pkh({
         pubkey: keyPair.publicKey,
+        network: getNetwork(),
       }).address;
     } catch (err) {
       return false;
@@ -404,9 +406,9 @@ export class LegacyWallet extends AbstractWallet {
     }
 
     for (const t of _targets) {
-      if (t.address?.startsWith('bc1')) {
+      if (t.address?.startsWith('bc1') || t.address?.startsWith('tb1')) {
         // in case address is non-typical and takes more bytes than coinselect library anticipates by default
-        t.script = { length: bitcoin.address.toOutputScript(t.address).length + 3 };
+        t.script = { length: bitcoin.address.toOutputScript(t.address, getNetwork()).length + 3 };
       }
 
       if (t.script?.hex) {
@@ -448,14 +450,14 @@ export class LegacyWallet extends AbstractWallet {
     if (targets.length === 0) throw new Error('No destination provided');
     const { inputs, outputs, fee } = this.coinselect(utxos, targets, feeRate);
     sequence = sequence || 0xffffffff; // disable RBF by default
-    const psbt = new bitcoin.Psbt();
+    const psbt = new bitcoin.Psbt({ network: getNetwork() });
     let c = 0;
     const values: Record<number, number> = {};
     let keyPair: Signer | null = null;
 
     if (!skipSigning) {
       // skiping signing related stuff
-      keyPair = ECPair.fromWIF(this.secret); // secret is WIF
+      keyPair = ECPair.fromWIF(this.secret, getNetwork()); // secret is WIF
     }
 
     inputs.forEach(input => {
@@ -526,9 +528,9 @@ export class LegacyWallet extends AbstractWallet {
    */
   isAddressValid(address: string): boolean {
     try {
-      bitcoin.address.toOutputScript(address); // throws, no?
+      bitcoin.address.toOutputScript(address, getNetwork()); // throws, no?
 
-      if (!address.toLowerCase().startsWith('bc1')) return true;
+      if (!address.toLowerCase().startsWith('bc1') && !address.toLowerCase().startsWith('tb1')) return true;
       const decoded = bitcoin.address.fromBech32(address);
       if (decoded.version === 0) return true;
       if (decoded.version === 1 && decoded.data.length !== 32) return false;
@@ -553,7 +555,7 @@ export class LegacyWallet extends AbstractWallet {
       return (
         bitcoin.payments.p2pkh({
           output: scriptPubKey2,
-          network: bitcoin.networks.bitcoin,
+          network: getNetwork(),
         }).address ?? false
       );
     } catch (_) {
@@ -615,7 +617,7 @@ export class LegacyWallet extends AbstractWallet {
   signMessage(message: string, address: string, useSegwit = true): string {
     const wif = this._getWIFbyAddress(address);
     if (!wif) throw new Error('Invalid address');
-    const keyPair = ECPair.fromWIF(wif);
+    const keyPair = ECPair.fromWIF(wif, getNetwork());
     const privateKey = keyPair.privateKey;
     if (!privateKey) throw new Error('Invalid private key');
     let segwitType: 'p2wpkh' | 'p2sh(p2wpkh)';

--- a/class/wallets/lightning-ark-wallet.ts
+++ b/class/wallets/lightning-ark-wallet.ts
@@ -15,6 +15,7 @@ import { LightningTransaction, Transaction } from './types.ts';
 import { hexToUint8Array, uint8ArrayToHex } from '../../blue_modules/uint8array-extras/index';
 import assert from 'assert';
 import ecc from '../../blue_modules/noble_ecc.ts';
+import { getNetwork, isTestnet } from '../../models/network';
 import { Measure } from '../measure.ts';
 const { bech32m } = require('bech32');
 
@@ -69,8 +70,8 @@ export class LightningArkWallet extends LightningCustodianWallet {
       const index = 0;
       const internal = 0;
       const accountNumber = 0;
-      const root = bip32.fromSeed(seed);
-      const path = `m/86'/0'/${accountNumber}'/${internal}/${index}`;
+      const root = bip32.fromSeed(seed, getNetwork());
+      const path = `m/86'/${isTestnet() ? 1 : 0}'/${accountNumber}'/${internal}/${index}`;
       const child = root.derivePath(path);
       assert(child.privateKey, 'Internal error: no private key for child');
 

--- a/class/wallets/multisig-hd-wallet.ts
+++ b/class/wallets/multisig-hd-wallet.ts
@@ -9,6 +9,7 @@ import { ECPairFactory } from 'ecpair';
 import * as mn from 'electrum-mnemonic';
 
 import * as BlueElectrum from '../../blue_modules/BlueElectrum';
+import { getNetwork } from '../../models/network';
 import ecc from '../../blue_modules/noble_ecc';
 import { decodeUR } from '../../blue_modules/ur';
 import { AbstractHDElectrumWallet } from './abstract-hd-electrum-wallet';
@@ -183,7 +184,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
     try {
       const tempWallet = new MultisigHDWallet();
       xpub = tempWallet._zpubToXpub(key);
-      bip32.fromBase58(xpub);
+      bip32.fromBase58(xpub, getNetwork());
       return true;
     } catch (_) {}
 
@@ -193,7 +194,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
   static isXprvValid(xprv: string): boolean {
     try {
       xprv = MultisigHDWallet.convertMultisigXprvToRegularXprv(xprv);
-      bip32.fromBase58(xprv);
+      bip32.fromBase58(xprv, getNetwork());
       return true;
     } catch (_) {
       return false;
@@ -260,7 +261,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
   }
 
   static convertXprvToXpub(xprv: string) {
-    const restored = bip32.fromBase58(MultisigHDWallet.convertMultisigXprvToRegularXprv(xprv));
+    const restored = bip32.fromBase58(MultisigHDWallet.convertMultisigXprvToRegularXprv(xprv), getNetwork());
     return restored.neutered().toBase58();
   }
 
@@ -307,7 +308,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
 
       if (!this._nodes[nodeIndex][cosignerIndex]) {
         const xpub = this._getXpubFromCosignerIndex(cosignerIndex);
-        const hdNode = bip32.fromBase58(xpub);
+        const hdNode = bip32.fromBase58(xpub, getNetwork());
         _node = hdNode.derive(nodeIndex);
         this._nodes[nodeIndex][cosignerIndex] = _node;
       } else {
@@ -320,8 +321,10 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
     if (this.isWrappedSegwit()) {
       const { address } = bitcoin.payments.p2sh({
         redeem: bitcoin.payments.p2wsh({
-          redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys) }),
+          redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys), network: getNetwork() }),
+          network: getNetwork(),
         }),
+        network: getNetwork(),
       });
       if (!address) {
         throw new Error('Internal error: could not make p2sh address');
@@ -330,7 +333,8 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
       return address;
     } else if (this.isNativeSegwit()) {
       const { address } = bitcoin.payments.p2wsh({
-        redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys) }),
+        redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys), network: getNetwork() }),
+        network: getNetwork(),
       });
       if (!address) {
         throw new Error('Internal error: could not make p2wsh address');
@@ -339,7 +343,8 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
       return address;
     } else if (this.isLegacy()) {
       const { address } = bitcoin.payments.p2sh({
-        redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys) }),
+        redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys), network: getNetwork() }),
+        network: getNetwork(),
       });
       if (!address) {
         throw new Error('Internal error: could not make p2sh address');
@@ -369,7 +374,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
       seed = bip39.mnemonicToSeedSync(mnemonic, passphrase);
     }
 
-    const root = bip32.fromSeed(seed);
+    const root = bip32.fromSeed(seed, getNetwork());
     const child = root.derivePath(path).neutered();
     return child.toBase58();
   }
@@ -754,7 +759,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
       }
 
       const xpub = this._getXpubFromCosignerIndex(cosignerIndex);
-      const hdNode0 = bip32.fromBase58(xpub);
+      const hdNode0 = bip32.fromBase58(xpub, getNetwork());
       const splt = path.split('/');
       const internal = +splt[splt.length - 2];
       const index = +splt[splt.length - 1];
@@ -775,7 +780,8 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
 
     if (this.isNativeSegwit()) {
       const p2wsh = bitcoin.payments.p2wsh({
-        redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys) }),
+        redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys), network: getNetwork() }),
+        network: getNetwork(),
       });
       if (!p2wsh.redeem || !p2wsh.output) {
         throw new Error('Could not create p2wsh output');
@@ -799,8 +805,10 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
     } else if (this.isWrappedSegwit()) {
       const p2shP2wsh = bitcoin.payments.p2sh({
         redeem: bitcoin.payments.p2wsh({
-          redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys) }),
+          redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys), network: getNetwork() }),
+          network: getNetwork(),
         }),
+        network: getNetwork(),
       });
       if (!p2shP2wsh?.redeem?.redeem?.output || !p2shP2wsh?.redeem?.output || !p2shP2wsh.output) {
         throw new Error('Could not create p2sh-p2wsh output');
@@ -826,7 +834,8 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
       });
     } else if (this.isLegacy()) {
       const p2sh = bitcoin.payments.p2sh({
-        redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys) }),
+        redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys), network: getNetwork() }),
+        network: getNetwork(),
       });
       if (!p2sh?.redeem?.output) {
         throw new Error('Could not create p2sh output');
@@ -863,7 +872,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
       }
 
       const xpub = this._getXpubFromCosignerIndex(cosignerIndex);
-      const hdNode0 = bip32.fromBase58(xpub);
+      const hdNode0 = bip32.fromBase58(xpub, getNetwork());
       const splt = path.split('/');
       const internal = +splt[splt.length - 2];
       const index = +splt[splt.length - 1];
@@ -879,7 +888,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
     }
 
     if (this.isLegacy()) {
-      const p2sh = bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys) });
+      const p2sh = bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys), network: getNetwork() });
       if (!p2sh.output) {
         throw new Error('Could not create redeemScript');
       }
@@ -892,8 +901,10 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
     if (this.isWrappedSegwit()) {
       const p2shP2wsh = bitcoin.payments.p2sh({
         redeem: bitcoin.payments.p2wsh({
-          redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys) }),
+          redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys), network: getNetwork() }),
+          network: getNetwork(),
         }),
+        network: getNetwork(),
       });
       const witnessScript = p2shP2wsh?.redeem?.redeem?.output;
       const redeemScript = p2shP2wsh?.redeem?.output;
@@ -910,7 +921,8 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
     if (this.isNativeSegwit()) {
       // not needed by coldcard, apparently..?
       const p2wsh = bitcoin.payments.p2wsh({
-        redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys) }),
+        redeem: bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys), network: getNetwork() }),
+        network: getNetwork(),
       });
       const witnessScript = p2wsh?.redeem?.output;
       if (!witnessScript) {
@@ -983,7 +995,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
     const { inputs, outputs, fee } = this.coinselect(utxos, targets, feeRate);
     sequence = sequence || AbstractHDElectrumWallet.defaultRBFSequence;
 
-    let psbt = new bitcoin.Psbt();
+    let psbt = new bitcoin.Psbt({ network: getNetwork() });
 
     let c = 0;
     inputs.forEach(input => {
@@ -1032,7 +1044,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
             seed = MultisigHDWallet.convertElectrumMnemonicToSeed(cosigner, passphrase);
           }
 
-          const hdRoot = bip32.fromSeed(seed);
+          const hdRoot = bip32.fromSeed(seed, getNetwork());
           psbt.signInputHD(cc, hdRoot);
           signaturesMade++;
         }
@@ -1074,7 +1086,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
   }
 
   static isPathValid(path: string): boolean {
-    const root = bip32.fromSeed(new Uint8Array(32));
+    const root = bip32.fromSeed(new Uint8Array(32), getNetwork());
     try {
       root.derivePath(path);
       return true;
@@ -1171,13 +1183,13 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
         let hdRoot;
         if (MultisigHDWallet.isXprvString(cosigner)) {
           const xprv = MultisigHDWallet.convertMultisigXprvToRegularXprv(cosigner);
-          hdRoot = bip32.fromBase58(xprv);
+          hdRoot = bip32.fromBase58(xprv, getNetwork());
         } else {
           const passphrase = this._cosignersPassphrases[cosignerIndex];
           const seed = cosigner.startsWith(ELECTRUM_SEED_PREFIX)
             ? MultisigHDWallet.convertElectrumMnemonicToSeed(cosigner, passphrase)
             : bip39.mnemonicToSeedSync(cosigner, passphrase);
-          hdRoot = bip32.fromSeed(seed);
+          hdRoot = bip32.fromSeed(seed, getNetwork());
         }
 
         try {
@@ -1206,7 +1218,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
             // if hdRoot.depth !== 0 than this hdnode was recovered from xprv and it already has been set to root path
             const child = hdRoot.derivePath(path);
             if (child.privateKey && psbt.inputHasPubkey(cc, child.publicKey)) {
-              const keyPair = ECPair.fromPrivateKey(child.privateKey);
+              const keyPair = ECPair.fromPrivateKey(child.privateKey, { network: getNetwork() });
               try {
                 psbt.signInput(cc, keyPair);
               } catch (_) {}

--- a/class/wallets/segwit-bech32-wallet.ts
+++ b/class/wallets/segwit-bech32-wallet.ts
@@ -6,6 +6,7 @@ import ecc from '../../blue_modules/noble_ecc';
 import { LegacyWallet } from './legacy-wallet';
 import { CreateTransactionResult, CreateTransactionUtxo } from './types';
 import { hexToUint8Array } from '../../blue_modules/uint8array-extras';
+import { getNetwork } from '../../models/network';
 
 const ECPair = ECPairFactory(ecc);
 
@@ -22,13 +23,14 @@ export class SegwitBech32Wallet extends LegacyWallet {
     if (this._address) return this._address;
     let address;
     try {
-      const keyPair = ECPair.fromWIF(this.secret);
+      const keyPair = ECPair.fromWIF(this.secret, getNetwork());
       if (!keyPair.compressed) {
         console.warn('only compressed public keys are good for segwit');
         return false;
       }
       address = bitcoin.payments.p2wpkh({
         pubkey: keyPair.publicKey,
+        network: getNetwork(),
       }).address;
     } catch (err) {
       return false;
@@ -44,7 +46,7 @@ export class SegwitBech32Wallet extends LegacyWallet {
       return (
         bitcoin.payments.p2wpkh({
           pubkey,
-          network: bitcoin.networks.bitcoin,
+          network: getNetwork(),
         }).address ?? false
       );
     } catch (_) {
@@ -64,7 +66,7 @@ export class SegwitBech32Wallet extends LegacyWallet {
       return (
         bitcoin.payments.p2wpkh({
           output: scriptPubKey2,
-          network: bitcoin.networks.bitcoin,
+          network: getNetwork(),
         }).address ?? false
       );
     } catch (_) {
@@ -84,17 +86,17 @@ export class SegwitBech32Wallet extends LegacyWallet {
     if (targets.length === 0) throw new Error('No destination provided');
     const { inputs, outputs, fee } = this.coinselect(utxos, targets, feeRate);
     sequence = sequence || 0xffffffff; // disable RBF by default
-    const psbt = new bitcoin.Psbt();
+    const psbt = new bitcoin.Psbt({ network: getNetwork() });
     let c = 0;
     const values: Record<number, number> = {};
-    const keyPair = ECPair.fromWIF(this.secret);
+    const keyPair = ECPair.fromWIF(this.secret, getNetwork());
 
     inputs.forEach(input => {
       values[c] = input.value;
       c++;
 
       const pubkey = keyPair.publicKey;
-      const p2wpkh = bitcoin.payments.p2wpkh({ pubkey });
+      const p2wpkh = bitcoin.payments.p2wpkh({ pubkey, network: getNetwork() });
       if (!p2wpkh.output) {
         throw new Error('Internal error: no p2wpkh.output during createTransaction()');
       }

--- a/class/wallets/segwit-p2sh-wallet.ts
+++ b/class/wallets/segwit-p2sh-wallet.ts
@@ -6,6 +6,7 @@ import ecc from '../../blue_modules/noble_ecc';
 import { LegacyWallet } from './legacy-wallet';
 import { CreateTransactionResult, CreateTransactionUtxo } from './types';
 import { hexToUint8Array } from '../../blue_modules/uint8array-extras';
+import { getNetwork } from '../../models/network';
 
 const ECPair = ECPairFactory(ecc);
 
@@ -17,7 +18,8 @@ const ECPair = ECPairFactory(ecc);
  */
 function pubkeyToP2shSegwitAddress(pubkey: Uint8Array): string | false {
   const { address } = bitcoin.payments.p2sh({
-    redeem: bitcoin.payments.p2wpkh({ pubkey }),
+    redeem: bitcoin.payments.p2wpkh({ pubkey, network: getNetwork() }),
+    network: getNetwork(),
   });
   return address ?? false;
 }
@@ -52,7 +54,7 @@ export class SegwitP2SHWallet extends LegacyWallet {
       return (
         bitcoin.payments.p2sh({
           output: scriptPubKey2,
-          network: bitcoin.networks.bitcoin,
+          network: getNetwork(),
         }).address ?? false
       );
     } catch (_) {
@@ -64,7 +66,7 @@ export class SegwitP2SHWallet extends LegacyWallet {
     if (this._address) return this._address;
     let address;
     try {
-      const keyPair = ECPair.fromWIF(this.secret);
+      const keyPair = ECPair.fromWIF(this.secret, getNetwork());
       const pubKey = keyPair.publicKey;
       if (!keyPair.compressed) {
         console.warn('only compressed public keys are good for segwit');
@@ -102,18 +104,18 @@ export class SegwitP2SHWallet extends LegacyWallet {
     if (targets.length === 0) throw new Error('No destination provided');
     const { inputs, outputs, fee } = this.coinselect(utxos, targets, feeRate);
     sequence = sequence || 0xffffffff; // disable RBF by default
-    const psbt = new bitcoin.Psbt();
+    const psbt = new bitcoin.Psbt({ network: getNetwork() });
     let c = 0;
     const values: Record<number, number> = {};
-    const keyPair = ECPair.fromWIF(this.secret);
+    const keyPair = ECPair.fromWIF(this.secret, getNetwork());
 
     inputs.forEach(input => {
       values[c] = input.value;
       c++;
 
       const pubkey = keyPair.publicKey;
-      const p2wpkh = bitcoin.payments.p2wpkh({ pubkey });
-      const p2sh = bitcoin.payments.p2sh({ redeem: p2wpkh });
+      const p2wpkh = bitcoin.payments.p2wpkh({ pubkey, network: getNetwork() });
+      const p2sh = bitcoin.payments.p2sh({ redeem: p2wpkh, network: getNetwork() });
       if (!p2sh.output) {
         throw new Error('Internal error: no p2sh.output during createTransaction()');
       }

--- a/class/wallets/taproot-wallet.ts
+++ b/class/wallets/taproot-wallet.ts
@@ -7,6 +7,7 @@ import { SegwitBech32Wallet } from './segwit-bech32-wallet';
 import { CreateTransactionResult, CreateTransactionUtxo } from './types.ts';
 import { CoinSelectTarget } from 'coinselect';
 import { hexToUint8Array } from '../../blue_modules/uint8array-extras';
+import { getNetwork } from '../../models/network';
 const ECPair = ECPairFactory(ecc);
 
 export class TaprootWallet extends SegwitBech32Wallet {
@@ -27,7 +28,7 @@ export class TaprootWallet extends SegwitBech32Wallet {
   static scriptPubKeyToAddress(scriptPubKey: string): string | false {
     try {
       const publicKey = hexToUint8Array(scriptPubKey);
-      return bitcoin.address.fromOutputScript(publicKey, bitcoin.networks.bitcoin);
+      return bitcoin.address.fromOutputScript(publicKey, getNetwork());
     } catch (_) {
       return false;
     }
@@ -53,7 +54,7 @@ export class TaprootWallet extends SegwitBech32Wallet {
     if (this._address) return this._address;
     let address;
     try {
-      const keyPair = ECPair.fromWIF(this.secret);
+      const keyPair = ECPair.fromWIF(this.secret, getNetwork());
       if (!keyPair.compressed) {
         console.warn('only compressed public keys are good for segwit');
         return false;
@@ -61,6 +62,7 @@ export class TaprootWallet extends SegwitBech32Wallet {
       const xOnlyPubkey = keyPair.publicKey.subarray(1, 33);
       address = bitcoin.payments.p2tr({
         internalPubkey: xOnlyPubkey,
+        network: getNetwork(),
       }).address;
     } catch (err: any) {
       console.log(err.message);
@@ -85,17 +87,18 @@ export class TaprootWallet extends SegwitBech32Wallet {
     sequence = sequence || 0xffffffff; // default if not passed
 
     // Derive keyPair & x-only pubkey
-    const keyPair = ECPair.fromWIF(this.secret);
+    const keyPair = ECPair.fromWIF(this.secret, getNetwork());
     const pubkey = keyPair.publicKey; // compressed: 0x02/03 || X
     const xOnlyPub = pubkey.subarray(1, 33); // strip prefix
 
     // Precompute the P2TR payment (to rebuild scriptPubKey)
     const p2tr = bitcoin.payments.p2tr({
       internalPubkey: xOnlyPub,
+      network: getNetwork(),
     });
     if (!p2tr.output) throw new Error('Could not build p2tr.output');
 
-    const psbt = new bitcoin.Psbt();
+    const psbt = new bitcoin.Psbt({ network: getNetwork() });
 
     // Add Taproot inputs
     inputs.forEach((input, idx) => {

--- a/class/wallets/watch-only-wallet.ts
+++ b/class/wallets/watch-only-wallet.ts
@@ -2,6 +2,7 @@ import BIP32Factory from 'bip32';
 import * as bitcoin from 'bitcoinjs-lib';
 
 import ecc from '../../blue_modules/noble_ecc';
+import { getNetwork } from '../../models/network';
 import { AbstractWallet } from './abstract-wallet';
 import { HDLegacyP2PKHWallet } from './hd-legacy-p2pkh-wallet';
 import { HDSegwitBech32Wallet } from './hd-segwit-bech32-wallet';
@@ -9,6 +10,29 @@ import { HDSegwitP2SHWallet } from './hd-segwit-p2sh-wallet';
 import { LegacyWallet } from './legacy-wallet';
 import { THDWalletForWatchOnly } from './types';
 import { HDTaprootWallet } from './hd-taproot-wallet';
+
+/**
+ * Checks if a string starts with any known extended public key prefix (mainnet or testnet).
+ * Mainnet: xpub, ypub, zpub. Testnet: tpub, upub, vpub.
+ */
+function isExtendedPubKey(secret: string): boolean {
+  return /^(xpub|ypub|zpub|tpub|upub|vpub)/.test(secret);
+}
+
+/** Returns true if the secret is a zpub (mainnet) or vpub (testnet) — native segwit BIP84 */
+function isZpub(secret: string): boolean {
+  return secret.startsWith('zpub') || secret.startsWith('vpub');
+}
+
+/** Returns true if the secret is a ypub (mainnet) or upub (testnet) — wrapped segwit BIP49 */
+function isYpub(secret: string): boolean {
+  return secret.startsWith('ypub') || secret.startsWith('upub');
+}
+
+/** Returns true if the secret is an xpub (mainnet) or tpub (testnet) — legacy BIP44 */
+function isXpub(secret: string): boolean {
+  return secret.startsWith('xpub') || secret.startsWith('tpub');
+}
 
 const bip32 = BIP32Factory(ecc);
 
@@ -58,10 +82,10 @@ export class WatchOnlyWallet extends LegacyWallet {
   }
 
   valid() {
-    if (this.secret.startsWith('xpub') || this.secret.startsWith('ypub') || this.secret.startsWith('zpub')) return this.isXpubValid();
+    if (isExtendedPubKey(this.secret)) return this.isXpubValid();
 
     try {
-      bitcoin.address.toOutputScript(this.getAddress());
+      bitcoin.address.toOutputScript(this.getAddress(), getNetwork());
       return true;
     } catch (_) {
       return false;
@@ -96,10 +120,10 @@ export class WatchOnlyWallet extends LegacyWallet {
       hdWalletInstance = new HDSegwitP2SHWallet();
     }
     // Final fallback to xpub prefix (legacy behavior for bare xpub/ypub/zpub)
-    else if (this.secret.startsWith('xpub')) {
+    else if (isXpub(this.secret)) {
       hdWalletInstance = new HDLegacyP2PKHWallet();
-    } else if (this.secret.startsWith('ypub')) hdWalletInstance = new HDSegwitP2SHWallet();
-    else if (this.secret.startsWith('zpub')) hdWalletInstance = new HDSegwitBech32Wallet();
+    } else if (isYpub(this.secret)) hdWalletInstance = new HDSegwitP2SHWallet();
+    else if (isZpub(this.secret)) hdWalletInstance = new HDSegwitBech32Wallet();
     else return this;
     hdWalletInstance._xpub = this.secret;
 
@@ -143,7 +167,7 @@ export class WatchOnlyWallet extends LegacyWallet {
   }
 
   async fetchBalance() {
-    if (this.secret.startsWith('xpub') || this.secret.startsWith('ypub') || this.secret.startsWith('zpub')) {
+    if (isExtendedPubKey(this.secret)) {
       if (!this._hdWalletInstance) this.init();
       if (!this._hdWalletInstance) throw new Error('Internal error: _hdWalletInstance is not initialized');
       return this._hdWalletInstance.fetchBalance();
@@ -154,7 +178,7 @@ export class WatchOnlyWallet extends LegacyWallet {
   }
 
   async fetchTransactions() {
-    if (this.secret.startsWith('xpub') || this.secret.startsWith('ypub') || this.secret.startsWith('zpub')) {
+    if (isExtendedPubKey(this.secret)) {
       if (!this._hdWalletInstance) this.init();
       if (!this._hdWalletInstance) throw new Error('Internal error: _hdWalletInstance is not initialized');
       return this._hdWalletInstance.fetchTransactions();
@@ -252,7 +276,7 @@ export class WatchOnlyWallet extends LegacyWallet {
   }
 
   isHd() {
-    return this.secret.startsWith('xpub') || this.secret.startsWith('ypub') || this.secret.startsWith('zpub');
+    return isExtendedPubKey(this.secret);
   }
 
   weOwnAddress(address: string) {
@@ -261,13 +285,13 @@ export class WatchOnlyWallet extends LegacyWallet {
       throw new Error('Not initialized');
     }
 
-    if (address && address.startsWith('BC1')) address = address.toLowerCase();
+    if (address && (address.startsWith('BC1') || address.startsWith('TB1'))) address = address.toLowerCase();
 
     return this.getAddress() === address;
   }
 
   allowMasterFingerprint() {
-    return this.getSecret().startsWith('zpub') || this.getSecret().startsWith('ypub') || this.getSecret().startsWith('xpub');
+    return isExtendedPubKey(this.getSecret());
   }
 
   useWithHardwareWalletEnabled() {
@@ -290,15 +314,15 @@ export class WatchOnlyWallet extends LegacyWallet {
     let xpub;
 
     try {
-      if (this.secret.startsWith('zpub')) {
+      if (isZpub(this.secret)) {
         xpub = this._zpubToXpub(this.secret);
-      } else if (this.secret.startsWith('ypub')) {
+      } else if (isYpub(this.secret)) {
         xpub = AbstractWallet._ypubToXpub(this.secret);
       } else {
         xpub = this.secret;
       }
 
-      const hdNode = bip32.fromBase58(xpub);
+      const hdNode = bip32.fromBase58(xpub, getNetwork());
       hdNode.derive(0);
       return true;
     } catch (_) {}

--- a/components/Context/SettingsProvider.tsx
+++ b/components/Context/SettingsProvider.tsx
@@ -16,8 +16,11 @@ import { BitcoinUnit } from '../../models/bitcoinUnits';
 import { TotalWalletsBalanceKey, TotalWalletsBalancePreferredUnit } from '../TotalWalletsBalance';
 import { BLOCK_EXPLORERS, getBlockExplorerUrl, saveBlockExplorer, BlockExplorer, normalizeUrl } from '../../models/blockExplorer';
 import * as BlueElectrum from '../../blue_modules/BlueElectrum';
+import { setNetworkType as setGlobalNetworkType, NetworkType } from '../../models/network';
 import { isBalanceDisplayAllowed, setBalanceDisplayAllowed } from '../../hooks/useWidgetCommunication';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const NETWORK_TYPE_KEY = 'network_type';
 
 const getDoNotTrackStorage = async (): Promise<boolean> => {
   try {
@@ -99,6 +102,8 @@ interface SettingsContextType {
   setBlockExplorerStorage: (explorer: BlockExplorer) => Promise<boolean>;
   isElectrumDisabled: boolean;
   setIsElectrumDisabled: (value: boolean) => void;
+  networkType: NetworkType;
+  setNetworkTypeStorage: (network: NetworkType) => Promise<void>;
 }
 
 const defaultSettingsContext: SettingsContextType = {
@@ -128,6 +133,8 @@ const defaultSettingsContext: SettingsContextType = {
   setBlockExplorerStorage: async () => false,
   isElectrumDisabled: false,
   setIsElectrumDisabled: () => {},
+  networkType: 'mainnet' as NetworkType,
+  setNetworkTypeStorage: async () => {},
 };
 
 export const SettingsContext = createContext<SettingsContextType>(defaultSettingsContext);
@@ -146,6 +153,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = React.m
   const [totalBalancePreferredUnit, setTotalBalancePreferredUnit] = useState<BitcoinUnit>(BitcoinUnit.BTC);
   const [selectedBlockExplorer, setSelectedBlockExplorer] = useState<BlockExplorer>(BLOCK_EXPLORERS.default);
   const [isElectrumDisabled, setIsElectrumDisabled] = useState<boolean>(true);
+  const [networkType, setNetworkType] = useState<NetworkType>('mainnet');
+  const [settingsLoaded, setSettingsLoaded] = useState<boolean>(false);
 
   const { walletsInitialized } = useStorage();
 
@@ -160,6 +169,12 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = React.m
       const promises: Promise<void>[] = [
         BlueElectrum.isDisabled().then(disabled => {
           setIsElectrumDisabled(disabled);
+        }),
+        DefaultPreference.get(NETWORK_TYPE_KEY).then(network => {
+          if (network === 'testnet' || network === 'signet') {
+            setNetworkType(network);
+            setGlobalNetworkType(network);
+          }
         }),
         getIsHandOffUseEnabled().then(handOff => {
           setIsHandOffUseEnabledState(handOff);
@@ -201,6 +216,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = React.m
           console.error(`Error loading setting ${index}:`, result.reason);
         }
       });
+
+      setSettingsLoaded(true);
     };
 
     loadSettings();
@@ -219,10 +236,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = React.m
   }, []);
 
   useEffect(() => {
-    if (walletsInitialized) {
-      isElectrumDisabled ? BlueElectrum.forceDisconnect() : BlueElectrum.connectMain();
+    if (walletsInitialized && settingsLoaded) {
+      isElectrumDisabled ? BlueElectrum.forceDisconnect() : BlueElectrum.connectMain(networkType);
     }
-  }, [isElectrumDisabled, walletsInitialized]);
+  }, [isElectrumDisabled, walletsInitialized, networkType, settingsLoaded]);
 
   const setPreferredFiatCurrencyStorage = useCallback(async (currency: TFiatUnit): Promise<void> => {
     try {
@@ -323,6 +340,24 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = React.m
     }
   }, []);
 
+  const setNetworkTypeStorage = useCallback(
+    async (network: NetworkType): Promise<void> => {
+      try {
+        DefaultPreference.setName(GROUP_IO_BLUEWALLET);
+        await DefaultPreference.set(NETWORK_TYPE_KEY, network);
+        setNetworkType(network);
+        setGlobalNetworkType(network);
+        BlueElectrum.forceDisconnect();
+        if (!isElectrumDisabled) {
+          BlueElectrum.connectMain(network);
+        }
+      } catch (e) {
+        console.error('Error setting networkType:', e);
+      }
+    },
+    [isElectrumDisabled],
+  );
+
   const setBlockExplorerStorage = useCallback(async (explorer: BlockExplorer): Promise<boolean> => {
     try {
       const success = await saveBlockExplorer(explorer.url);
@@ -364,6 +399,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = React.m
       setBlockExplorerStorage,
       isElectrumDisabled,
       setIsElectrumDisabled,
+      networkType,
+      setNetworkTypeStorage,
     }),
     [
       preferredFiatCurrency,
@@ -391,6 +428,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = React.m
       selectedBlockExplorer,
       setBlockExplorerStorage,
       isElectrumDisabled,
+      networkType,
+      setNetworkTypeStorage,
     ],
   );
 

--- a/components/TransactionListItem.tsx
+++ b/components/TransactionListItem.tsx
@@ -14,6 +14,7 @@ import TransactionPendingIcon from '../components/icons/TransactionPendingIcon';
 import loc, { formatBalanceWithoutSuffix, formatTransactionListDate, transactionTimeToReadable } from '../loc';
 import { BitcoinUnit } from '../models/bitcoinUnits';
 import { useSettings } from '../hooks/context/useSettings';
+import { adjustBlockExplorerUrlForNetwork } from '../models/blockExplorer';
 import { useTheme } from './themes';
 import { Action } from './types';
 import { useExtendedNavigation } from '../hooks/useExtendedNavigation';
@@ -99,7 +100,8 @@ export const TransactionListItem: React.FC<TransactionListItemProps> = memo(
     const { colors } = useTheme();
     const { navigate } = useExtendedNavigation<NavigationProps>();
     const { txMetadata, counterpartyMetadata, wallets } = useStorage();
-    const { language, selectedBlockExplorer } = useSettings();
+    const { language, selectedBlockExplorer, networkType } = useSettings();
+    const blockExplorerUrl = adjustBlockExplorerUrlForNetwork(selectedBlockExplorer.url, networkType);
     const insets = useSafeAreaInsets();
     const containerStyle = useMemo(
       () => ({
@@ -344,16 +346,16 @@ export const TransactionListItem: React.FC<TransactionListItemProps> = memo(
     const handleOnCopyTransactionID = useCallback(() => Clipboard.setString(item.hash), [item.hash]);
     const handleOnCopyNote = useCallback(() => Clipboard.setString(noteForCopy ?? ''), [noteForCopy]);
     const handleOnViewOnBlockExplorer = useCallback(() => {
-      const url = `${selectedBlockExplorer.url}/tx/${item.hash}`;
+      const url = `${blockExplorerUrl}/tx/${item.hash}`;
       Linking.canOpenURL(url).then(supported => {
         if (supported) {
           Linking.openURL(url);
         }
       });
-    }, [item.hash, selectedBlockExplorer]);
+    }, [item.hash, blockExplorerUrl]);
     const handleCopyOpenInBlockExplorerPress = useCallback(() => {
-      Clipboard.setString(`${selectedBlockExplorer.url}/tx/${item.hash}`);
-    }, [item.hash, selectedBlockExplorer]);
+      Clipboard.setString(`${blockExplorerUrl}/tx/${item.hash}`);
+    }, [item.hash, blockExplorerUrl]);
 
     const onToolTipPress = useCallback(
       (id: any) => {

--- a/loc/en.json
+++ b/loc/en.json
@@ -221,6 +221,8 @@
     "about_selftest": "Run self-test",
     "block_explorer_invalid_custom_url": "The URL provided is invalid. Please enter a valid URL starting with http:// or https://.",
     "about_selftest_electrum_disabled": "Self-testing is not available with Electrum Offline Mode. Please disable offline mode and try again.",
+    "network_select": "Select Network",
+    "network_restart": "Please restart the app for the network change to take full effect.",
     "about_selftest_ok": "All internal tests have passed successfully. The wallet works well.",
     "about_sm_github": "GitHub",
     "about_sm_telegram": "Telegram channel",

--- a/models/blockExplorer.ts
+++ b/models/blockExplorer.ts
@@ -1,5 +1,6 @@
 // blockExplorer.ts
 import DefaultPreference from 'react-native-default-preference';
+import { NetworkType } from './network';
 
 export interface BlockExplorer {
   key: string;
@@ -44,6 +45,31 @@ export const getDomain = (url: string): string => {
   } catch {
     return '';
   }
+};
+
+/**
+ * Adjusts a block explorer URL for the given network.
+ * e.g. mempool.space -> mempool.space/testnet4, blockstream.info -> blockstream.info/testnet
+ */
+export const adjustBlockExplorerUrlForNetwork = (url: string, network: NetworkType): string => {
+  if (network === 'mainnet') return url;
+
+  const normalized = normalizeUrl(url);
+  const networkPath = network === 'testnet' ? 'testnet4' : 'signet';
+
+  const domain = getDomain(normalized);
+
+  if (domain === 'mempool.space') {
+    return `${normalized}/${networkPath}`;
+  }
+  if (domain === 'blockstream.info') {
+    return `${normalized}/${network === 'testnet' ? 'testnet' : 'signet'}`;
+  }
+  if (domain === 'blockchair.com') {
+    return `${normalized.replace('/bitcoin', '')}/${network === 'testnet' ? 'bitcoin/testnet' : 'bitcoin/signet'}`;
+  }
+
+  return normalized;
 };
 
 const BLOCK_EXPLORER_STORAGE_KEY = 'blockExplorer';

--- a/models/network.ts
+++ b/models/network.ts
@@ -1,0 +1,33 @@
+import * as bitcoin from 'bitcoinjs-lib';
+
+export type NetworkType = 'mainnet' | 'testnet' | 'signet';
+
+let _networkType: NetworkType = 'mainnet';
+
+/**
+ * Sets the current network type. This should be called early during app initialization,
+ * before any wallet operations. Changing the network at runtime takes effect for new
+ * Electrum connections, but existing wallets in memory retain stale state — the user
+ * should restart the app after switching.
+ */
+export function setNetworkType(network: NetworkType): void {
+  _networkType = network;
+}
+
+/**
+ * Returns the bitcoinjs-lib network object for the current network.
+ * Testnet and signet both use bitcoin.networks.testnet (same address format, derivation paths).
+ */
+export function getNetwork(): bitcoin.Network {
+  if (_networkType === 'testnet' || _networkType === 'signet') {
+    return bitcoin.networks.testnet;
+  }
+  return bitcoin.networks.bitcoin;
+}
+
+/**
+ * Returns true if the current network is not mainnet.
+ */
+export function isTestnet(): boolean {
+  return _networkType !== 'mainnet';
+}

--- a/screen/send/Broadcast.tsx
+++ b/screen/send/Broadcast.tsx
@@ -11,6 +11,7 @@ import { useTheme } from '../../components/themes';
 import { platformSizing, platformLayout, getSettingsRowBackgroundColor, SettingsScrollView } from '../../components/platform';
 import loc from '../../loc';
 import { useSettings } from '../../hooks/context/useSettings';
+import { adjustBlockExplorerUrlForNetwork } from '../../models/blockExplorer';
 import { majorTomToGroundControl } from '../../blue_modules/notifications';
 import { scanQrHelper } from '../../helpers/scan-qr';
 import { BlueSpacing10, BlueSpacing20 } from '../../components/BlueSpacing';
@@ -30,7 +31,8 @@ const Broadcast: React.FC = () => {
   const sizing = platformSizing;
   const layout = platformLayout;
   const [broadcastResult, setBroadcastResult] = useState<string>(BROADCAST_RESULT.none);
-  const { selectedBlockExplorer } = useSettings();
+  const { selectedBlockExplorer, networkType } = useSettings();
+  const blockExplorerUrl = adjustBlockExplorerUrlForNetwork(selectedBlockExplorer.url, networkType);
   const rowBackgroundColor = getSettingsRowBackgroundColor(colors, dark);
 
   const styles = StyleSheet.create({
@@ -191,7 +193,7 @@ const Broadcast: React.FC = () => {
             <BlueSpacing20 />
           </>
         )}
-        {BROADCAST_RESULT.success === broadcastResult && tx && <SuccessScreen tx={tx} url={`${selectedBlockExplorer.url}/tx/${tx}`} />}
+        {BROADCAST_RESULT.success === broadcastResult && tx && <SuccessScreen tx={tx} url={`${blockExplorerUrl}/tx/${tx}`} />}
       </View>
     </SettingsScrollView>
   );

--- a/screen/send/Confirm.tsx
+++ b/screen/send/Confirm.tsx
@@ -26,6 +26,7 @@ import { HDSegwitBech32Wallet } from '../../class';
 import { useSettings } from '../../hooks/context/useSettings';
 import { majorTomToGroundControl } from '../../blue_modules/notifications';
 import { uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
+import { getNetwork } from '../../models/network';
 
 enum ActionType {
   SET_LOADING = 'SET_LOADING',
@@ -170,7 +171,8 @@ const Confirm: React.FC = () => {
     if (!(recipients.length > 0) || !recipients[0].address) {
       return undefined;
     }
-    return bitcoin.address.toOutputScript(recipients[0].address, bitcoin.networks.bitcoin);
+    const addr = recipients[0].address;
+    return bitcoin.address.toOutputScript(addr, getNetwork());
   };
 
   const handleSendTransaction = async () => {

--- a/screen/send/success.tsx
+++ b/screen/send/success.tsx
@@ -12,6 +12,7 @@ import { BitcoinUnit } from '../../models/bitcoinUnits';
 import HandOffComponent from '../../components/HandOffComponent';
 import { HandOffActivityType } from '../../components/types';
 import { useSettings } from '../../hooks/context/useSettings';
+import { adjustBlockExplorerUrlForNetwork } from '../../models/blockExplorer';
 import { SendDetailsStackParamList } from '../../navigation/SendDetailsStackParamList.ts';
 import { popToTop } from '../../NavigationService.ts';
 
@@ -19,7 +20,8 @@ type RouteProps = RouteProp<SendDetailsStackParamList, 'Success'>;
 
 const Success = () => {
   const { colors } = useTheme();
-  const { selectedBlockExplorer } = useSettings();
+  const { selectedBlockExplorer, networkType } = useSettings();
+  const blockExplorerUrl = adjustBlockExplorerUrlForNetwork(selectedBlockExplorer.url, networkType);
   const route = useRoute<RouteProps>();
   const { amount, fee, amountUnit = BitcoinUnit.BTC, invoiceDescription = '', txid } = route.params || {};
   const stylesHook = StyleSheet.create({
@@ -53,7 +55,7 @@ const Success = () => {
         <HandOffComponent
           title={loc.transactions.details_title}
           type={HandOffActivityType.ViewInBlockExplorer}
-          url={`${selectedBlockExplorer.url}/tx/${txid}`}
+          url={`${blockExplorerUrl}/tx/${txid}`}
         />
       )}
     </SafeArea>

--- a/screen/settings/About.tsx
+++ b/screen/settings/About.tsx
@@ -1,6 +1,6 @@
 import Clipboard from '@react-native-clipboard/clipboard';
-import React, { useCallback } from 'react';
-import { Alert, Image, Linking, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useState } from 'react';
+import { ActionSheetIOS, Alert, Image, Linking, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { getApplicationName, getBuildNumber, getBundleId, getUniqueIdSync, getVersion, hasGmsSync } from 'react-native-device-info';
 import Icon from '@react-native-vector-icons/fontawesome6';
 
@@ -20,6 +20,7 @@ import {
 } from '../../components/platform';
 import { useTheme } from '../../components/themes';
 import { useSettings } from '../../hooks/context/useSettings';
+import { NetworkType } from '../../models/network';
 import { useExtendedNavigation } from '../../hooks/useExtendedNavigation';
 import loc, { formatStringAddTwoWhiteSpaces } from '../../loc';
 
@@ -33,8 +34,9 @@ interface AboutItem extends SettingsListItemProps {
 
 const About: React.FC = () => {
   const { navigate } = useExtendedNavigation();
-  const { isElectrumDisabled } = useSettings();
+  const { isElectrumDisabled, networkType, setNetworkTypeStorage } = useSettings();
   const { colors } = useTheme();
+  const [, setLogoTapCount] = useState(0);
 
   const handleOnReleaseNotesPress = useCallback(() => {
     navigate('ReleaseNotes');
@@ -76,6 +78,52 @@ const About: React.FC = () => {
     }
   }, []);
 
+  const handleLogoPress = useCallback(() => {
+    setLogoTapCount(prev => {
+      const next = prev + 1;
+      if (next >= 10) {
+        const networks: { label: string; value: NetworkType }[] = [
+          { label: `Mainnet${networkType === 'mainnet' ? ' (current)' : ''}`, value: 'mainnet' },
+          { label: `Testnet${networkType === 'testnet' ? ' (current)' : ''}`, value: 'testnet' },
+          { label: `Signet${networkType === 'signet' ? ' (current)' : ''}`, value: 'signet' },
+        ];
+
+        if (Platform.OS === 'ios') {
+          ActionSheetIOS.showActionSheetWithOptions(
+            {
+              title: loc.settings.network_select,
+              options: [...networks.map(n => n.label), loc._.cancel],
+              cancelButtonIndex: networks.length,
+            },
+            buttonIndex => {
+              if (buttonIndex < networks.length && networks[buttonIndex].value !== networkType) {
+                setNetworkTypeStorage(networks[buttonIndex].value).then(() => {
+                  Alert.alert(loc.settings.network_select, loc.settings.network_restart);
+                });
+              }
+            },
+          );
+        } else {
+          Alert.alert(loc.settings.network_select, undefined, [
+            ...networks.map(n => ({
+              text: n.label,
+              onPress: () => {
+                if (n.value !== networkType) {
+                  setNetworkTypeStorage(n.value).then(() => {
+                    Alert.alert(loc.settings.network_select, loc.settings.network_restart);
+                  });
+                }
+              },
+            })),
+            { text: loc._.cancel, style: 'cancel' as const },
+          ]);
+        }
+        return 0;
+      }
+      return next;
+    });
+  }, [networkType, setNetworkTypeStorage]);
+
   const handlePerformanceTest = useCallback(async () => {
     const secret = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
     const w = new HDSegwitBech32Wallet();
@@ -102,7 +150,9 @@ const About: React.FC = () => {
           <SettingsSection compact>
             <SettingsCard style={[styles.card, styles.headerCard]}>
               <View style={styles.center}>
-                <Image style={styles.logo} source={require('../../img/bluebeast.png')} />
+                <TouchableOpacity onPress={handleLogoPress} activeOpacity={1}>
+                  <Image style={styles.logo} source={require('../../img/bluebeast.png')} />
+                </TouchableOpacity>
                 <Text style={[styles.textFree, { color: colors.foregroundColor }]}>{loc.settings.about_free}</Text>
                 <Text style={[styles.textBackup, { color: colors.alternativeTextColor }]}>
                   {formatStringAddTwoWhiteSpaces(loc.settings.about_backup)}
@@ -230,6 +280,7 @@ const About: React.FC = () => {
   }, [
     colors.foregroundColor,
     colors.alternativeTextColor,
+    handleLogoPress,
     handleOnRatePress,
     handleOnXPress,
     handleOnTelegramPress,

--- a/screen/settings/ElectrumSettings.tsx
+++ b/screen/settings/ElectrumSettings.tsx
@@ -4,7 +4,11 @@ import { Alert, Keyboard, LayoutAnimation, Platform, StyleSheet, Switch, Text, T
 import DefaultPreference from 'react-native-default-preference';
 
 import * as BlueElectrum from '../../blue_modules/BlueElectrum';
-import { hardcodedPeers, presentResetToDefaultsAlert, suggestedServers } from '../../blue_modules/BlueElectrum';
+import {
+  getHardcodedPeersForCurrentNetwork,
+  getSuggestedServersForCurrentNetwork,
+  presentResetToDefaultsAlert,
+} from '../../blue_modules/BlueElectrum';
 import { GROUP_IO_BLUEWALLET } from '../../blue_modules/currency';
 import triggerHapticFeedback, { HapticFeedbackTypes, triggerSelectionHapticFeedback } from '../../blue_modules/hapticFeedback';
 import DeeplinkSchemaMatch from '../../class/deeplink-schema-match';
@@ -65,6 +69,8 @@ const ElectrumSettings: React.FC = () => {
     tcp: '',
     ssl: '',
   });
+  const hardcodedPeers = useMemo(() => getHardcodedPeersForCurrentNetwork(), []);
+  const suggestedServers = useMemo(() => getSuggestedServersForCurrentNetwork(), []);
 
   const stylesHook = StyleSheet.create({
     inputWrap: {
@@ -147,7 +153,7 @@ const ElectrumSettings: React.FC = () => {
     return () => {
       if (configIntervalRef.current) clearInterval(configIntervalRef.current);
     };
-  }, []);
+  }, [hardcodedPeers, suggestedServers]);
 
   useEffect(() => {
     fetchData();
@@ -240,7 +246,7 @@ const ElectrumSettings: React.FC = () => {
         setIsLoading(false);
       }
     },
-    [host, port, sslPort, fetchData, serverHistory],
+    [host, port, sslPort, fetchData, serverHistory, hardcodedPeers],
   );
 
   const selectServer = useCallback(
@@ -402,7 +408,7 @@ const ElectrumSettings: React.FC = () => {
     actions.push(resetToDefaults);
 
     return actions;
-  }, [config?.connected, config?.host, config.port, createServerAction, host, isPreferred, serverHistory]);
+  }, [config?.connected, config?.host, config.port, createServerAction, host, isPreferred, serverHistory, suggestedServers]);
 
   const HeaderRight = useMemo(
     () => <HeaderMenuButton actions={generateToolTipActions()} onPressMenuItem={onPressMenuItem} />,

--- a/screen/settings/SelfTest.tsx
+++ b/screen/settings/SelfTest.tsx
@@ -27,6 +27,7 @@ import presentAlert from '../../components/Alert';
 import Button from '../../components/Button';
 import SaveFileButton from '../../components/SaveFileButton';
 import loc from '../../loc';
+import { getNetwork } from '../../models/network';
 import { CreateTransactionUtxo } from '../../class/wallets/types';
 import { BlueSpacing20 } from '../../components/BlueSpacing';
 import { BlueLoading } from '../../components/BlueLoading';
@@ -270,16 +271,16 @@ export default class SelfTest extends Component {
       const mnemonic =
         'honey risk juice trip orient galaxy win situate shoot anchor bounce remind horse traffic exotic since escape mimic ramp skin judge owner topple erode';
       const seed = bip39.mnemonicToSeedSync(mnemonic);
-      const root = bip32.fromSeed(seed);
+      const root = bip32.fromSeed(seed, getNetwork());
 
       const path = "m/49'/0'/0'/0/0";
       const child = root.derivePath(path);
       const address = bitcoin.payments.p2sh({
         redeem: bitcoin.payments.p2wpkh({
           pubkey: child.publicKey,
-          network: bitcoin.networks.bitcoin,
+          network: getNetwork(),
         }),
-        network: bitcoin.networks.bitcoin,
+        network: getNetwork(),
       }).address;
 
       if (address !== '3GcKN7q7gZuZ8eHygAhHrvPa5zZbG5Q1rK') {

--- a/screen/transactions/TransactionDetails.tsx
+++ b/screen/transactions/TransactionDetails.tsx
@@ -19,6 +19,7 @@ import { DetailViewStackParamList } from '../../navigation/DetailViewStackParamL
 import { useStorage } from '../../hooks/context/useStorage';
 import { HandOffActivityType } from '../../components/types';
 import { useSettings } from '../../hooks/context/useSettings';
+import { adjustBlockExplorerUrlForNetwork } from '../../models/blockExplorer';
 import SafeAreaScrollView from '../../components/SafeAreaScrollView';
 import { BlueSpacing20 } from '../../components/BlueSpacing';
 import { BlueLoading } from '../../components/BlueLoading';
@@ -66,7 +67,8 @@ const TransactionDetails = () => {
   const { navigate } = useExtendedNavigation<NavigationProps>();
   const { hash, walletID } = useRoute<RouteProps>().params;
   const { saveToDisk, txMetadata, counterpartyMetadata, wallets, getTransactions } = useStorage();
-  const { selectedBlockExplorer } = useSettings();
+  const { selectedBlockExplorer, networkType } = useSettings();
+  const blockExplorerUrl = adjustBlockExplorerUrlForNetwork(selectedBlockExplorer.url, networkType);
   const [from, setFrom] = useState<string[]>([]);
   const [to, setTo] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -157,7 +159,7 @@ const TransactionDetails = () => {
   }, [saveTransactionDetails]);
 
   const handleOnOpenTransactionOnBlockExplorerTapped = () => {
-    const url = `${selectedBlockExplorer.url}/tx/${tx?.hash}`;
+    const url = `${blockExplorerUrl}/tx/${tx?.hash}`;
     Linking.canOpenURL(url)
       .then(supported => {
         if (supported) {
@@ -182,7 +184,7 @@ const TransactionDetails = () => {
   };
 
   const handleCopyPress = (stringToCopy: string) => {
-    Clipboard.setString(stringToCopy !== actionKeys.CopyToClipboard ? stringToCopy : `${selectedBlockExplorer.url}/tx/${tx?.hash}`);
+    Clipboard.setString(stringToCopy !== actionKeys.CopyToClipboard ? stringToCopy : `${blockExplorerUrl}/tx/${tx?.hash}`);
   };
 
   if (isLoading || !tx) {
@@ -253,7 +255,7 @@ const TransactionDetails = () => {
       <HandOffComponent
         title={loc.transactions.details_title}
         type={HandOffActivityType.ViewInBlockExplorer}
-        url={`${selectedBlockExplorer.url}/tx/${tx.hash}`}
+        url={`${blockExplorerUrl}/tx/${tx.hash}`}
       />
       <BlueCard>
         <View>

--- a/screen/transactions/TransactionStatus.tsx
+++ b/screen/transactions/TransactionStatus.tsx
@@ -22,6 +22,7 @@ import { HandOffActivityType } from '../../components/types';
 import HeaderRightButton from '../../components/HeaderRightButton';
 import { DetailViewStackParamList } from '../../navigation/DetailViewStackParamList';
 import { useSettings } from '../../hooks/context/useSettings';
+import { adjustBlockExplorerUrlForNetwork } from '../../models/blockExplorer';
 import { useExtendedNavigation } from '../../hooks/useExtendedNavigation';
 import { BlueSpacing10, BlueSpacing20 } from '../../components/BlueSpacing';
 import { BlueLoading } from '../../components/BlueLoading';
@@ -117,7 +118,8 @@ const TransactionStatus: React.FC<TransactionStatusProps> = ({ transaction, txid
   const subscribedWallet = useWalletSubscribe(walletID!);
   const { navigate, setOptions, goBack } = useExtendedNavigation<NavigationProps>();
   const { colors } = useTheme();
-  const { selectedBlockExplorer } = useSettings();
+  const { selectedBlockExplorer, networkType } = useSettings();
+  const blockExplorerUrl = adjustBlockExplorerUrlForNetwork(selectedBlockExplorer.url, networkType);
   const fetchTxInterval = useRef<NodeJS.Timeout | undefined>(undefined);
   const stylesHook = StyleSheet.create({
     value: {
@@ -569,7 +571,7 @@ const TransactionStatus: React.FC<TransactionStatusProps> = ({ transaction, txid
           <HandOffComponent
             title={loc.transactions.details_title}
             type={HandOffActivityType.ViewInBlockExplorer}
-            url={`${selectedBlockExplorer.url}/tx/${tx.hash}`}
+            url={`${blockExplorerUrl}/tx/${tx.hash}`}
           />
 
           <View style={styles.container}>

--- a/screen/wallets/Add.tsx
+++ b/screen/wallets/Add.tsx
@@ -13,6 +13,7 @@ import WalletButton from '../../components/WalletButton';
 import loc from '../../loc';
 import { Chain } from '../../models/bitcoinUnits';
 import { useStorage } from '../../hooks/context/useStorage';
+import { useSettings } from '../../hooks/context/useSettings';
 import { CommonToolTipActions } from '../../typings/CommonToolTipActions';
 import { Action } from '../../components/types';
 import { getLNDHub } from '../../helpers/lndHub';
@@ -114,6 +115,7 @@ const WalletsAdd: React.FC = () => {
   const colorScheme = useColorScheme();
   //
   const { addWallet, saveToDisk } = useStorage();
+  const { networkType } = useSettings();
   const { entropy: entropyHex, words } = useRoute<RouteProps>().params || {};
   const entropy = entropyHex ? hexToUint8Array(entropyHex) : undefined;
   const { navigate, goBack, setOptions, setParams } = useExtendedNavigation<NavigationProps>();
@@ -176,6 +178,8 @@ const WalletsAdd: React.FC = () => {
     },
     [entropy, setParams, words],
   );
+
+  const isTestnet = networkType !== 'mainnet';
 
   const toolTipActions = useMemo(() => {
     const walletSubactions: Action[] = [
@@ -502,7 +506,7 @@ const WalletsAdd: React.FC = () => {
             onPress={handleOnVaultButtonPressed}
             size={styles.button}
           />
-          {backdoorPressed >= 20 ? (
+          {!isTestnet && backdoorPressed >= 20 ? (
             <WalletButton
               buttonType="LightningArk"
               testID="ActivateLightningArkButton"
@@ -511,7 +515,7 @@ const WalletsAdd: React.FC = () => {
               size={styles.button}
             />
           ) : null}
-          {selectedWalletType === ButtonSelected.OFFCHAIN && LightningButtonMemo}
+          {!isTestnet && selectedWalletType === ButtonSelected.OFFCHAIN && LightningButtonMemo}
         </View>
         <View style={styles.advanced}>
           {selectedWalletType === ButtonSelected.OFFCHAIN && (


### PR DESCRIPTION
Networks can be selected through tapping the beast image within the About screen 20 times. The network is stored in the app settings, as well as in a global var in the code base. The alternative to a global var was to do big refactors in order to encapsulate more Electrum operations into a class/object which could be given a network field.

An approach with a new wallet class was also considered. However, there's a large quantity of calls to
`bitcoin.address.fromOutputScript`, block explorer URL construction and other places where the selected network is required. This commit tries to strike a decent balance between diff size and cleanliness.

Closes #4724