### PR TITLE
OPS: Implement 16kb page size support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         googlePlayServicesVersion = "16.+"
         googlePlayServicesIidVersion = "16.0.1"
         firebaseVersion = "21.1.0"
-        ndkVersion = "27.1.12297006"
+        ndkVersion = "28.2.13676358"
         kotlinVersion = '2.1.20'
     }
     repositories {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2141,12 +2141,12 @@ PODS:
   - react-native-tcp-socket (6.4.1):
     - CocoaAsyncSocket
     - React-Core
-  - react-native-vector-icons-entypo (12.4.2)
+  - react-native-vector-icons-entypo (12.5.0)
   - react-native-vector-icons-fontawesome (12.4.2)
   - react-native-vector-icons-fontawesome6 (12.3.2)
-  - react-native-vector-icons-ionicons (12.4.2)
-  - react-native-vector-icons-material-design-icons (12.4.2)
-  - react-native-vector-icons-material-icons (12.4.2)
+  - react-native-vector-icons-ionicons (12.5.0)
+  - react-native-vector-icons-material-design-icons (12.5.0)
+  - react-native-vector-icons-material-icons (12.5.0)
   - React-NativeModulesApple (0.83.1):
     - boost
     - DoubleConversion
@@ -2796,7 +2796,7 @@ PODS:
     - React-Core
   - RNFS (2.20.0):
     - React-Core
-  - RNGestureHandler (2.30.0):
+  - RNGestureHandler (2.31.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2826,7 +2826,7 @@ PODS:
     - Yoga
   - RNHandoff (0.0.3):
     - React
-  - RNKeychain (9.2.3):
+  - RNKeychain (10.0.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2910,8 +2910,34 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNQrGenerator (1.4.5):
-    - React
+  - RNQrGenerator (2.0.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
     - ZXingObjC
   - RNQuickAction (0.3.13):
     - React
@@ -3657,7 +3683,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 309703e71d3f2f1ed7dc7889d58309c9d77a95a4
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: b6ee973c4fd6366874d9aabcaf396d53475038eb
+  hermes-engine: 1195b00d0f49a367b01a38c87b43227542fc3532
   lottie-ios: 8f959969761e9c45d70353667d00af0e5b9cadb3
   lottie-react-native: 983fd0489530e8d40f173de7f04e2f88b9317a15
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
@@ -3708,12 +3734,12 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: befb5404eb8a16fdc07fa2bebab3568ecabcbb8a
   react-native-secure-key-store: eb45b44bdec3f48e9be5cdfca0f49ddf64892ea6
   react-native-tcp-socket: 7c7e53a07f122ecf00fb3626684bc0ca82c4f044
-  react-native-vector-icons-entypo: df7884c4002b70c79d41b7de10b53df3ce8c1e8e
+  react-native-vector-icons-entypo: 3cd60c5950ea9b2cf7f1fe4fe50fbcbcef2ba381
   react-native-vector-icons-fontawesome: 3604609191a2b4323637a4a25dcd4e6e05579dc2
   react-native-vector-icons-fontawesome6: 3765e18f5116ae4498997bf8548eaab05de72ee6
-  react-native-vector-icons-ionicons: 7cc4388958a60560aa6f5e257ad8197d555700ff
-  react-native-vector-icons-material-design-icons: 12bc222b4cd6781a3cbbf4b537767d3d528011dd
-  react-native-vector-icons-material-icons: 433cb95ee9de1246934b2ae8414f9c02b520b628
+  react-native-vector-icons-ionicons: 7e633927db6ab96e0255b5920c053777cacca505
+  react-native-vector-icons-material-design-icons: 95914f2f6b18e26e5c9563afe33184e110afe674
+  react-native-vector-icons-material-icons: 8717ed6d0adafdea7a20475dababba112992a372
   React-NativeModulesApple: a2c3d2cbec893956a5b3e4060322db2984fff75b
   React-networking: 3f98bd96893a294376e7e03730947a08d474c380
   React-oscompat: 80166b66da22e7af7fad94474e9997bd52d4c8c6
@@ -3754,12 +3780,12 @@ SPEC CHECKSUMS:
   RNDefaultPreference: 8a089ee8ce829a66c5453e3c5434f0785499d1c3
   RNDeviceInfo: bcce8752b5043a623fe3c26789679b473f705d3c
   RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
-  RNGestureHandler: cd4be101cfa17ea6bbd438710caa02e286a84381
+  RNGestureHandler: 884f03ad24511911552480eb2058266db0b177ce
   RNHandoff: bc8af5a86853ff13b033e7ba1114c3c5b38e6385
-  RNKeychain: 483402cf2b90647eb0cf569cebbc069d32addea4
+  RNKeychain: a2c134ab796272c3d605e035ab727591000b30f3
   RNLocalize: 1aedbc2c15073861a364174919d23c31c5924b16
   RNPermissions: 29cfd9c9bbb7f0bd35e702dc849e33b294feac52
-  RNQrGenerator: b467624cdcb0e88108a8b4ca74c94b0978efa265
+  RNQrGenerator: 3318e98283e861e9d93e58111fc4de8e03e2ddb3
   RNQuickAction: c2c8f379e614428be0babe4d53a575739667744d
   RNReactNativeHapticFeedback: 43181767a132b77676b6a58b7ed852928e0d4862
   RNReanimated: 18324d3313d6477e1d12836c20c3ee30afb5de30

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "react-native-handoff": "github:BlueWallet/react-native-handoff#v0.0.4",
         "react-native-haptic-feedback": "2.3.4",
         "react-native-image-picker": "8.2.1",
-        "react-native-keychain": "9.2.3",
+        "react-native-keychain": "10.0.0",
         "react-native-linear-gradient": "2.8.3",
         "react-native-localize": "3.7.0",
         "react-native-notifications": "5.2.2",
@@ -16158,7 +16158,9 @@
       }
     },
     "node_modules/react-native-keychain": {
-      "version": "9.2.3",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-keychain/-/react-native-keychain-10.0.0.tgz",
+      "integrity": "sha512-YzPKSAnSzGEJ12IK6CctNLU79T1W15WDrElRQ+1/FsOazGX9ucFPTQwgYe8Dy8jiSEDJKM4wkVa3g4lD2Z+Pnw==",
       "license": "MIT",
       "workspaces": [
         "KeychainExample",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "react-native-handoff": "github:BlueWallet/react-native-handoff#v0.0.4",
     "react-native-haptic-feedback": "2.3.4",
     "react-native-image-picker": "8.2.1",
-    "react-native-keychain": "9.2.3",
+    "react-native-keychain": "10.0.0",
     "react-native-linear-gradient": "2.8.3",
     "react-native-localize": "3.7.0",
     "react-native-notifications": "5.2.2",


### PR DESCRIPTION
- updated ndk version to `28.2.13676358`  (NDK version r28 and higher compile 16 KB-aligned by default)
- updated `react-native-keychain-package` version to `10.0.0` as the previous version had `libconceal.so` that used 4kb page size'

Please test on physical devices

Refer to https://developer.android.com/guide/practices/page-sizes#native-code for more about 16kb page size support

# Screenshots before making changes
A screenshot of android studio apk analyzer showing that app does not support 16kb devices

<img width="1096" height="428" alt="image" src="https://github.com/user-attachments/assets/b192adb2-c41e-4912-9f61-e038b02b8d56" />


<p>&nbsp;</p>
A screenshot of android studio apk analyzer showing libconceal.so 

<img width="1096" height="428" alt="image" src="https://github.com/user-attachments/assets/d690bec9-dd4c-4270-95d2-abe26932ce60" />


<p>&nbsp;</p>


# Screenshots after making changes

Screenshot of apk analyzer no longer showing that app does not support 16kb page size
<img width="1096" height="428" alt="image" src="https://github.com/user-attachments/assets/eb80966e-da76-4173-99b7-b7883c242b97" />

<p>&nbsp;</p>