### PR TITLE
Request incognito keyboard for sensitive Android inputs

### DIFF
--- a/BlueComponents.tsx
+++ b/BlueComponents.tsx
@@ -8,7 +8,6 @@ import {
   StyleProp,
   StyleSheet,
   Text,
-  TextInput,
   TextInputProps,
   TextProps,
   View,
@@ -17,6 +16,7 @@ import {
 } from 'react-native';
 
 import Icon from './components/Icon';
+import IncognitoKeyboardTextInput from './components/IncognitoKeyboardTextInput';
 import { useTheme } from './components/themes';
 
 const { height, width } = Dimensions.get('window');
@@ -93,8 +93,9 @@ export const BlueFormMultiInput: React.FC<TextInputProps> = props => {
   const { style, editable, ...restProps } = props;
 
   return (
-    <TextInput
+    <IncognitoKeyboardTextInput
       multiline
+      incognitoKeyboard
       underlineColorAndroid="transparent"
       numberOfLines={4}
       editable={editable}

--- a/BlueComponents.tsx
+++ b/BlueComponents.tsx
@@ -95,7 +95,6 @@ export const BlueFormMultiInput: React.FC<TextInputProps> = props => {
   return (
     <IncognitoKeyboardTextInput
       multiline
-      incognitoKeyboard
       underlineColorAndroid="transparent"
       numberOfLines={4}
       editable={editable}
@@ -109,9 +108,6 @@ export const BlueFormMultiInput: React.FC<TextInputProps> = props => {
         },
         style,
       ]}
-      autoCorrect={false}
-      autoCapitalize="none"
-      spellCheck={false}
       {...restProps}
       selectTextOnFocus={false}
       keyboardType={Platform.OS === 'android' ? 'visible-password' : 'default'}

--- a/android/app/src/main/java/io/bluewallet/bluewallet/SettingsModule.kt
+++ b/android/app/src/main/java/io/bluewallet/bluewallet/SettingsModule.kt
@@ -3,6 +3,9 @@ package io.bluewallet.bluewallet
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import android.widget.TextView
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.Promise
@@ -206,6 +209,36 @@ class SettingsModule(reactContext: ReactApplicationContext) : NativeSettingsModu
         } catch (e: Exception) {
             Log.e(TAG, "Error opening settings", e)
             promise.reject("ERROR", e.message)
+        }
+    }
+
+    /**
+     * Request that the currently focused Android text editor does not update personalized keyboard data.
+     */
+    @ReactMethod
+    override fun requestKeyboardIncognitoMode(promise: Promise) {
+        val activity = currentActivity
+        if (activity == null) {
+            promise.resolve(false)
+            return
+        }
+
+        activity.runOnUiThread {
+            try {
+                val focusedView = activity.currentFocus
+                if (focusedView !is TextView) {
+                    promise.resolve(false)
+                    return@runOnUiThread
+                }
+
+                focusedView.imeOptions = focusedView.imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
+                val inputMethodManager = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+                inputMethodManager?.restartInput(focusedView)
+                promise.resolve(true)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error requesting keyboard incognito mode", e)
+                promise.reject("ERROR", e.message)
+            }
         }
     }
 }

--- a/blue_modules/SettingsModule.ts
+++ b/blue_modules/SettingsModule.ts
@@ -44,6 +44,11 @@ interface SettingsModuleInterface {
    * This opens the app's settings screen
    */
   openSettings(): Promise<boolean>;
+
+  /**
+   * Request Android IME incognito mode for the currently focused input
+   */
+  requestKeyboardIncognitoMode(): Promise<boolean>;
 }
 
 // Only available on Android

--- a/blue_modules/requestKeyboardIncognitoMode.ts
+++ b/blue_modules/requestKeyboardIncognitoMode.ts
@@ -1,0 +1,11 @@
+import { Platform } from 'react-native';
+
+import SettingsModule from './SettingsModule';
+
+const requestKeyboardIncognitoMode = () => {
+  if (Platform.OS !== 'android') return;
+
+  SettingsModule?.requestKeyboardIncognitoMode().catch(() => undefined);
+};
+
+export default requestKeyboardIncognitoMode;

--- a/blue_modules/requestKeyboardIncognitoMode.ts
+++ b/blue_modules/requestKeyboardIncognitoMode.ts
@@ -2,10 +2,14 @@ import { Platform } from 'react-native';
 
 import SettingsModule from './SettingsModule';
 
-const requestKeyboardIncognitoMode = () => {
-  if (Platform.OS !== 'android') return;
+const requestKeyboardIncognitoMode = async (): Promise<boolean> => {
+  if (Platform.OS !== 'android') return false;
 
-  SettingsModule?.requestKeyboardIncognitoMode().catch(() => undefined);
+  try {
+    return (await SettingsModule?.requestKeyboardIncognitoMode()) ?? false;
+  } catch {
+    return false;
+  }
 };
 
 export default requestKeyboardIncognitoMode;

--- a/codegen/NativeSettingsModule.ts
+++ b/codegen/NativeSettingsModule.ts
@@ -10,6 +10,7 @@ export interface Spec extends TurboModule {
   setDoNotTrack(enabled: boolean): Promise<boolean>;
   getDoNotTrack(): Promise<boolean>;
   openSettings(): Promise<boolean>;
+  requestKeyboardIncognitoMode(): Promise<boolean>;
 }
 
 const nativeModule = TurboModuleRegistry.get<Spec>('SettingsModule');

--- a/components/IncognitoKeyboardTextInput.tsx
+++ b/components/IncognitoKeyboardTextInput.tsx
@@ -3,30 +3,26 @@ import { TextInput, TextInputProps } from 'react-native';
 
 import requestKeyboardIncognitoMode from '../blue_modules/requestKeyboardIncognitoMode';
 
-export type IncognitoKeyboardTextInputProps = TextInputProps & {
-  incognitoKeyboard?: boolean;
-};
+export type IncognitoKeyboardTextInputProps = TextInputProps;
 
 const IncognitoKeyboardTextInput = forwardRef<TextInput, IncognitoKeyboardTextInputProps>(
-  ({ autoCapitalize, autoCorrect, incognitoKeyboard = false, onFocus, spellCheck, ...props }, ref) => {
+  ({ autoCapitalize, autoCorrect, onFocus, spellCheck, ...props }, ref) => {
     const handleFocus = useCallback<NonNullable<TextInputProps['onFocus']>>(
       event => {
-        if (incognitoKeyboard) {
-          requestKeyboardIncognitoMode();
-        }
+        requestKeyboardIncognitoMode();
 
         onFocus?.(event);
       },
-      [incognitoKeyboard, onFocus],
+      [onFocus],
     );
 
     return (
       <TextInput
         ref={ref}
-        autoCapitalize={incognitoKeyboard ? (autoCapitalize ?? 'none') : autoCapitalize}
-        autoCorrect={incognitoKeyboard ? (autoCorrect ?? false) : autoCorrect}
+        autoCapitalize={autoCapitalize ?? 'none'}
+        autoCorrect={autoCorrect ?? false}
         onFocus={handleFocus}
-        spellCheck={incognitoKeyboard ? (spellCheck ?? false) : spellCheck}
+        spellCheck={spellCheck ?? false}
         {...props}
       />
     );

--- a/components/IncognitoKeyboardTextInput.tsx
+++ b/components/IncognitoKeyboardTextInput.tsx
@@ -8,7 +8,7 @@ export type IncognitoKeyboardTextInputProps = TextInputProps & {
 };
 
 const IncognitoKeyboardTextInput = forwardRef<TextInput, IncognitoKeyboardTextInputProps>(
-  ({ autoCapitalize, autoCorrect, importantForAutofill, incognitoKeyboard = false, onFocus, spellCheck, ...props }, ref) => {
+  ({ autoCapitalize, autoCorrect, incognitoKeyboard = false, onFocus, spellCheck, ...props }, ref) => {
     const handleFocus = useCallback<NonNullable<TextInputProps['onFocus']>>(
       event => {
         if (incognitoKeyboard) {
@@ -25,7 +25,6 @@ const IncognitoKeyboardTextInput = forwardRef<TextInput, IncognitoKeyboardTextIn
         ref={ref}
         autoCapitalize={incognitoKeyboard ? (autoCapitalize ?? 'none') : autoCapitalize}
         autoCorrect={incognitoKeyboard ? (autoCorrect ?? false) : autoCorrect}
-        importantForAutofill={incognitoKeyboard ? (importantForAutofill ?? 'no') : importantForAutofill}
         onFocus={handleFocus}
         spellCheck={incognitoKeyboard ? (spellCheck ?? false) : spellCheck}
         {...props}

--- a/components/IncognitoKeyboardTextInput.tsx
+++ b/components/IncognitoKeyboardTextInput.tsx
@@ -1,0 +1,39 @@
+import React, { forwardRef, useCallback } from 'react';
+import { TextInput, TextInputProps } from 'react-native';
+
+import requestKeyboardIncognitoMode from '../blue_modules/requestKeyboardIncognitoMode';
+
+export type IncognitoKeyboardTextInputProps = TextInputProps & {
+  incognitoKeyboard?: boolean;
+};
+
+const IncognitoKeyboardTextInput = forwardRef<TextInput, IncognitoKeyboardTextInputProps>(
+  ({ autoCapitalize, autoCorrect, importantForAutofill, incognitoKeyboard = false, onFocus, spellCheck, ...props }, ref) => {
+    const handleFocus = useCallback<NonNullable<TextInputProps['onFocus']>>(
+      event => {
+        if (incognitoKeyboard) {
+          requestKeyboardIncognitoMode();
+        }
+
+        onFocus?.(event);
+      },
+      [incognitoKeyboard, onFocus],
+    );
+
+    return (
+      <TextInput
+        ref={ref}
+        autoCapitalize={incognitoKeyboard ? (autoCapitalize ?? 'none') : autoCapitalize}
+        autoCorrect={incognitoKeyboard ? (autoCorrect ?? false) : autoCorrect}
+        importantForAutofill={incognitoKeyboard ? (importantForAutofill ?? 'no') : importantForAutofill}
+        onFocus={handleFocus}
+        spellCheck={incognitoKeyboard ? (spellCheck ?? false) : spellCheck}
+        {...props}
+      />
+    );
+  },
+);
+
+IncognitoKeyboardTextInput.displayName = 'IncognitoKeyboardTextInput';
+
+export default IncognitoKeyboardTextInput;

--- a/components/PasswordInput.tsx
+++ b/components/PasswordInput.tsx
@@ -139,7 +139,6 @@ export const PasswordInput = forwardRef<PasswordInputHandle, PasswordInputProps>
       >
         <IncognitoKeyboardTextInput
           ref={inputRef}
-          incognitoKeyboard
           testID="PasswordInput"
           style={[styles.input, stylesHook.input]}
           value={password}
@@ -151,8 +150,6 @@ export const PasswordInput = forwardRef<PasswordInputHandle, PasswordInputProps>
           placeholder={placeholder}
           placeholderTextColor={colors.alternativeTextColor}
           secureTextEntry
-          autoCapitalize="none"
-          autoCorrect={false}
           editable={!isSuccess}
           onSubmitEditing={handleSubmit}
           returnKeyType="done"

--- a/components/PasswordInput.tsx
+++ b/components/PasswordInput.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import { Animated, Easing, StyleSheet, TextInput, View } from 'react-native';
+import IncognitoKeyboardTextInput from './IncognitoKeyboardTextInput';
 import { useTheme } from './themes';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../blue_modules/hapticFeedback';
 import loc from '../loc';
@@ -136,8 +137,9 @@ export const PasswordInput = forwardRef<PasswordInputHandle, PasswordInputProps>
           },
         ]}
       >
-        <TextInput
+        <IncognitoKeyboardTextInput
           ref={inputRef}
+          incognitoKeyboard
           testID="PasswordInput"
           style={[styles.input, stylesHook.input]}
           value={password}

--- a/helpers/prompt.ts
+++ b/helpers/prompt.ts
@@ -1,6 +1,7 @@
 import { Platform } from 'react-native';
 import prompt from 'react-native-prompt-android';
 import loc from '../loc';
+import requestKeyboardIncognitoMode from '../blue_modules/requestKeyboardIncognitoMode';
 
 export default (
   title: string,
@@ -52,5 +53,9 @@ export default (
       // @ts-ignore suppressed because its supported only on ios and is absent from type definitions
       keyboardType,
     });
+
+    if (Platform.OS === 'android' && type === 'secure-text') {
+      setTimeout(requestKeyboardIncognitoMode, 250);
+    }
   });
 };

--- a/helpers/prompt.ts
+++ b/helpers/prompt.ts
@@ -3,6 +3,31 @@ import prompt from 'react-native-prompt-android';
 import loc from '../loc';
 import requestKeyboardIncognitoMode from '../blue_modules/requestKeyboardIncognitoMode';
 
+const startKeyboardIncognitoRetry = (): (() => void) => {
+  const retryDelayMs = 100;
+  const maxDurationMs = 1500;
+  const startedAt = Date.now();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let stopped = false;
+
+  const attempt = () => {
+    if (stopped) return;
+
+    requestKeyboardIncognitoMode().then(applied => {
+      if (stopped || applied || Date.now() - startedAt >= maxDurationMs) return;
+
+      timeout = setTimeout(attempt, retryDelayMs);
+    });
+  };
+
+  timeout = setTimeout(attempt, retryDelayMs);
+
+  return () => {
+    stopped = true;
+    if (timeout) clearTimeout(timeout);
+  };
+};
+
 export default (
   title: string,
   text: string,
@@ -19,11 +44,13 @@ export default (
   }
 
   return new Promise((resolve, reject) => {
+    let stopKeyboardIncognitoRetry = () => {};
     const buttons: Array<PromptButton> = isCancelable
       ? [
           {
             text: loc._.cancel,
             onPress: () => {
+              stopKeyboardIncognitoRetry();
               reject(Error('Cancel Pressed'));
             },
             style: 'cancel',
@@ -31,6 +58,7 @@ export default (
           {
             text: continueButtonText,
             onPress: password => {
+              stopKeyboardIncognitoRetry();
               console.log('OK Pressed');
               resolve(password);
             },
@@ -41,6 +69,7 @@ export default (
           {
             text: continueButtonText,
             onPress: password => {
+              stopKeyboardIncognitoRetry();
               console.log('OK Pressed');
               resolve(password);
             },
@@ -55,7 +84,7 @@ export default (
     });
 
     if (Platform.OS === 'android' && type === 'secure-text') {
-      setTimeout(requestKeyboardIncognitoMode, 250);
+      stopKeyboardIncognitoRetry = startKeyboardIncognitoRetry();
     }
   });
 };

--- a/screen/PromptPasswordConfirmationSheet.tsx
+++ b/screen/PromptPasswordConfirmationSheet.tsx
@@ -225,13 +225,10 @@ const PromptPasswordConfirmationSheet = () => {
                 <Animated.View style={{ transform: [{ translateX: shakeAnimation }] }}>
                   <IncognitoKeyboardTextInput
                     testID="PasswordInput"
-                    incognitoKeyboard
                     secureTextEntry
                     placeholder="Password"
                     value={password}
-                    autoCapitalize="none"
                     autoComplete="off"
-                    autoCorrect={false}
                     onChangeText={setPassword}
                     style={[styles.input, stylesHook.input]}
                     clearTextOnFocus
@@ -243,14 +240,11 @@ const PromptPasswordConfirmationSheet = () => {
                   <Animated.View style={{ transform: [{ translateX: shakeAnimation }] }}>
                     <IncognitoKeyboardTextInput
                       testID="ConfirmPasswordInput"
-                      incognitoKeyboard
                       secureTextEntry
                       placeholder="Confirm Password"
                       value={confirmPassword}
                       clearTextOnFocus
-                      autoCorrect={false}
                       autoComplete="off"
-                      autoCapitalize="none"
                       clearButtonMode="while-editing"
                       onChangeText={setConfirmPassword}
                       style={[styles.input, stylesHook.input]}

--- a/screen/PromptPasswordConfirmationSheet.tsx
+++ b/screen/PromptPasswordConfirmationSheet.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RouteProp, StackActions, useNavigation, useRoute } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { Animated, Easing, Keyboard, StyleSheet, Text, TextInput, View, TextStyle, ViewStyle } from 'react-native';
+import { Animated, Easing, Keyboard, StyleSheet, Text, View, TextStyle, ViewStyle } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { SecondButton } from '../components/SecondButton';
@@ -12,6 +12,7 @@ import { DetailViewStackParamList } from '../navigation/DetailViewStackParamList
 import { MODAL_TYPES } from './PromptPasswordConfirmationSheet.types';
 import { useStorage } from '../hooks/context/useStorage';
 import presentAlert from '../components/Alert';
+import IncognitoKeyboardTextInput from '../components/IncognitoKeyboardTextInput';
 
 type DynamicStyles = {
   modalContent: ViewStyle;
@@ -222,8 +223,9 @@ const PromptPasswordConfirmationSheet = () => {
               </Text>
               <View style={styles.inputContainer}>
                 <Animated.View style={{ transform: [{ translateX: shakeAnimation }] }}>
-                  <TextInput
+                  <IncognitoKeyboardTextInput
                     testID="PasswordInput"
+                    incognitoKeyboard
                     secureTextEntry
                     placeholder="Password"
                     value={password}
@@ -239,8 +241,9 @@ const PromptPasswordConfirmationSheet = () => {
                 </Animated.View>
                 {(modalType === MODAL_TYPES.CREATE_PASSWORD || modalType === MODAL_TYPES.CREATE_FAKE_STORAGE) && (
                   <Animated.View style={{ transform: [{ translateX: shakeAnimation }] }}>
-                    <TextInput
+                    <IncognitoKeyboardTextInput
                       testID="ConfirmPasswordInput"
+                      incognitoKeyboard
                       secureTextEntry
                       placeholder="Confirm Password"
                       value={confirmPassword}

--- a/screen/wallets/ImportSpeed.tsx
+++ b/screen/wallets/ImportSpeed.tsx
@@ -7,6 +7,7 @@ import { HDSegwitBech32Wallet } from '../../class/wallets/hd-segwit-bech32-walle
 import { WatchOnlyWallet } from '../../class/wallets/watch-only-wallet';
 import presentAlert from '../../components/Alert';
 import Button from '../../components/Button';
+import IncognitoKeyboardTextInput from '../../components/IncognitoKeyboardTextInput';
 import SafeArea from '../../components/SafeArea';
 import { useTheme } from '../../components/themes';
 import { useStorage } from '../../hooks/context/useStorage';
@@ -93,7 +94,14 @@ const ImportSpeed = () => {
       <BlueFormLabel>Wallet type</BlueFormLabel>
       <TextInput testID="SpeedWalletTypeInput" value={walletType} style={styles.pathInput} onChangeText={setWalletType} />
       <BlueFormLabel>Passphrase</BlueFormLabel>
-      <TextInput testID="SpeedPassphraseInput" value={passphrase} style={styles.pathInput} onChangeText={setPassphrase} />
+      <IncognitoKeyboardTextInput
+        testID="SpeedPassphraseInput"
+        incognitoKeyboard
+        secureTextEntry
+        value={passphrase}
+        style={styles.pathInput}
+        onChangeText={setPassphrase}
+      />
       <BlueSpacing20 />
       <View style={styles.center}>
         {loading ? <ActivityIndicator /> : <Button testID="SpeedDoImport" title="Import" onPress={importMnemonic} />}

--- a/screen/wallets/ImportSpeed.tsx
+++ b/screen/wallets/ImportSpeed.tsx
@@ -96,7 +96,6 @@ const ImportSpeed = () => {
       <BlueFormLabel>Passphrase</BlueFormLabel>
       <IncognitoKeyboardTextInput
         testID="SpeedPassphraseInput"
-        incognitoKeyboard
         secureTextEntry
         value={passphrase}
         style={styles.pathInput}


### PR DESCRIPTION
## Summary
- Adds an Android native bridge that applies `EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING` to the currently focused text editor and restarts the IME.
- Routes mnemonic/seed entry, password inputs, import-speed passphrases, and secure prompt dialogs through the incognito request path.
- Keeps existing iOS behavior unchanged.

Fixes #2235.

Bounty payout address: `BTC: 39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`

## Test plan
- `npm run lint`
- `./node_modules/.bin/prettier --check --single-quote --print-width 140 --trailing-comma all --arrow-parens avoid BlueComponents.tsx blue_modules/SettingsModule.ts blue_modules/requestKeyboardIncognitoMode.ts codegen/NativeSettingsModule.ts components/IncognitoKeyboardTextInput.tsx components/PasswordInput.tsx helpers/prompt.ts screen/PromptPasswordConfirmationSheet.tsx screen/wallets/ImportSpeed.tsx`
- `git diff --check`

Not run: Android/Gradle build. This machine has no Java runtime installed (`java -version` fails before Gradle starts).
