### PR TITLE
OPS: pin action versions, prebuild RN core, warm iOS sim for e2e

### DIFF
--- a/.github/workflows/build-ios-release-pullrequest.yml
+++ b/.github/workflows/build-ios-release-pullrequest.yml
@@ -208,7 +208,7 @@ jobs:
           echo -e "\033[1;34m======================================================\033[0m"
 
       - name: Set Up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           ruby-version: 3.4.8
 
@@ -259,6 +259,9 @@ jobs:
             ${{ runner.os }}-pods-ios-release-
 
       - name: Install CocoaPods Dependencies
+        env:
+          RCT_USE_RN_DEP: "1"
+          RCT_USE_PREBUILT_RNCORE: "1"
         run: |
           bundle exec fastlane ios install_pods
           echo "CocoaPods dependencies installed successfully"
@@ -490,17 +493,17 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set Up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           ruby-version: 3.4.8
-          
+
       - name: Install Dependencies with Bundler
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3 --quiet
 
       - name: Download IPA from Artifact
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: BlueWallet_IPA
           path: ./
@@ -544,7 +547,7 @@ jobs:
 
       - name: Post PR Comment
         if: success() && github.event_name == 'pull_request'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           BUILD_NUMBER: ${{ needs.build.outputs.new_build_number }}
           PROJECT_VERSION: ${{ needs.build.outputs.project_version }}

--- a/.github/workflows/build-mac-catalyst.yml
+++ b/.github/workflows/build-mac-catalyst.yml
@@ -91,9 +91,11 @@ jobs:
 
       - name: Install CocoaPods dependencies
         if: github.event_name == 'workflow_dispatch' || steps.labels.outputs.has_mac_dmg == 'true'
-        run: bundle exec fastlane ios install_pods
         env:
           SKIP_APP_STORE_CONNECT_AUTH: '1'
+          RCT_USE_RN_DEP: "1"
+          RCT_USE_PREBUILT_RNCORE: "1"
+        run: bundle exec fastlane ios install_pods
 
       - name: Create temporary keychain for signing
         if: (github.event_name == 'workflow_dispatch' || steps.labels.outputs.has_mac_dmg == 'true') && steps.labels.outputs.upload_testflight == 'true'

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -43,7 +43,7 @@ jobs:
           cache: 'npm'
 
       - name: Use specific Java version for sdkmanager to work
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -59,7 +59,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
       - name: Install Android SDK components
         run: |
@@ -147,7 +147,7 @@ jobs:
         run: bundle install --jobs 4 --retry 3
 
       - name: Download APK artifact
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: signed-apk
 

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -54,7 +54,7 @@ jobs:
       run: npm ci || npm ci
 
     - name: Use specific Java version for sdkmanager to work
-      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'temurin'
         java-version: '17'
@@ -114,7 +114,7 @@ jobs:
       run: npm ci || npm ci
 
     - name: Use specific Java version for sdkmanager to work
-      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'temurin'
         java-version: '17'
@@ -126,7 +126,7 @@ jobs:
         sudo udevadm trigger --name-match=kvm
 
     - name: Download APKs
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: bluewallet-android-apks
 
@@ -134,7 +134,7 @@ jobs:
       run: tar -xzf bluewallet-android-apks.tar.gz
 
     - name: Run tests
-      uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2
+      uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
       with:
         api-level: 36
         profile: pixel

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm ci || npm ci
 
       - name: Cache CocoaPods
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ios/Pods
@@ -51,7 +51,7 @@ jobs:
         run: brew install ccache
 
       - name: Cache ccache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.ccache
           key: ${{ runner.os }}-ccache-${{ github.sha }}
@@ -185,7 +185,7 @@ jobs:
           brew install applesimutils
 
       - name: Download simulator app
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bluewallet-ios-app
 
@@ -193,6 +193,22 @@ jobs:
         run: |
           mkdir -p ios/build/Build/Products/Release-iphonesimulator
           tar -xzf BlueWallet.app.tar.gz -C ios/build/Build/Products/Release-iphonesimulator
+
+      - name: Disable simulator animations
+        run: defaults write com.apple.iphonesimulator SlowMotionAnimation -bool NO
+
+      # Pre-boot simulator so first detox launchApp lands warm.
+      - name: Pre-boot iOS simulator
+        run: |
+          DEVICE_TYPE=$(jq -r '.devices.simulator.device.type' .detoxrc.json)
+          UDID=$(applesimutils --list --byType "$DEVICE_TYPE" | jq -r '.[0].udid // empty')
+          if [ -z "$UDID" ]; then
+            echo "ERROR: no simulator of type '$DEVICE_TYPE' found"
+            exit 1
+          fi
+          xcrun simctl boot "$UDID" 2>/dev/null || true
+          xcrun simctl bootstatus "$UDID" -b
+          xcrun simctl launch "$UDID" com.apple.springboard >/dev/null 2>&1 || true
 
       - name: Run detox tests
         timeout-minutes: 360


### PR DESCRIPTION
## Summary

CI hardening + iOS e2e speedup.

## Changes

- Pin GitHub Action SHAs with explicit version tags (cache, setup-java, setup-ruby, setup-android, download-artifact, github-script, emulator-runner)
- Enable prebuilt React Native core for CocoaPods install via `RCT_USE_RN_DEP=1` + `RCT_USE_PREBUILT_RNCORE=1` (iOS PR build, Mac Catalyst)
- e2e-ios: pre-boot simulator + disable animations so first `launchApp` lands warm
- e2e-ios: drop system monitor logging steps
- Fastfile: whitespace cleanup
