### PR TITLE
FIX: transaction details fee rate to one decimal place

### DIFF
--- a/screen/transactions/TransactionStatus.tsx
+++ b/screen/transactions/TransactionStatus.tsx
@@ -823,8 +823,8 @@ const TransactionStatus: React.FC = () => {
     return null;
   }, [tx, txFromElectrum, mempoolFee]);
 
-  // Calculate fee rate
-  const feeRate = calculatedFee && tx?.vsize ? Math.round(calculatedFee / tx.vsize) : null;
+  // Calculate fee rate (sat/vB), rounded to one decimal place for display
+  const feeRate = calculatedFee && tx?.vsize ? Math.round((calculatedFee / tx.vsize) * 10) / 10 : null;
   const parsedTxValue = Number(tx?.value);
   const txValue = Number.isFinite(parsedTxValue) ? parsedTxValue : null;
   const parsedConfirmations = Number(tx?.confirmations);
@@ -1202,7 +1202,7 @@ const TransactionStatus: React.FC = () => {
               <BlueText style={[styles.detailLabel, stylesHook.detailLabel]}>{loc.transactions.details_fee_rate}</BlueText>
               <View style={styles.detailValueContainer}>
                 <CopyTextToClipboard
-                  text={feeRate ? `${feeRate} sats/vb` : '-'}
+                  text={feeRate != null ? `${Number(feeRate.toFixed(1))} sats/vb` : '-'}
                   style={StyleSheet.flatten([styles.detailValue, stylesHook.detailValue])}
                   textAlign="right"
                 />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the transaction details screen (Advanced section), the fee rate was computed with `Math.round(fee / vsize)`, so values such as **3.6** sats/vB appeared as **4**.

## Change

- Round **fee ÷ vsize** to **one decimal place** (`Math.round(rate * 10) / 10`).
- Format the displayed and copied string with `Number(rate.toFixed(1))` so whole numbers stay compact (e.g. `4` instead of `4.0`) while avoiding floating-point noise.

## Testing

- `npx eslint screen/transactions/TransactionStatus.tsx`
- `npm run unit` (includes `tests/unit/transaction-status.test.tsx`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92f0e01e-9593-49a1-b8c4-02da513f585e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92f0e01e-9593-49a1-b8c4-02da513f585e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

