### PR TITLE
ref: receive screen layout

### DIFF
--- a/components/CopyTextToClipboard.tsx
+++ b/components/CopyTextToClipboard.tsx
@@ -1,21 +1,30 @@
 import Clipboard from '@react-native-clipboard/clipboard';
-import React, { forwardRef, useEffect, useState } from 'react';
-import { Animated, StyleSheet, TouchableOpacity, View, Text } from 'react-native';
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from 'react';
+import { Animated, StyleProp, StyleSheet, Text, TextStyle, TouchableOpacity, View, ViewStyle } from 'react-native';
 
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../blue_modules/hapticFeedback';
 import loc from '../loc';
 import { useTheme } from './themes';
 
-type CopyTextToClipboardProps = {
-  text: string;
-  truncated?: boolean;
-  isAddress?: boolean;
+export type CopyTextToClipboardHandle = {
+  copy: (options?: { suppressHaptic?: boolean }) => void;
 };
 
-const CopyTextToClipboard = forwardRef<React.ElementRef<typeof TouchableOpacity>, CopyTextToClipboardProps>(
-  ({ text, truncated, isAddress }, ref) => {
+type CopyTextToClipboardProps = {
+  text: string;
+  displayText?: string;
+  truncated?: boolean;
+  isAddress?: boolean;
+  interactive?: boolean;
+  textStyle?: StyleProp<TextStyle>;
+  containerStyle?: StyleProp<ViewStyle>;
+};
+
+const CopyTextToClipboard = forwardRef<CopyTextToClipboardHandle, CopyTextToClipboardProps>(
+  ({ text, displayText, truncated, isAddress, interactive = true, textStyle, containerStyle }, ref) => {
     const [hasTappedText, setHasTappedText] = useState(false);
-    const [address, setAddress] = useState(text);
+    const resolvedDisplayText = displayText ?? text;
+    const [address, setAddress] = useState(resolvedDisplayText);
     const { colors } = useTheme();
 
     const stylesHook = StyleSheet.create({
@@ -27,26 +36,32 @@ const CopyTextToClipboard = forwardRef<React.ElementRef<typeof TouchableOpacity>
 
     useEffect(() => {
       if (!hasTappedText) {
-        setAddress(text);
+        setAddress(resolvedDisplayText);
       }
-    }, [text, hasTappedText]);
+    }, [resolvedDisplayText, hasTappedText]);
 
-    const copyToClipboard = () => {
+    const copyToClipboard = useCallback((options?: { suppressHaptic?: boolean }) => {
       setHasTappedText(true);
       Clipboard.setString(text);
-      triggerHapticFeedback(HapticFeedbackTypes.Selection);
+      if (!options?.suppressHaptic) {
+        triggerHapticFeedback(HapticFeedbackTypes.Selection);
+      }
       setAddress(loc.wallets.xpub_copiedToClipboard);
       setTimeout(() => {
         setHasTappedText(false);
-        setAddress(text);
-      }, 1000);
-    };
+        setAddress(resolvedDisplayText);
+      }, 1800);
+    }, [text, resolvedDisplayText]);
+
+    useImperativeHandle(ref, () => ({ copy: copyToClipboard }), [copyToClipboard]);
+
+    const composedTextStyle = [styles.address, textStyle];
 
     const renderHighlightedAddress = () => {
       if (address.includes(loc.wallets.xpub_copiedToClipboard)) {
         return (
           <Animated.Text
-            style={styles.address}
+            style={composedTextStyle}
             {...(truncated ? { numberOfLines: 1, ellipsizeMode: 'middle' } : { numberOfLines: 0 })}
             testID="AddressValue"
           >
@@ -69,7 +84,7 @@ const CopyTextToClipboard = forwardRef<React.ElementRef<typeof TouchableOpacity>
         const end = addrPart.slice(-6);
 
         return (
-          <Animated.Text style={styles.address} numberOfLines={truncated ? 1 : 0} ellipsizeMode="middle" testID="AddressValue">
+          <Animated.Text style={composedTextStyle} numberOfLines={truncated ? 1 : 0} ellipsizeMode="middle" testID="AddressValue">
             <Text>{prefix}</Text>
 
             <Text style={stylesHook.addressSection}>{start}</Text>
@@ -85,7 +100,7 @@ const CopyTextToClipboard = forwardRef<React.ElementRef<typeof TouchableOpacity>
 
       return (
         <Animated.Text
-          style={styles.address}
+          style={composedTextStyle}
           {...(truncated ? { numberOfLines: 1, ellipsizeMode: 'middle' } : { numberOfLines: 0 })}
           testID="AddressValue"
         >
@@ -96,26 +111,37 @@ const CopyTextToClipboard = forwardRef<React.ElementRef<typeof TouchableOpacity>
       );
     };
 
+    const content = isAddress ? (
+      renderHighlightedAddress()
+    ) : (
+      <Animated.Text
+        style={composedTextStyle}
+        {...(truncated ? { numberOfLines: 1, ellipsizeMode: 'middle' } : { numberOfLines: 0 })}
+        testID="AddressValue"
+      >
+        {address}
+      </Animated.Text>
+    );
+
+    const outerStyle = [styles.container, containerStyle];
+
+    if (!interactive) {
+      return (
+        <View style={outerStyle} testID="CopyTextToClipboard">
+          {content}
+        </View>
+      );
+    }
+
     return (
-      <View style={styles.container}>
+      <View style={outerStyle}>
         <TouchableOpacity
-          ref={ref}
           accessibilityRole="button"
-          onPress={copyToClipboard}
+          onPress={() => copyToClipboard()}
           disabled={hasTappedText}
           testID="CopyTextToClipboard"
         >
-          {isAddress ? (
-            <>{renderHighlightedAddress()}</>
-          ) : (
-            <Animated.Text
-              style={styles.address}
-              {...(truncated ? { numberOfLines: 1, ellipsizeMode: 'middle' } : { numberOfLines: 0 })}
-              testID="AddressValue"
-            >
-              {address}
-            </Animated.Text>
-          )}
+          {content}
         </TouchableOpacity>
       </View>
     );

--- a/components/CopyTextToClipboard.tsx
+++ b/components/CopyTextToClipboard.tsx
@@ -40,20 +40,26 @@ const CopyTextToClipboard = forwardRef<CopyTextToClipboardHandle, CopyTextToClip
       }
     }, [resolvedDisplayText, hasTappedText]);
 
-    const copyToClipboard = useCallback((options?: { suppressHaptic?: boolean }) => {
-      setHasTappedText(true);
-      Clipboard.setString(text);
-      if (!options?.suppressHaptic) {
-        triggerHapticFeedback(HapticFeedbackTypes.Selection);
-      }
-      setAddress(loc.wallets.xpub_copiedToClipboard);
-      setTimeout(() => {
-        setHasTappedText(false);
-        setAddress(resolvedDisplayText);
-      }, 1800);
-    }, [text, resolvedDisplayText]);
+    const copyToClipboard = useCallback(
+      (options?: { suppressHaptic?: boolean }) => {
+        setHasTappedText(true);
+        Clipboard.setString(text);
+        if (!options?.suppressHaptic) {
+          triggerHapticFeedback(HapticFeedbackTypes.Selection);
+        }
+        setAddress(loc.wallets.xpub_copiedToClipboard);
+        setTimeout(() => {
+          setHasTappedText(false);
+          setAddress(resolvedDisplayText);
+        }, 1800);
+      },
+      [text, resolvedDisplayText],
+    );
 
     useImperativeHandle(ref, () => ({ copy: copyToClipboard }), [copyToClipboard]);
+
+    /** Single-line value for screen readers / Detox `by.label` when visual text uses newlines or splits (e.g. receive address). */
+    const accessibilityLabelResolved = hasTappedText ? loc.wallets.xpub_copiedToClipboard : text;
 
     const composedTextStyle = [styles.address, textStyle];
 
@@ -127,7 +133,13 @@ const CopyTextToClipboard = forwardRef<CopyTextToClipboardHandle, CopyTextToClip
 
     if (!interactive) {
       return (
-        <View style={outerStyle} testID="CopyTextToClipboard">
+        <View
+          style={outerStyle}
+          testID="CopyTextToClipboard"
+          accessible
+          accessibilityRole="text"
+          accessibilityLabel={accessibilityLabelResolved}
+        >
           {content}
         </View>
       );
@@ -137,6 +149,8 @@ const CopyTextToClipboard = forwardRef<CopyTextToClipboardHandle, CopyTextToClip
       <View style={outerStyle}>
         <TouchableOpacity
           accessibilityRole="button"
+          accessible
+          accessibilityLabel={accessibilityLabelResolved}
           onPress={() => copyToClipboard()}
           disabled={hasTappedText}
           testID="CopyTextToClipboard"

--- a/components/CopyTextToClipboard.tsx
+++ b/components/CopyTextToClipboard.tsx
@@ -1,6 +1,6 @@
 import Clipboard from '@react-native-clipboard/clipboard';
 import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from 'react';
-import { Animated, StyleProp, StyleSheet, Text, TextStyle, TouchableOpacity, View, ViewStyle } from 'react-native';
+import { Animated, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../blue_modules/hapticFeedback';
 import loc from '../loc';
@@ -16,12 +16,10 @@ type CopyTextToClipboardProps = {
   truncated?: boolean;
   isAddress?: boolean;
   interactive?: boolean;
-  textStyle?: StyleProp<TextStyle>;
-  containerStyle?: StyleProp<ViewStyle>;
 };
 
 const CopyTextToClipboard = forwardRef<CopyTextToClipboardHandle, CopyTextToClipboardProps>(
-  ({ text, displayText, truncated, isAddress, interactive = true, textStyle, containerStyle }, ref) => {
+  ({ text, displayText, truncated, isAddress, interactive = true }, ref) => {
     const [hasTappedText, setHasTappedText] = useState(false);
     const resolvedDisplayText = displayText ?? text;
     const [address, setAddress] = useState(resolvedDisplayText);
@@ -61,13 +59,11 @@ const CopyTextToClipboard = forwardRef<CopyTextToClipboardHandle, CopyTextToClip
     /** Single-line value for screen readers / Detox `by.label` when visual text uses newlines or splits (e.g. receive address). */
     const accessibilityLabelResolved = hasTappedText ? loc.wallets.xpub_copiedToClipboard : text;
 
-    const composedTextStyle = [styles.address, textStyle];
-
     const renderHighlightedAddress = () => {
       if (address.includes(loc.wallets.xpub_copiedToClipboard)) {
         return (
           <Animated.Text
-            style={composedTextStyle}
+            style={styles.address}
             {...(truncated ? { numberOfLines: 1, ellipsizeMode: 'middle' } : { numberOfLines: 0 })}
             testID="AddressValue"
           >
@@ -90,7 +86,7 @@ const CopyTextToClipboard = forwardRef<CopyTextToClipboardHandle, CopyTextToClip
         const end = addrPart.slice(-6);
 
         return (
-          <Animated.Text style={composedTextStyle} numberOfLines={truncated ? 1 : 0} ellipsizeMode="middle" testID="AddressValue">
+          <Animated.Text style={styles.address} numberOfLines={truncated ? 1 : 0} ellipsizeMode="middle" testID="AddressValue">
             <Text>{prefix}</Text>
 
             <Text style={stylesHook.addressSection}>{start}</Text>
@@ -106,7 +102,7 @@ const CopyTextToClipboard = forwardRef<CopyTextToClipboardHandle, CopyTextToClip
 
       return (
         <Animated.Text
-          style={composedTextStyle}
+          style={styles.address}
           {...(truncated ? { numberOfLines: 1, ellipsizeMode: 'middle' } : { numberOfLines: 0 })}
           testID="AddressValue"
         >
@@ -121,7 +117,7 @@ const CopyTextToClipboard = forwardRef<CopyTextToClipboardHandle, CopyTextToClip
       renderHighlightedAddress()
     ) : (
       <Animated.Text
-        style={composedTextStyle}
+        style={styles.address}
         {...(truncated ? { numberOfLines: 1, ellipsizeMode: 'middle' } : { numberOfLines: 0 })}
         testID="AddressValue"
       >
@@ -129,12 +125,10 @@ const CopyTextToClipboard = forwardRef<CopyTextToClipboardHandle, CopyTextToClip
       </Animated.Text>
     );
 
-    const outerStyle = [styles.container, containerStyle];
-
     if (!interactive) {
       return (
         <View
-          style={outerStyle}
+          style={styles.container}
           testID="CopyTextToClipboard"
           accessible
           accessibilityRole="text"
@@ -146,7 +140,7 @@ const CopyTextToClipboard = forwardRef<CopyTextToClipboardHandle, CopyTextToClip
     }
 
     return (
-      <View style={outerStyle}>
+      <View style={styles.container}>
         <TouchableOpacity
           accessibilityRole="button"
           accessible
@@ -165,9 +159,8 @@ const CopyTextToClipboard = forwardRef<CopyTextToClipboardHandle, CopyTextToClip
 export default CopyTextToClipboard;
 
 const styles = StyleSheet.create({
-  container: { justifyContent: 'center', alignItems: 'center', paddingHorizontal: 16 },
+  container: { justifyContent: 'center', alignItems: 'center' },
   address: {
-    marginVertical: 32,
     fontSize: 15,
     color: '#9aa0aa',
     textAlign: 'center',

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2763,7 +2763,7 @@ SPEC CHECKSUMS:
   BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   FBLazyVector: 26fd21c75314e101f280d401e97f27d54f3f7064
-  hermes-engine: 86cdbf283775c54dc008895c3eacd24a1f2a40b4
+  hermes-engine: d893d2fd6b166772460a5b88e7f1eb2164dfe7a1
   lottie-ios: 8f959969761e9c45d70353667d00af0e5b9cadb3
   lottie-react-native: 615e5f4651bee144ea991ad8e900630b6b3daf5d
   RCTDeprecation: c7a2768f905d76ca6d2cfefb26e4349eacbdfca3
@@ -2774,7 +2774,7 @@ SPEC CHECKSUMS:
   React: 13cf8451582adb1bb324306e1893b91d1cba28c6
   React-callinvoker: 91e6a605826b684ad2e623811253b4d0c4196bef
   React-Core: 46818de5f211b2a2759ac823b591af8a0a95c2c1
-  React-Core-prebuilt: 632528c2a5a42f18b27da6ed4b1053f1767d86b0
+  React-Core-prebuilt: c058914ab85cb1cfea0ede854d17fb966667759f
   React-CoreModules: a6a37afee48d4a31ab398640b0795462647d5c67
   React-cxxreact: 2ec3e2f7a8ae9303460d4ba94cde183ea90d64cd
   React-debug: 0d21117b897ce0359c9d2c9dfe952f237476a14a
@@ -2854,7 +2854,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 4d6207496654098eb8425ce4a3a892f99ea8f971
   ReactCommon: a804bb8d1dcf3ecdec3a77eb8bba19b7863bbbdb
   ReactNativeCameraKit: 5974256fc608631c1c812710cd98abe95dae0f88
-  ReactNativeDependencies: 57f80ca59b1643a914e21e6ba3bf1a937f16c894
+  ReactNativeDependencies: 9596763379fdefee23ec9355942637513dfe9206
   RealmJS: 1c37c6bdfe060f4caa0f9175aa0eedb962622ee1
   RNCAsyncStorage: 2ad919e88b8bc2cd80e8697ce66d04d006743283
   RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
@@ -2878,4 +2878,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 7e23f7f009125b117989e69fd28c8a04aa4eacc8
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/navigation/DetailViewScreensStack.tsx
+++ b/navigation/DetailViewScreensStack.tsx
@@ -387,7 +387,6 @@ const DetailViewStackScreensStack = () => {
         options={navigationStyle({
           title: loc.receive.header,
           closeButtonPosition: CloseButtonPosition.Left,
-          statusBarStyle: 'light',
           headerShown: true,
           presentation: 'modal',
         })(theme)}

--- a/navigation/ReceiveDetailsStack.tsx
+++ b/navigation/ReceiveDetailsStack.tsx
@@ -21,7 +21,6 @@ const ReceiveDetailsStack = () => {
         options={navigationStyle({
           title: loc.receive.header,
           closeButtonPosition: CloseButtonPosition.Left,
-          statusBarStyle: 'light',
           headerShown: true,
         })(theme)}
       />

--- a/screen/lnd/lndViewAdditionalInvoicePreImage.tsx
+++ b/screen/lnd/lndViewAdditionalInvoicePreImage.tsx
@@ -32,7 +32,9 @@ const LNDViewAdditionalInvoicePreImage = () => {
           <QRCode value={preImageData} size={300} logoSize={90} />
         </View>
         <BlueSpacing20 />
-        <CopyTextToClipboard text={preImageData} />
+        <View style={styles.copyText}>
+          <CopyTextToClipboard text={preImageData} />
+        </View>
       </View>
     </SafeArea>
   );
@@ -48,6 +50,10 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     marginHorizontal: 16,
+  },
+  copyText: {
+    marginVertical: 32,
+    paddingHorizontal: 16,
   },
 });
 

--- a/screen/lnd/lndViewInvoice.tsx
+++ b/screen/lnd/lndViewInvoice.tsx
@@ -263,7 +263,9 @@ const LNDViewInvoice = () => {
                   {loc.lndViewInvoice.for} {invoice.description ?? ''}
                 </BlueText>
               )}
-              <CopyTextToClipboard truncated text={invoice.payment_request} />
+              <View style={styles.copyText}>
+                <CopyTextToClipboard truncated text={invoice.payment_request} />
+              </View>
               <Button onPress={handleOnSharePressed} title={loc.receive.details_share} />
             </View>
           </ScrollView>
@@ -332,5 +334,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     marginHorizontal: 16,
+  },
+  copyText: {
+    marginVertical: 32,
+    paddingHorizontal: 16,
   },
 });

--- a/screen/receive/ReceiveDetails.tsx
+++ b/screen/receive/ReceiveDetails.tsx
@@ -654,8 +654,6 @@ const ReceiveDetails = () => {
                   isAddress={isAddressTab}
                   truncated={false}
                   interactive={false}
-                  textStyle={styles.cardAddressText}
-                  containerStyle={styles.addressCopyContainer}
                 />
               </View>
             </>
@@ -918,14 +916,8 @@ const styles = StyleSheet.create({
     alignSelf: 'stretch',
     marginHorizontal: -CARD_INTERNAL_PADDING,
     paddingHorizontal: 16,
-  },
-  addressCopyContainer: {
-    paddingHorizontal: 0,
     minHeight: 48,
     justifyContent: 'center',
-  },
-  cardAddressText: {
-    marginVertical: 0,
   },
   bip47NotFoundContainer: {
     paddingVertical: 40,

--- a/screen/receive/ReceiveDetails.tsx
+++ b/screen/receive/ReceiveDetails.tsx
@@ -1,7 +1,18 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RouteProp, useFocusEffect, useRoute } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { BackHandler, Image, ImageSourcePropType, Platform, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import {
+  BackHandler,
+  Image,
+  ImageSourcePropType,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  useColorScheme,
+  View,
+} from 'react-native';
 import Animated, { Easing, Layout, useAnimatedStyle, useSharedValue, withDelay, withTiming } from 'react-native-reanimated';
 import Share from 'react-native-share';
 import * as BlueElectrum from '../../blue_modules/BlueElectrum';
@@ -39,10 +50,6 @@ const segmentControlValues = [loc.wallets.details_address, loc.bip47.payment_cod
 const CARD_HORIZONTAL_MARGIN = 24;
 const CARD_INTERNAL_PADDING = 6;
 const QR_CARD_PADDING = 6;
-const ADDRESS_HORIZONTAL_PADDING = 16;
-const QR_TO_ADDRESS_GAP = 24;
-const ADDRESS_AREA_MIN_HEIGHT = 48;
-const HEADER_TO_RECEIVE_CARD = 56;
 const MAX_QR_SIZE = 500;
 const MIN_QR_SIZE = 120;
 const QR_SCROLL_RESERVED_WIDTH = (CARD_HORIZONTAL_MARGIN + CARD_INTERNAL_PADDING + QR_CARD_PADDING) * 2;
@@ -177,6 +184,7 @@ const ReceiveDetails = () => {
   const { wallets, saveToDisk, sleep, fetchAndSaveWalletTransactions } = useStorage();
   const { isElectrumDisabled } = useSettings();
   const { colors, closeImage } = useTheme();
+  const isDarkTheme = useColorScheme() === 'dark';
   const [customLabel, setCustomLabel] = useState('');
   const [customAmount, setCustomAmount] = useState('');
   const [customUnit, setCustomUnit] = useState<BitcoinUnit>(BitcoinUnit.BTC);
@@ -197,13 +205,8 @@ const ReceiveDetails = () => {
   const wallet = walletID ? wallets.find(w => w.getID() === walletID) : undefined;
   const isBIP47Enabled = wallet?.isBIP47Enabled();
 
-  const paymentCodeString = useMemo(() => {
-    if (!wallet || !isBIP47Enabled || !('getBIP47PaymentCode' in wallet)) return '';
-    const fn = wallet.getBIP47PaymentCode;
-    return typeof fn === 'function' ? (fn.call(wallet) ?? '') : '';
-  }, [wallet, isBIP47Enabled]);
+  const paymentCodeString = useMemo(() => (wallet && 'getBIP47PaymentCode' in wallet && wallet.getBIP47PaymentCode()) || '', [wallet]);
 
-  const isDarkTheme = colors.background === '#000000';
   /** Dark: theme input surface (#262626) reads softer than pure elevated / system gray 6. Light: iOS-style grouped background. */
   const cardBackgroundColor = isDarkTheme ? colors.inputBackgroundColor : '#F2F2F7';
 
@@ -770,12 +773,7 @@ const ReceiveDetails = () => {
   };
 
   const handleShareButtonPressed = () => {
-    let message: string | false = false;
-    if (currentTab === segmentControlValues[0]) {
-      message = bip21encoded;
-    } else {
-      message = (wallet && 'getBIP47PaymentCode' in wallet && wallet.getBIP47PaymentCode()) ?? false;
-    }
+    const message = currentTab === segmentControlValues[0] ? bip21encoded : paymentCodeString;
 
     if (!message) {
       presentAlert({ title: loc.errors.error, message: loc.bip47.not_found });
@@ -869,7 +867,7 @@ const styles = StyleSheet.create({
   cardPressable: {
     alignSelf: 'center',
     marginHorizontal: CARD_HORIZONTAL_MARGIN,
-    marginTop: HEADER_TO_RECEIVE_CARD,
+    marginTop: 56,
     marginBottom: 8,
   },
   receiveCard: {
@@ -914,16 +912,16 @@ const styles = StyleSheet.create({
     borderRadius: 4,
   },
   cardSpacer: {
-    height: QR_TO_ADDRESS_GAP,
+    height: 24,
   },
   addressRow: {
     alignSelf: 'stretch',
     marginHorizontal: -CARD_INTERNAL_PADDING,
-    paddingHorizontal: ADDRESS_HORIZONTAL_PADDING,
+    paddingHorizontal: 16,
   },
   addressCopyContainer: {
     paddingHorizontal: 0,
-    minHeight: ADDRESS_AREA_MIN_HEIGHT,
+    minHeight: 48,
     justifyContent: 'center',
   },
   cardAddressText: {

--- a/screen/receive/ReceiveDetails.tsx
+++ b/screen/receive/ReceiveDetails.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RouteProp, useFocusEffect, useRoute } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { BackHandler, Image, ImageSourcePropType, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { BackHandler, Image, ImageSourcePropType, Platform, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import Animated, { Easing, Layout, useAnimatedStyle, useSharedValue, withDelay, withTiming } from 'react-native-reanimated';
 import Share from 'react-native-share';
 import * as BlueElectrum from '../../blue_modules/BlueElectrum';
@@ -365,8 +365,11 @@ const ReceiveDetails = () => {
   const renderHeaderRightMenu = useCallback(() => HeaderRight, [HeaderRight]);
 
   useEffect(() => {
+    const androidNoDuplicateBack = Platform.OS === 'android' ? { headerBackVisible: false as const } : {};
+
     if (wallet?.allowBIP47() && isBIP47Enabled) {
       setOptions({
+        ...androidNoDuplicateBack,
         headerLeft: renderHeaderCloseButton,
         headerRight: renderHeaderRightMenu,
       });
@@ -374,8 +377,10 @@ const ReceiveDetails = () => {
     }
 
     // When payment-code menu is hidden, move close button to the right.
+    // Android: static `navigationStyle` uses `headerBackImageSource` for left "close"; hide back so only `headerRight` shows.
     setOptions({
-      headerLeft: undefined,
+      ...androidNoDuplicateBack,
+      headerLeft: () => null,
       headerRight: renderHeaderCloseButton,
     });
   }, [isBIP47Enabled, renderHeaderCloseButton, renderHeaderRightMenu, setOptions, wallet]);

--- a/screen/receive/ReceiveDetails.tsx
+++ b/screen/receive/ReceiveDetails.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RouteProp, useFocusEffect, useRoute } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { BackHandler, Platform, StyleSheet, Text, View } from 'react-native';
-import Animated, { Layout } from 'react-native-reanimated';
+import { BackHandler, Image, ImageSourcePropType, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import Animated, { Easing, Layout, useAnimatedStyle, useSharedValue, withDelay, withTiming } from 'react-native-reanimated';
 import Share from 'react-native-share';
 import * as BlueElectrum from '../../blue_modules/BlueElectrum';
 import { fiatToBTC, satoshiToBTC } from '../../blue_modules/currency';
@@ -12,13 +12,12 @@ import { BlueButtonLink, BlueCard, BlueText } from '../../BlueComponents';
 import DeeplinkSchemaMatch from '../../class/deeplink-schema-match';
 import presentAlert from '../../components/Alert';
 import Button from '../../components/Button';
-import CopyTextToClipboard from '../../components/CopyTextToClipboard';
+import CopyTextToClipboard, { CopyTextToClipboardHandle } from '../../components/CopyTextToClipboard';
 import HandOffComponent from '../../components/HandOffComponent';
 import HeaderMenuButton from '../../components/HeaderMenuButton';
 import QRCode from '../../components/QRCode';
 import SegmentedControl from '../../components/SegmentedControl';
 import { useTheme } from '../../components/themes';
-import TipBox from '../../components/TipBox';
 import { TransactionPendingIconBig } from '../../components/TransactionPendingIconBig';
 import { HandOffActivityType } from '../../components/types';
 import { useSettings } from '../../hooks/context/useSettings';
@@ -34,32 +33,140 @@ import { BlueLoading } from '../../components/BlueLoading';
 import SafeAreaScrollView from '../../components/SafeAreaScrollView';
 
 const segmentControlValues = [loc.wallets.details_address, loc.bip47.payment_code];
-const HORIZONTAL_PADDING = 20;
 
-type StickyHeaderProps = {
-  wallet: any;
-  isBIP47Enabled: boolean;
-  tabValues: string[];
-  currentTab: string;
-  setCurrentTab: (tab: string) => void;
-  backgroundColor: string;
+// Tappable receive card layout constants. Kept in one place because the QR
+// size depends on subtracting all the surrounding paddings/margins.
+const CARD_HORIZONTAL_MARGIN = 24;
+const CARD_INTERNAL_PADDING = 6;
+const QR_CARD_PADDING = 6;
+const ADDRESS_HORIZONTAL_PADDING = 16;
+const QR_TO_ADDRESS_GAP = 24;
+const ADDRESS_AREA_MIN_HEIGHT = 48;
+const HEADER_TO_RECEIVE_CARD = 56;
+const MAX_QR_SIZE = 500;
+const MIN_QR_SIZE = 120;
+const QR_SCROLL_RESERVED_WIDTH = (CARD_HORIZONTAL_MARGIN + CARD_INTERNAL_PADDING + QR_CARD_PADDING) * 2;
+const QR_PORTRAIT_HEIGHT_FRACTION = 0.44;
+const QR_LANDSCAPE_HEIGHT_FRACTION = 0.52;
+const QR_WIDTH_USE_FRACTION = 0.92;
+
+/** Staggered “reveal” for the QR: white tiles fade out in random order */
+const QR_STAGGER_GRID = 5;
+const QR_STAGGER_MAX_DELAY_MS = 420;
+const QR_STAGGER_TILE_DURATION_MS = 400;
+
+/** Deterministic stagger delays for a given payload key */
+function staggerDelaysForRunKey(runKey: string, tileCount: number, maxDelayMs: number): number[] {
+  const delays: number[] = [];
+  for (let i = 0; i < tileCount; i++) {
+    let n = 0;
+    const s = `${runKey}:${i}`;
+    for (let j = 0; j < s.length; j++) {
+      n = (n * 31 + s.charCodeAt(j) * (j + 1)) % 2147483647;
+    }
+    delays.push(n % maxDelayMs);
+  }
+  return delays;
+}
+
+const receiveAuxStyles = StyleSheet.create({
+  headerCloseButton: {
+    minWidth: 40,
+    height: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  qrRevealTile: {
+    position: 'absolute',
+  },
+  qrStaggerHost: {
+    overflow: 'hidden',
+  },
+});
+
+type QrRevealTileProps = {
+  width: number;
+  height: number;
+  left: number;
+  top: number;
+  maskColor: string;
+  delayMs: number;
+  runKey: string;
 };
 
-const StickyHeader = React.memo(({ wallet, isBIP47Enabled, tabValues, currentTab, setCurrentTab, backgroundColor }: StickyHeaderProps) => {
-  if (!wallet || !isBIP47Enabled) return null;
+const QrRevealTile: React.FC<QrRevealTileProps> = ({ width, height, left, top, maskColor, delayMs, runKey }) => {
+  const opacity = useSharedValue(1);
+  useEffect(() => {
+    opacity.value = 1;
+    opacity.value = withDelay(delayMs, withTiming(0, { duration: QR_STAGGER_TILE_DURATION_MS, easing: Easing.out(Easing.quad) }));
+  }, [runKey, delayMs, opacity]);
+  const tileStyle = useAnimatedStyle(() => ({ opacity: opacity.value }));
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[receiveAuxStyles.qrRevealTile, { left, top, width, height, backgroundColor: maskColor }, tileStyle]}
+    />
+  );
+};
+
+type QrStaggerRevealProps = {
+  size: number;
+  maskColor: string;
+  runKey: string;
+  children: React.ReactNode;
+};
+
+const QrStaggerReveal: React.FC<QrStaggerRevealProps> = ({ size, maskColor, runKey, children }) => {
+  const delays = useMemo(() => staggerDelaysForRunKey(runKey, QR_STAGGER_GRID * QR_STAGGER_GRID, QR_STAGGER_MAX_DELAY_MS), [runKey]);
+  const g = QR_STAGGER_GRID;
+  const qx = Math.floor(size / g);
+  const extraX = size - qx * g;
+  const qy = Math.floor(size / g);
+  const extraY = size - qy * g;
+  const tileW = (c: number) => (c === g - 1 ? qx + extraX : qx);
+  const tileH = (r: number) => (r === g - 1 ? qy + extraY : qy);
+  const left = (c: number) => c * qx;
+  const top = (r: number) => r * qy;
 
   return (
-    <View style={[styles.tabsContainer, { backgroundColor }]}>
-      <SegmentedControl
-        values={tabValues}
-        selectedIndex={tabValues.findIndex(tab => tab === currentTab)}
-        onChange={index => {
-          setCurrentTab(tabValues[index]);
-        }}
-      />
+    <View style={[receiveAuxStyles.qrStaggerHost, { width: size, height: size }]}>
+      {children}
+      {delays.map((delayMs, i) => {
+        const row = Math.floor(i / g);
+        const col = i % g;
+        return (
+          <QrRevealTile
+            key={`${runKey}-${i}`}
+            width={tileW(col)}
+            height={tileH(row)}
+            left={left(col)}
+            top={top(row)}
+            maskColor={maskColor}
+            delayMs={delayMs}
+            runKey={runKey}
+          />
+        );
+      })}
     </View>
   );
-});
+};
+
+type ReceiveDetailsCloseButtonProps = {
+  closeImage: ImageSourcePropType;
+  onPress: () => void;
+};
+
+const ReceiveDetailsCloseButton: React.FC<ReceiveDetailsCloseButtonProps> = ({ closeImage, onPress }) => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={loc._.close}
+    style={receiveAuxStyles.headerCloseButton}
+    onPress={onPress}
+    testID="NavigationCloseButton"
+  >
+    <Image source={closeImage} />
+  </TouchableOpacity>
+);
 
 type NavigationProps = NativeStackNavigationProp<ReceiveDetailsStackParamList, 'ReceiveDetails'>;
 type RouteProps = RouteProp<ReceiveDetailsStackParamList, 'ReceiveDetails'>;
@@ -69,7 +176,7 @@ const ReceiveDetails = () => {
   const { walletID, address } = route.params;
   const { wallets, saveToDisk, sleep, fetchAndSaveWalletTransactions } = useStorage();
   const { isElectrumDisabled } = useSettings();
-  const { colors } = useTheme();
+  const { colors, closeImage } = useTheme();
   const [customLabel, setCustomLabel] = useState('');
   const [customAmount, setCustomAmount] = useState('');
   const [customUnit, setCustomUnit] = useState<BitcoinUnit>(BitcoinUnit.BTC);
@@ -90,6 +197,16 @@ const ReceiveDetails = () => {
   const wallet = walletID ? wallets.find(w => w.getID() === walletID) : undefined;
   const isBIP47Enabled = wallet?.isBIP47Enabled();
 
+  const paymentCodeString = useMemo(() => {
+    if (!wallet || !isBIP47Enabled || !('getBIP47PaymentCode' in wallet)) return '';
+    const fn = wallet.getBIP47PaymentCode;
+    return typeof fn === 'function' ? (fn.call(wallet) ?? '') : '';
+  }, [wallet, isBIP47Enabled]);
+
+  const isDarkTheme = colors.background === '#000000';
+  /** Dark: theme input surface (#262626) reads softer than pure elevated / system gray 6. Light: iOS-style grouped background. */
+  const cardBackgroundColor = isDarkTheme ? colors.inputBackgroundColor : '#F2F2F7';
+
   const stylesHook = StyleSheet.create({
     root: {
       backgroundColor: colors.elevated,
@@ -100,7 +217,37 @@ const ReceiveDetails = () => {
     label: {
       color: colors.foregroundColor,
     },
+    receiveCard: {
+      backgroundColor: cardBackgroundColor,
+    },
+    /** Total width: QR + white card padding + gray card horizontal padding (each side). */
+    receiveCardColumn: {
+      width: qrCodeSize + QR_CARD_PADDING * 2 + CARD_INTERNAL_PADDING * 2,
+    },
+    bip47NotFound: {
+      color: colors.foregroundColor,
+    },
+    qrPlaceholderFill: {
+      backgroundColor: isDarkTheme ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)',
+    },
   });
+
+  const copyRef = useRef<CopyTextToClipboardHandle>(null);
+  const scrollLayoutRef = useRef({ width: 0, height: 0 });
+  const pressScale = useSharedValue(1);
+  const pressAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: pressScale.value }],
+  }));
+  const handlePressIn = useCallback(() => {
+    pressScale.value = withTiming(0.97, { duration: 110, easing: Easing.out(Easing.quad) });
+  }, [pressScale]);
+  const handlePressOut = useCallback(() => {
+    pressScale.value = withTiming(1, { duration: 140, easing: Easing.out(Easing.quad) });
+  }, [pressScale]);
+  const handleCardPress = useCallback(() => {
+    triggerHapticFeedback(HapticFeedbackTypes.ImpactLight);
+    copyRef.current?.copy({ suppressHaptic: true });
+  }, []);
 
   const setAddressBIP21Encoded = useCallback(
     (addr: string) => {
@@ -210,12 +357,28 @@ const ReceiveDetails = () => {
     [onPressMenuItem, toolTipActions],
   );
 
+  const renderHeaderCloseButton = useCallback(
+    () => <ReceiveDetailsCloseButton closeImage={closeImage} onPress={goBack} />,
+    [closeImage, goBack],
+  );
+
+  const renderHeaderRightMenu = useCallback(() => HeaderRight, [HeaderRight]);
+
   useEffect(() => {
-    wallet?.allowBIP47() &&
+    if (wallet?.allowBIP47() && isBIP47Enabled) {
       setOptions({
-        headerRight: () => HeaderRight,
+        headerLeft: renderHeaderCloseButton,
+        headerRight: renderHeaderRightMenu,
       });
-  }, [HeaderRight, colors.foregroundColor, setOptions, wallet]);
+      return;
+    }
+
+    // When payment-code menu is hidden, move close button to the right.
+    setOptions({
+      headerLeft: undefined,
+      headerRight: renderHeaderCloseButton,
+    });
+  }, [isBIP47Enabled, renderHeaderCloseButton, renderHeaderRightMenu, setOptions, wallet]);
 
   // re-fetching address balance periodically
   useEffect(() => {
@@ -344,73 +507,154 @@ const ReceiveDetails = () => {
     );
   };
 
-  const onLayout = useCallback((e: { nativeEvent: { layout: { height: number; width: number } } }) => {
-    const { height, width } = e.nativeEvent.layout;
+  const recomputeQrCodeSize = useCallback(() => {
+    const { width: sw, height: sh } = scrollLayoutRef.current;
+    if (sw <= 0 || sh <= 0) return;
 
-    const isPortrait = height > width;
-    const maxQRSize = 500;
-
-    if (isPortrait) {
-      const heightBasedSize = Math.min(height * 0.6, maxQRSize);
-      const widthBasedSize = width * 0.85 - HORIZONTAL_PADDING * 2;
-      setQRCodeSize(Math.min(heightBasedSize, widthBasedSize));
-    } else {
-      const heightBasedSize = Math.min(height * 0.7, maxQRSize);
-      const widthBasedSize = width * 0.45;
-      setQRCodeSize(Math.min(heightBasedSize, widthBasedSize));
-    }
+    const isPortrait = sh > sw;
+    const heightCap = Math.min(isPortrait ? sh * QR_PORTRAIT_HEIGHT_FRACTION : sh * QR_LANDSCAPE_HEIGHT_FRACTION, MAX_QR_SIZE);
+    const widthBudget = sw - QR_SCROLL_RESERVED_WIDTH;
+    const innerWidthCap = Math.max(MIN_QR_SIZE, Math.floor(widthBudget * QR_WIDTH_USE_FRACTION));
+    const size = Math.max(MIN_QR_SIZE, Math.min(innerWidthCap, heightCap, MAX_QR_SIZE));
+    setQRCodeSize(Math.round(size));
   }, []);
 
-  const renderTabContent = () => {
-    if (currentTab === segmentControlValues[0]) {
-      return (
-        <View style={styles.container}>
-          {address && (
-            <View style={styles.scrollBody}>
-              {isCustom && (
-                <>
-                  {getDisplayAmount() && (
-                    <BlueText testID="BitcoinAmountText" style={[styles.amount, stylesHook.amount]} numberOfLines={1}>
-                      {getDisplayAmount()}
-                    </BlueText>
-                  )}
-                  {customLabel?.length > 0 && (
-                    <BlueText testID="CustomAmountDescriptionText" style={[styles.label, stylesHook.label]} numberOfLines={1}>
-                      {customLabel}
-                    </BlueText>
-                  )}
-                </>
-              )}
-              <View style={styles.qrCodeContainer}>
-                <QRCode value={bip21encoded} size={qrCodeSize} />
-              </View>
-              <CopyTextToClipboard text={isCustom ? bip21encoded : address} isAddress={true} />
+  const onScrollViewLayout = useCallback(
+    (e: { nativeEvent: { layout: { height: number; width: number } } }) => {
+      const { height, width } = e.nativeEvent.layout;
+      scrollLayoutRef.current = { width, height };
+      recomputeQrCodeSize();
+    },
+    [recomputeQrCodeSize],
+  );
+
+  const toBalancedMultilineText = useCallback((value: string) => {
+    const normalized = value.replace(/\n/g, '');
+    if (normalized.length <= 1) return normalized;
+    const midpoint = Math.ceil(normalized.length / 2);
+    return `${normalized.slice(0, midpoint)}\n${normalized.slice(midpoint)}`;
+  }, []);
+
+  const showReceiveSkeleton = !showAddress && !showPendingBalance && !showConfirmedBalance && Boolean(wallet ?? route.params.address);
+
+  const renderReceiveSkeleton = () => {
+    const showTabs = Boolean(wallet && isBIP47Enabled);
+    return (
+      <View style={styles.cardPressable} testID="ReceiveCardSkeleton">
+        <View style={[styles.receiveCard, stylesHook.receiveCard, stylesHook.receiveCardColumn]}>
+          {showTabs && (
+            <View style={styles.tabsInsideCard} onStartShouldSetResponder={() => true}>
+              <SegmentedControl
+                values={segmentControlValues}
+                selectedIndex={segmentControlValues.findIndex(tab => tab === currentTab)}
+                onChange={index => setCurrentTab(segmentControlValues[index])}
+              />
             </View>
           )}
+          <View style={styles.qrCardWrapper}>
+            <View style={[styles.qrPlaceholder, stylesHook.qrPlaceholderFill, { width: qrCodeSize, height: qrCodeSize }]} />
+          </View>
         </View>
-      );
+      </View>
+    );
+  };
+
+  const renderReceiveCard = () => {
+    const isAddressTab = currentTab === segmentControlValues[0];
+
+    let qrValue: string | undefined;
+    let copyText: string | undefined;
+
+    if (isAddressTab) {
+      if (!address) return null;
+      qrValue = bip21encoded;
+      copyText = isCustom ? bip21encoded : address;
     } else if (wallet && isBIP47Enabled) {
-      // wallet is always defined here
-      const qrValue =
-        'getBIP47PaymentCode' in wallet && typeof wallet.getBIP47PaymentCode === 'function' ? wallet.getBIP47PaymentCode() : undefined;
-      return (
-        <View style={styles.container}>
-          {qrValue ? (
-            <>
-              <TipBox description={loc.receive.bip47_explanation} containerStyle={styles.tip} />
-              <View style={styles.qrCodeContainer}>
-                <QRCode value={qrValue} size={qrCodeSize} />
-              </View>
-              <CopyTextToClipboard text={qrValue} truncated={false} />
-            </>
-          ) : (
-            <Text>{loc.bip47.not_found}</Text>
-          )}
-        </View>
-      );
-    } else {
-      return null;
+      qrValue = paymentCodeString || undefined;
+      copyText = paymentCodeString || undefined;
     }
+
+    const showTabs = Boolean(wallet && isBIP47Enabled);
+    const showTip = !isAddressTab && Boolean(qrValue);
+    const showCustomAmount = isAddressTab && isCustom;
+    const displayCopyText = copyText && isAddressTab ? toBalancedMultilineText(copyText) : undefined;
+
+    return (
+      <Pressable
+        onPress={handleCardPress}
+        onPressIn={handlePressIn}
+        onPressOut={handlePressOut}
+        disabled={!copyText}
+        style={styles.cardPressable}
+        accessibilityRole="button"
+        accessibilityLabel={loc.transactions.details_copy}
+        testID="ReceiveCard"
+      >
+        <Animated.View style={[styles.receiveCard, stylesHook.receiveCard, stylesHook.receiveCardColumn, pressAnimatedStyle]}>
+          {showTabs && (
+            <View
+              style={styles.tabsInsideCard}
+              // Keep tab interactions local: tapping segmented control should not
+              // trigger the parent receive-card copy press.
+              onStartShouldSetResponder={() => true}
+            >
+              <SegmentedControl
+                values={segmentControlValues}
+                selectedIndex={segmentControlValues.findIndex(tab => tab === currentTab)}
+                onChange={index => setCurrentTab(segmentControlValues[index])}
+              />
+            </View>
+          )}
+
+          {showTip && <BlueText style={[styles.paymentCodeDescription, stylesHook.label]}>{loc.receive.bip47_explanation}</BlueText>}
+
+          {showCustomAmount && (
+            <View style={styles.customAmountWrapper}>
+              {getDisplayAmount() && (
+                <BlueText testID="BitcoinAmountText" style={[styles.amount, stylesHook.amount]} numberOfLines={1}>
+                  {getDisplayAmount()}
+                </BlueText>
+              )}
+              {customLabel?.length > 0 && (
+                <BlueText testID="CustomAmountDescriptionText" style={[styles.label, stylesHook.label]} numberOfLines={1}>
+                  {customLabel}
+                </BlueText>
+              )}
+            </View>
+          )}
+
+          {qrValue ? (
+            <View style={styles.qrCardWrapper}>
+              <QrStaggerReveal size={qrCodeSize} maskColor="#FFFFFF" runKey={`${currentTab}|${qrValue}`}>
+                <QRCode value={qrValue} size={qrCodeSize} />
+              </QrStaggerReveal>
+            </View>
+          ) : (
+            <View style={styles.bip47NotFoundContainer}>
+              <Text style={stylesHook.bip47NotFound}>{loc.bip47.not_found}</Text>
+            </View>
+          )}
+
+          {copyText && (
+            <>
+              <View style={styles.cardSpacer} />
+              <View style={styles.addressRow}>
+                <CopyTextToClipboard
+                  ref={copyRef}
+                  text={copyText}
+                  displayText={displayCopyText}
+                  isAddress={isAddressTab}
+                  truncated={false}
+                  interactive={false}
+                  textStyle={styles.cardAddressText}
+                  containerStyle={styles.addressCopyContainer}
+                />
+              </View>
+            </>
+          )}
+        </Animated.View>
+      </Pressable>
+    );
   };
 
   const hasIncomingCustomParams =
@@ -547,27 +791,17 @@ const ReceiveDetails = () => {
         style={stylesHook.root}
         contentContainerStyle={[styles.root, stylesHook.root]}
         keyboardShouldPersistTaps="always"
-        onLayout={onLayout}
-        stickyHeaderIndices={wallet && isBIP47Enabled ? [0] : []}
+        onLayout={onScrollViewLayout}
       >
-        {wallet && isBIP47Enabled && (
-          <StickyHeader
-            wallet={wallet}
-            isBIP47Enabled={isBIP47Enabled}
-            tabValues={segmentControlValues}
-            currentTab={currentTab}
-            setCurrentTab={setCurrentTab}
-            backgroundColor={colors.elevated}
-          />
-        )}
-        {showAddress && renderTabContent()}
+        {showAddress && renderReceiveCard()}
+        {showReceiveSkeleton && renderReceiveSkeleton()}
         {showAddress && address !== undefined && (
           <HandOffComponent title={loc.send.details_address} type={HandOffActivityType.ReceiveOnchain} userInfo={{ address }} />
         )}
         {showConfirmedBalance && renderConfirmedBalance()}
         {showPendingBalance && renderPendingBalance()}
 
-        {!showAddress && !showPendingBalance && !showConfirmedBalance && (
+        {!showAddress && !showPendingBalance && !showConfirmedBalance && !showReceiveSkeleton && (
           <View style={styles.loadingContainer}>
             <BlueLoading />
           </View>
@@ -603,13 +837,6 @@ const styles = StyleSheet.create({
   flex: {
     flex: 1,
   },
-  tabsContainer: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    backgroundColor: Platform.OS === 'ios' ? 'transparent' : undefined,
-  },
   scrollBody: {
     flex: 1,
     alignItems: 'center',
@@ -634,20 +861,72 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     paddingBottom: 12,
   },
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+  cardPressable: {
+    alignSelf: 'center',
+    marginHorizontal: CARD_HORIZONTAL_MARGIN,
+    marginTop: HEADER_TO_RECEIVE_CARD,
+    marginBottom: 8,
   },
-  tip: {
-    marginHorizontal: 16,
-    borderRadius: 12,
-    padding: 16,
-  },
-  qrCodeContainer: {
+  receiveCard: {
+    borderRadius: 26,
+    paddingHorizontal: CARD_INTERNAL_PADDING,
+    paddingTop: CARD_INTERNAL_PADDING,
+    paddingBottom: 16,
     alignItems: 'center',
-    justifyContent: 'center',
+  },
+  tabsInsideCard: {
     width: '100%',
+    paddingHorizontal: 8,
+    paddingTop: 4,
+    paddingBottom: 8,
+  },
+  paymentCodeDescription: {
+    alignSelf: 'stretch',
+    textAlign: 'left',
+    paddingHorizontal: 8,
+    paddingTop: 4,
+    paddingBottom: 8,
+  },
+  customAmountWrapper: {
+    width: '100%',
+    paddingHorizontal: 8,
+    paddingTop: 8,
+  },
+  qrCardWrapper: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 20,
+    padding: QR_CARD_PADDING,
+    alignSelf: 'center',
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.12,
+    shadowRadius: 12,
+    elevation: 4,
+  },
+  qrPlaceholder: {
+    borderRadius: 4,
+  },
+  cardSpacer: {
+    height: QR_TO_ADDRESS_GAP,
+  },
+  addressRow: {
+    alignSelf: 'stretch',
+    marginHorizontal: -CARD_INTERNAL_PADDING,
+    paddingHorizontal: ADDRESS_HORIZONTAL_PADDING,
+  },
+  addressCopyContainer: {
+    paddingHorizontal: 0,
+    minHeight: ADDRESS_AREA_MIN_HEIGHT,
+    justifyContent: 'center',
+  },
+  cardAddressText: {
+    marginVertical: 0,
+  },
+  bip47NotFoundContainer: {
+    paddingVertical: 40,
+    alignItems: 'center',
   },
   loadingContainer: {
     flex: 1,

--- a/screen/wallets/ViewEditMultisigShareCosignerSheet.tsx
+++ b/screen/wallets/ViewEditMultisigShareCosignerSheet.tsx
@@ -29,7 +29,9 @@ const ViewEditMultisigShareCosignerSheet = () => {
           <QRCode value={cosignerXpubURv2} size={260} />
         </View>
         <BlueSpacing20 />
-        <CopyTextToClipboard text={cosignerXpub} truncated={false} />
+        <View style={styles.copyText}>
+          <CopyTextToClipboard text={cosignerXpub} truncated={false} />
+        </View>
       </View>
     </SafeAreaView>
   );
@@ -47,6 +49,10 @@ const styles = StyleSheet.create({
   },
   qrContainer: {
     alignItems: 'center',
+  },
+  copyText: {
+    marginVertical: 32,
+    paddingHorizontal: 16,
   },
 });
 

--- a/screen/wallets/WalletsAddMultisigCosignerXpubSheet.tsx
+++ b/screen/wallets/WalletsAddMultisigCosignerXpubSheet.tsx
@@ -32,7 +32,9 @@ const WalletsAddMultisigCosignerXpubSheet = () => {
           <QRCode value={cosignerXpubURv2} size={260} />
         </View>
         <BlueSpacing20 />
-        <CopyTextToClipboard text={cosignerXpub} truncated={false} />
+        <View style={styles.copyText}>
+          <CopyTextToClipboard text={cosignerXpub} truncated={false} />
+        </View>
       </View>
       <View style={styles.footer}>
         <Button title={loc.send.success_done} onPress={() => navigation.goBack()} />
@@ -57,6 +59,10 @@ const styles = StyleSheet.create({
   footer: {
     paddingHorizontal: 22,
     paddingVertical: 16,
+  },
+  copyText: {
+    marginVertical: 32,
+    paddingHorizontal: 16,
   },
 });
 

--- a/screen/wallets/pleaseBackupLNDHub.tsx
+++ b/screen/wallets/pleaseBackupLNDHub.tsx
@@ -41,6 +41,10 @@ const PleaseBackupLNDHub = () => {
       padding: 20,
       paddingHorizontal: 30, // Added additional horizontal padding
     },
+    copyText: {
+      marginVertical: 32,
+      paddingHorizontal: 16,
+    },
   });
 
   useEffect(() => {
@@ -70,7 +74,9 @@ const PleaseBackupLNDHub = () => {
       </View>
       <BlueSpacing20 />
       <QRCode value={wallet.getSecret()} size={qrCodeSize} />
-      <CopyTextToClipboard text={wallet.getSecret()} />
+      <View style={styles.copyText}>
+        <CopyTextToClipboard text={wallet.getSecret()} />
+      </View>
       <BlueSpacing20 />
       <Button onPress={dismiss} title={loc.pleasebackup.ok_lnd} />
     </SafeAreaScrollView>

--- a/screen/wallets/xpub.styles.ts
+++ b/screen/wallets/xpub.styles.ts
@@ -17,6 +17,10 @@ export const styles = StyleSheet.create({
     alignSelf: 'center',
     width: '40%',
   },
+  copyText: {
+    marginVertical: 32,
+    paddingHorizontal: 16,
+  },
 });
 
 export const useDynamicStyles = () => {

--- a/screen/wallets/xpub.tsx
+++ b/screen/wallets/xpub.tsx
@@ -120,7 +120,11 @@ const WalletXpub: React.FC = () => {
             )}
             <QRCode value={xPubText || xpub} size={qrCodeSize} />
 
-            {xPubText && <CopyTextToClipboard text={xPubText} />}
+            {xPubText && (
+              <View style={styles.copyText}>
+                <CopyTextToClipboard text={xPubText} />
+              </View>
+            )}
           </View>
           <HandOffComponent title={loc.wallets.xpub_title} type={HandOffActivityType.Xpub} userInfo={{ xpub: xPubText }} />
           <View style={styles.share}>

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -19,6 +19,7 @@ import {
   waitForId,
   waitForKeyboardToClose,
   waitForText,
+  waitForLabel,
 } from './helperz';
 
 // if loglevel is set to `error`, this kind of logging will still get through
@@ -590,7 +591,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
       await element(by.text(`No, and do not ask me again.`)).tap(); // sometimes the first click doesnt work (detox issue, not app's)
     } catch (_) {}
 
-    await waitForText('bc1qmf06nt4jhvzz4387ak8fecs42k6jqygr2unumetfc7xkdup7ah9s8phlup');
+    await waitForLabel('bc1qmf06nt4jhvzz4387ak8fecs42k6jqygr2unumetfc7xkdup7ah9s8phlup');
     await goBack();
 
     await element(by.id('WalletDetails')).tap();

--- a/tests/e2e/bluewallet3.spec.js
+++ b/tests/e2e/bluewallet3.spec.js
@@ -58,7 +58,7 @@ describe('BlueWallet UI Tests - import Watch-only wallet (zpub)', () => {
       await element(by.text(`No, and do not ask me again.`)).tap(); // sometimes the first click doesnt work (detox issue, not app's)
     } catch (_) {}
     await expect(element(by.id('BitcoinAddressQRCode'))).toBeVisible();
-    await expect(element(by.text('bc1qgrhr5xc5774maph97d73ydrjlqqmg2v6jjlr29'))).toBeVisible();
+    await expect(element(by.label('bc1qgrhr5xc5774maph97d73ydrjlqqmg2v6jjlr29'))).toBeVisible();
     await element(by.id('SetCustomAmountButton')).tap();
     await element(by.id('BitcoinAmountInput')).replaceText('1');
     await element(by.id('CustomAmountDescription')).typeText('Test');
@@ -70,7 +70,7 @@ describe('BlueWallet UI Tests - import Watch-only wallet (zpub)', () => {
 
     await expect(element(by.id('BitcoinAddressQRCode'))).toBeVisible();
 
-    await expect(element(by.text('bitcoin:BC1QGRHR5XC5774MAPH97D73YDRJLQQMG2V6JJLR29?amount=1&label=Test'))).toBeVisible();
+    await expect(element(by.label('bitcoin:BC1QGRHR5XC5774MAPH97D73YDRJLQQMG2V6JJLR29?amount=1&label=Test'))).toBeVisible();
     await goBack();
     await element(by.id('SendButton')).tap();
     await element(by.text('OK')).tap();

--- a/tests/e2e/helperz.js
+++ b/tests/e2e/helperz.js
@@ -63,6 +63,27 @@ export async function waitForText(text, timeout = 33000) {
   }
 }
 
+/** Waits for `accessibilityLabel` (Detox `by.label`), e.g. full address while UI text is multiline. */
+export async function waitForLabel(label, timeout = 33000) {
+  const callsite = captureCallsite(waitForLabel);
+  try {
+    await waitFor(element(by.label(label)))
+      .toBeVisible()
+      .withTimeout(timeout / 2);
+    return true;
+  } catch (_) {
+    // nop
+  }
+
+  try {
+    await waitFor(element(by.label(label)))
+      .toBeVisible()
+      .withTimeout(timeout / 2);
+  } catch (err) {
+    rethrowWithCallsite(err, callsite);
+  }
+}
+
 export async function getSwitchValue(switchId) {
   try {
     await expect(element(by.id(switchId))).toHaveToggleValue(true);


### PR DESCRIPTION
Redesigns the receive screen, more polished but still simple with smooth animations to feel less web-ish.

- Adds a container to make the entire area copyable
- A fade in animation to not show the loading image, so it feels faster to the user (400ms)

https://github.com/user-attachments/assets/89ec5dbc-8c7f-4d96-8a85-60c3ebfd7727

