### PR TITLE
Add LNDHub LNURL-pay tipping UI

### DIFF
--- a/class/wallets/lightning-custodian-wallet.ts
+++ b/class/wallets/lightning-custodian-wallet.ts
@@ -224,6 +224,53 @@ export class LightningCustodianWallet extends LegacyWallet {
     return json.pay_req;
   }
 
+  async getLnurlPayInfo(): Promise<{ username: string | false; url?: string; lnurl?: string }> {
+    await this.checkLogin();
+
+    const response = await fetch(this.baseURI + '/lnurlpay', {
+      method: 'GET',
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer' + ' ' + this.access_token,
+      },
+    });
+    const json = await response.json();
+    if (!json) {
+      throw new Error('API failure: ' + response.statusText);
+    }
+
+    if (json.error) {
+      throw new Error('API error: ' + json.message + ' (code ' + json.code + ')');
+    }
+
+    return json;
+  }
+
+  async claimLnurlPayUsername(username: string): Promise<{ username: string | false; url?: string; lnurl?: string }> {
+    await this.checkLogin();
+
+    const response = await fetch(this.baseURI + '/lnurlpay/username', {
+      method: 'POST',
+      body: JSON.stringify({ username }),
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer' + ' ' + this.access_token,
+      },
+    });
+    const json = await response.json();
+    if (!json) {
+      throw new Error('API failure: ' + response.statusText);
+    }
+
+    if (json.error) {
+      throw new Error('API error: ' + json.message + ' (code ' + json.code + ')');
+    }
+
+    return json;
+  }
+
   /**
    * Uses login & pass stored in `this.secret` to authorize
    * and set internal `access_token` & `refresh_token`

--- a/loc/en.json
+++ b/loc/en.json
@@ -63,6 +63,11 @@
     "refill_create": "In order to proceed, please create a Bitcoin wallet to refill with.",
     "refill_external": "Refill with External Wallet",
     "refill_lnd_balance": "Refill Lightning Wallet Balance",
+    "lnurlpay_tipping": "LNURL-pay tipping",
+    "lnurlpay_tipping_claim": "Choose a public username for receiving tips. Use 3-32 letters, numbers, underscores, or hyphens.",
+    "lnurlpay_tipping_claim_button": "Claim",
+    "lnurlpay_tipping_no_username": "Tap to claim a public tipping username",
+    "lnurlpay_tipping_share": "Tap to share your tipping link",
     "sameWalletAsInvoiceError": "You cannot pay an invoice with the same wallet used to create it.",
     "title": "Manage Funds"
   },

--- a/screen/wallets/WalletDetails.tsx
+++ b/screen/wallets/WalletDetails.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, LayoutAnimation, StyleSheet, Switch, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import Share from 'react-native-share';
 import { writeFileAndExport } from '../../blue_modules/fs';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
 import { uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
@@ -36,6 +37,8 @@ import { BlueSpacing10, BlueSpacing20 } from '../../components/BlueSpacing';
 import { BlueLoading } from '../../components/BlueLoading';
 
 type RouteProps = RouteProp<DetailViewStackParamList, 'WalletDetails'>;
+type LnurlPayInfo = { username: string | false; url?: string; lnurl?: string };
+
 const WalletDetails: React.FC = () => {
   const { saveToDisk, wallets, txMetadata, handleWalletDeletion } = useStorage();
   const { isBiometricUseCapableAndEnabled } = useBiometrics();
@@ -63,6 +66,8 @@ const WalletDetails: React.FC = () => {
 
   const [masterFingerprint, setMasterFingerprint] = useState<string | undefined>();
   const [arkAddress, setArkAddress] = useState<string>('');
+  const [lnurlPayInfo, setLnurlPayInfo] = useState<LnurlPayInfo | undefined>();
+  const [isLnurlPayLoading, setIsLnurlPayLoading] = useState<boolean>(false);
   const walletTransactionsLength = useMemo<number>(() => wallet.getTransactions().length, [wallet]);
   const derivationPath = useMemo<string | null>(() => {
     try {
@@ -94,6 +99,20 @@ const WalletDetails: React.FC = () => {
     };
 
     fetchArkAddress();
+  }, [wallet]);
+
+  useEffect(() => {
+    const fetchLnurlPayInfo = async () => {
+      if (!(wallet instanceof LightningCustodianWallet)) return;
+
+      try {
+        setLnurlPayInfo(await wallet.getLnurlPayInfo());
+      } catch (error: any) {
+        console.log('LNURL-pay tipping is not available on this LNDHub instance:', error.message);
+      }
+    };
+
+    fetchLnurlPayInfo();
   }, [wallet]);
 
   const navigateToOverviewAndDeleteWallet = useCallback(async () => {
@@ -333,6 +352,40 @@ const WalletDetails: React.FC = () => {
     });
 
   const navigateToContacts = () => navigate('PaymentCodeList', { walletID });
+
+  const handleLnurlPayPress = useCallback(async () => {
+    if (!(wallet instanceof LightningCustodianWallet)) return;
+
+    setIsLnurlPayLoading(true);
+    try {
+      let info = lnurlPayInfo;
+      if (!info?.username) {
+        const username = await prompt(
+          loc.lnd.lnurlpay_tipping,
+          loc.lnd.lnurlpay_tipping_claim,
+          true,
+          'plain-text',
+          false,
+          loc.lnd.lnurlpay_tipping_claim_button,
+        );
+        info = await wallet.claimLnurlPayUsername(username);
+        setLnurlPayInfo(info);
+        triggerHapticFeedback(HapticFeedbackTypes.NotificationSuccess);
+      }
+
+      const message = info?.lnurl ? 'lightning:' + info.lnurl : info?.url;
+      if (message) {
+        await Share.open({ message });
+      }
+    } catch (error: any) {
+      if (error.message !== 'Cancel Pressed') {
+        triggerHapticFeedback(HapticFeedbackTypes.NotificationError);
+        presentAlert({ message: error.message });
+      }
+    } finally {
+      setIsLnurlPayLoading(false);
+    }
+  }, [lnurlPayInfo, wallet]);
 
   const exportInternals = async () => {
     if (backdoorPressed < 10) return setBackdoorPressed(backdoorPressed + 1);
@@ -631,6 +684,16 @@ const WalletDetails: React.FC = () => {
               <ListItem onPress={navigateToAddresses} title={loc.wallets.details_show_addresses} chevron />
             )}
             {isContactsVisible ? <ListItem onPress={navigateToContacts} title={loc.bip47.contacts} chevron /> : null}
+            {wallet.type === LightningCustodianWallet.type && lnurlPayInfo ? (
+              <ListItem
+                onPress={handleLnurlPayPress}
+                disabled={isLnurlPayLoading}
+                title={loc.lnd.lnurlpay_tipping}
+                subtitle={lnurlPayInfo.username ? loc.lnd.lnurlpay_tipping_share : loc.lnd.lnurlpay_tipping_no_username}
+                rightTitle={lnurlPayInfo.username ? '@' + lnurlPayInfo.username : undefined}
+                chevron
+              />
+            ) : null}
             <BlueCard style={styles.address}>
               <View>
                 <BlueSpacing20 />

--- a/screen/wallets/WalletDetails.tsx
+++ b/screen/wallets/WalletDetails.tsx
@@ -368,6 +368,7 @@ const WalletDetails: React.FC = () => {
           false,
           loc.lnd.lnurlpay_tipping_claim_button,
         );
+        if (!username) return;
         info = await wallet.claimLnurlPayUsername(username);
         setLnurlPayInfo(info);
         triggerHapticFeedback(HapticFeedbackTypes.NotificationSuccess);
@@ -375,7 +376,7 @@ const WalletDetails: React.FC = () => {
 
       const message = info?.lnurl ? 'lightning:' + info.lnurl : info?.url;
       if (message) {
-        await Share.open({ message });
+        await Share.open({ message }).catch(error => console.log('LNURL-pay tipping share canceled:', error.message));
       }
     } catch (error: any) {
       if (error.message !== 'Cancel Pressed') {


### PR DESCRIPTION
Refs BlueWallet/LndHub#110.
Depends on backend PR: https://github.com/BlueWallet/LndHub/pull/661

Adds the BlueWallet side for LNDHub LNURL-pay tipping:

- adds `LightningCustodianWallet.getLnurlPayInfo()` and `claimLnurlPayUsername()` for the new LNDHub endpoints
- shows an LNURL-pay tipping row on LNDHub wallet details when the connected server supports it
- lets the user claim a public tipping username if missing
- displays the claimed username and shares the encoded `lightning:LNURL...` tipping link

Verification:

```bash
npm ci --cache /private/tmp/bluewallet-lnurl-pay-npm-cache --no-audit --no-fund
npm run tslint
node scripts/find-unused-loc.js
./node_modules/.bin/eslint class/wallets/lightning-custodian-wallet.ts screen/wallets/WalletDetails.tsx
git diff --check
```

BTC payout address if needed: `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`