### PR TITLE
Request incognito keyboard for sensitive Android inputs

### DIFF
--- a/BlueComponents.tsx
+++ b/BlueComponents.tsx
@@ -8,7 +8,6 @@ import {
   StyleProp,
   StyleSheet,
   Text,
-  TextInput,
   TextInputProps,
   TextProps,
   View,
@@ -16,6 +15,7 @@ import {
   ViewStyle,
 } from 'react-native';
 
+import IncognitoKeyboardTextInput from './components/IncognitoKeyboardTextInput';
 import Icon from './components/Icon';
 import { useTheme } from './components/themes';
 
@@ -93,7 +93,7 @@ export const BlueFormMultiInput: React.FC<TextInputProps> = props => {
   const { style, editable, ...restProps } = props;
 
   return (
-    <TextInput
+    <IncognitoKeyboardTextInput
       multiline
       underlineColorAndroid="transparent"
       numberOfLines={4}
@@ -108,9 +108,6 @@ export const BlueFormMultiInput: React.FC<TextInputProps> = props => {
         },
         style,
       ]}
-      autoCorrect={false}
-      autoCapitalize="none"
-      spellCheck={false}
       {...restProps}
       selectTextOnFocus={false}
       keyboardType={Platform.OS === 'android' ? 'visible-password' : 'default'}

--- a/android/app/src/main/java/io/bluewallet/bluewallet/SettingsModule.kt
+++ b/android/app/src/main/java/io/bluewallet/bluewallet/SettingsModule.kt
@@ -3,6 +3,9 @@ package io.bluewallet.bluewallet
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import android.widget.TextView
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.Promise
@@ -206,6 +209,40 @@ class SettingsModule(reactContext: ReactApplicationContext) : NativeSettingsModu
         } catch (e: Exception) {
             Log.e(TAG, "Error opening settings", e)
             promise.reject("ERROR", e.message)
+        }
+    }
+
+    /**
+     * Request Android IME privacy mode for the currently focused text editor.
+     *
+     * Android exposes this as a best-effort IME option. Keyboards that honor
+     * IME_FLAG_NO_PERSONALIZED_LEARNING should not store typed text for
+     * suggestions, analytics, or user dictionaries while the input is active.
+     */
+    @ReactMethod
+    override fun requestKeyboardIncognitoMode(promise: Promise) {
+        val activity = currentActivity
+        if (activity == null) {
+            promise.resolve(false)
+            return
+        }
+
+        activity.runOnUiThread {
+            try {
+                val focusedView = activity.currentFocus
+                if (focusedView !is TextView) {
+                    promise.resolve(false)
+                    return@runOnUiThread
+                }
+
+                focusedView.imeOptions = focusedView.imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
+                val inputMethodManager = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+                inputMethodManager?.restartInput(focusedView)
+                promise.resolve(true)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error requesting keyboard incognito mode", e)
+                promise.reject("ERROR", e.message)
+            }
         }
     }
 }

--- a/blue_modules/SettingsModule.ts
+++ b/blue_modules/SettingsModule.ts
@@ -44,6 +44,11 @@ interface SettingsModuleInterface {
    * This opens the app's settings screen
    */
   openSettings(): Promise<boolean>;
+
+  /**
+   * Ask Android keyboards not to persist personalized learning for the focused input.
+   */
+  requestKeyboardIncognitoMode(): Promise<boolean>;
 }
 
 // Only available on Android

--- a/blue_modules/requestKeyboardIncognitoMode.ts
+++ b/blue_modules/requestKeyboardIncognitoMode.ts
@@ -1,0 +1,15 @@
+import { Platform } from 'react-native';
+
+import SettingsModule from './SettingsModule';
+
+const requestKeyboardIncognitoMode = async (): Promise<boolean> => {
+  if (Platform.OS !== 'android') return false;
+
+  try {
+    return (await SettingsModule?.requestKeyboardIncognitoMode()) ?? false;
+  } catch {
+    return false;
+  }
+};
+
+export default requestKeyboardIncognitoMode;

--- a/codegen/NativeSettingsModule.ts
+++ b/codegen/NativeSettingsModule.ts
@@ -10,6 +10,7 @@ export interface Spec extends TurboModule {
   setDoNotTrack(enabled: boolean): Promise<boolean>;
   getDoNotTrack(): Promise<boolean>;
   openSettings(): Promise<boolean>;
+  requestKeyboardIncognitoMode(): Promise<boolean>;
 }
 
 const nativeModule = TurboModuleRegistry.get<Spec>('SettingsModule');

--- a/components/IncognitoKeyboardTextInput.tsx
+++ b/components/IncognitoKeyboardTextInput.tsx
@@ -1,0 +1,33 @@
+import React, { forwardRef, useCallback } from 'react';
+import { TextInput, TextInputProps } from 'react-native';
+
+import requestKeyboardIncognitoMode from '../blue_modules/requestKeyboardIncognitoMode';
+
+export type IncognitoKeyboardTextInputProps = TextInputProps;
+
+const IncognitoKeyboardTextInput = forwardRef<TextInput, IncognitoKeyboardTextInputProps>(
+  ({ autoCapitalize, autoCorrect, onFocus, spellCheck, ...props }, ref) => {
+    const handleFocus = useCallback<NonNullable<TextInputProps['onFocus']>>(
+      event => {
+        requestKeyboardIncognitoMode();
+        onFocus?.(event);
+      },
+      [onFocus],
+    );
+
+    return (
+      <TextInput
+        ref={ref}
+        autoCapitalize={autoCapitalize ?? 'none'}
+        autoCorrect={autoCorrect ?? false}
+        onFocus={handleFocus}
+        spellCheck={spellCheck ?? false}
+        {...props}
+      />
+    );
+  },
+);
+
+IncognitoKeyboardTextInput.displayName = 'IncognitoKeyboardTextInput';
+
+export default IncognitoKeyboardTextInput;

--- a/components/PasswordInput.tsx
+++ b/components/PasswordInput.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import { Animated, Easing, StyleSheet, TextInput, View } from 'react-native';
+import IncognitoKeyboardTextInput from './IncognitoKeyboardTextInput';
 import { useTheme } from './themes';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../blue_modules/hapticFeedback';
 import loc from '../loc';
@@ -136,7 +137,7 @@ export const PasswordInput = forwardRef<PasswordInputHandle, PasswordInputProps>
           },
         ]}
       >
-        <TextInput
+        <IncognitoKeyboardTextInput
           ref={inputRef}
           testID="PasswordInput"
           style={[styles.input, stylesHook.input]}
@@ -149,8 +150,6 @@ export const PasswordInput = forwardRef<PasswordInputHandle, PasswordInputProps>
           placeholder={placeholder}
           placeholderTextColor={colors.alternativeTextColor}
           secureTextEntry
-          autoCapitalize="none"
-          autoCorrect={false}
           editable={!isSuccess}
           onSubmitEditing={handleSubmit}
           returnKeyType="done"

--- a/helpers/prompt.ts
+++ b/helpers/prompt.ts
@@ -1,6 +1,33 @@
 import { Platform } from 'react-native';
 import prompt from 'react-native-prompt-android';
+import requestKeyboardIncognitoMode from '../blue_modules/requestKeyboardIncognitoMode';
 import loc from '../loc';
+
+const startKeyboardIncognitoRetry = (): (() => void) => {
+  if (Platform.OS !== 'android') return () => {};
+
+  const retryDelayMs = 100;
+  const maxDurationMs = 1500;
+  const startedAt = Date.now();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let stopped = false;
+
+  const attempt = () => {
+    if (stopped) return;
+
+    requestKeyboardIncognitoMode().then(applied => {
+      if (stopped || applied || Date.now() - startedAt >= maxDurationMs) return;
+      timeout = setTimeout(attempt, retryDelayMs);
+    });
+  };
+
+  timeout = setTimeout(attempt, retryDelayMs);
+
+  return () => {
+    stopped = true;
+    if (timeout) clearTimeout(timeout);
+  };
+};
 
 export default (
   title: string,
@@ -19,11 +46,13 @@ export default (
   }
 
   return new Promise((resolve, reject) => {
+    let stopKeyboardIncognitoRetry = () => {};
     const buttons: Array<PromptButton> = isCancelable
       ? [
           {
             text: loc._.cancel,
             onPress: () => {
+              stopKeyboardIncognitoRetry();
               reject(Error('Cancel Pressed'));
             },
             style: 'cancel',
@@ -31,6 +60,7 @@ export default (
           {
             text: continueButtonText,
             onPress: password => {
+              stopKeyboardIncognitoRetry();
               console.log('OK Pressed');
               resolve(password);
             },
@@ -41,6 +71,7 @@ export default (
           {
             text: continueButtonText,
             onPress: password => {
+              stopKeyboardIncognitoRetry();
               console.log('OK Pressed');
               resolve(password);
             },
@@ -55,5 +86,9 @@ export default (
       keyboardType,
       ...(defaultInputValue !== undefined && { defaultValue: defaultInputValue }),
     });
+
+    if (type === 'secure-text') {
+      stopKeyboardIncognitoRetry = startKeyboardIncognitoRetry();
+    }
   });
 };


### PR DESCRIPTION
## Summary

Closes #2235.

Adds Android IME privacy mode for sensitive text entry by requesting `EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING` when sensitive inputs receive focus.

Covered surfaces:
- wallet import / mnemonic entry fields via `BlueFormMultiInput`
- app password entry via `PasswordInput`
- secure Android prompts, including import passphrases, via the shared prompt helper

## Why

Android keyboards that honor `IME_FLAG_NO_PERSONALIZED_LEARNING` can temporarily avoid saving typed text into personalized suggestions, analytics, or user dictionaries. This does not replace a trusted keyboard, but it is a useful privacy hardening for seed words, passphrases, and app passwords.

## Implementation notes

- Adds a small Android `SettingsModule.requestKeyboardIncognitoMode()` bridge that applies the flag to the currently focused `TextView` and restarts input.
- Adds `IncognitoKeyboardTextInput`, preserving existing `TextInput` props while defaulting suggestions off.
- Uses retry logic for secure prompt dialogs because the native Android prompt input may not be focused immediately when `prompt()` returns.

## Validation

- `npm run tslint`
- `npx eslint BlueComponents.tsx components/PasswordInput.tsx components/IncognitoKeyboardTextInput.tsx helpers/prompt.ts blue_modules/SettingsModule.ts blue_modules/requestKeyboardIncognitoMode.ts codegen/NativeSettingsModule.ts`
- `git diff --check`

## Bounty

This PR is intended for the 100k sat bounty on #2235.

Payout address: `bc1qmn0ulweh9n9nfhdkd9ek3l9g8j5qslsy0kcf5s`
