### PR TITLE
ref: lazy-load translations

### DIFF
--- a/loc/index.ts
+++ b/loc/index.ts
@@ -12,7 +12,7 @@ import * as RNLocalize from 'react-native-localize';
 
 import { satoshiToLocalCurrency } from '../blue_modules/currency';
 import { BitcoinUnit } from '../models/bitcoinUnits';
-import { AvailableLanguages } from './languages';
+import { AvailableLanguages, LangCode } from './languages';
 import enJson from './en.json';
 
 export const STORAGE_KEY = 'lang';
@@ -26,6 +26,83 @@ interface ILocalization1 extends LocalizedStrings<typeof enJson> {}
 interface ILocalization extends Omit<ILocalization1, 'formatString'> {
   formatString: (...args: Parameters<ILocalization1['formatString']>) => string;
 }
+
+// Lazy loaders for non-en langs
+type LanguageDict = typeof enJson;
+const languageLoaders: Record<Exclude<LangCode, 'en'>, () => LanguageDict> = {
+  ar: () => require('./ar.json'),
+  be: () => require('./be@tarask.json'),
+  bg_bg: () => require('./bg_bg.json'),
+  bqi: () => require('./bqi.json'),
+  ca: () => require('./ca.json'),
+  cs_cz: () => require('./cs_cz.json'),
+  cy: () => require('./cy.json'),
+  da_dk: () => require('./da_dk.json'),
+  de_de: () => require('./de_de.json'),
+  el: () => require('./el.json'),
+  es: () => require('./es.json'),
+  es_419: () => require('./es_419.json'),
+  et: () => require('./et_EE.json'),
+  fa: () => require('./fa.json'),
+  fi_fi: () => require('./fi_fi.json'),
+  fo: () => require('./fo.json'),
+  fr_fr: () => require('./fr_fr.json'),
+  he: () => require('./he.json'),
+  hr_hr: () => require('./hr_hr.json'),
+  hu_hu: () => require('./hu_hu.json'),
+  id_id: () => require('./id_id.json'),
+  it: () => require('./it.json'),
+  jp_jp: () => require('./jp_jp.json'),
+  'kk@Cyrl': () => require('./kk@Cyrl.json'),
+  kn: () => require('./kn.json'),
+  ko_kr: () => require('./ko_KR.json'),
+  lrc: () => require('./lrc.json'),
+  ms: () => require('./ms.json'),
+  nb_no: () => require('./nb_no.json'),
+  ne: () => require('./ne.json'),
+  nl_nl: () => require('./nl_nl.json'),
+  pcm: () => require('./pcm.json'),
+  pl: () => require('./pl.json'),
+  pt_br: () => require('./pt_br.json'),
+  pt_pt: () => require('./pt_pt.json'),
+  ro: () => require('./ro.json'),
+  ru: () => require('./ru.json'),
+  si_lk: () => require('./si_LK.json'),
+  sk_sk: () => require('./sk_sk.json'),
+  sl_si: () => require('./sl_SI.json'),
+  sq_AL: () => require('./sq_AL.json'),
+  sr_rs: () => require('./sr_RS.json'),
+  sv_se: () => require('./sv_se.json'),
+  th_th: () => require('./th_th.json'),
+  tr_tr: () => require('./tr_tr.json'),
+  ua: () => require('./ua.json'),
+  vi_vn: () => require('./vi_vn.json'),
+  zar_afr: () => require('./zar_afr.json'),
+  zar_xho: () => require('./zar_xho.json'),
+  zh_cn: () => require('./zh_cn.json'),
+  zh_tw: () => require('./zh_tw.json'),
+};
+
+// Cache so toggling between languages does not re-parse the JSON.
+export const parsedLanguages: Record<string, LanguageDict> = { en: enJson };
+
+const loc = new Localization<typeof enJson>({ en: enJson }) as ILocalization;
+
+const isKnownLang = (lang: string): lang is Exclude<LangCode, 'en'> => Object.prototype.hasOwnProperty.call(languageLoaders, lang);
+
+const applyLanguage = (lang: string) => {
+  if (lang === 'en' || !isKnownLang(lang)) {
+    loc.setContent({ en: enJson });
+    loc.setLanguage('en');
+    return;
+  }
+  if (!parsedLanguages[lang]) {
+    parsedLanguages[lang] = languageLoaders[lang]();
+  }
+  // `setContent` resets active language to interface; explicit setLanguage after, with `en` as fallback.
+  loc.setContent({ en: enJson, [lang]: parsedLanguages[lang] });
+  loc.setLanguage(lang);
+};
 
 const setDateTimeLocale = async () => {
   let lang = (await AsyncStorage.getItem(STORAGE_KEY)) ?? '';
@@ -213,98 +290,26 @@ const setDateTimeLocale = async () => {
   }
 };
 
+// Fire-and-forget; `loc` starts as `{en}` until this resolves, so synchronous reads on a cold launch with non-en saved preference render English briefly.
 const init = async () => {
-  // finding out whether lang preference was saved
   const lang = await AsyncStorage.getItem(STORAGE_KEY);
   if (lang) {
     await saveLanguage(lang);
-    await loc.setLanguage(lang);
-    if (process.env.JEST_WORKER_ID === undefined) {
-      const foundLang = AvailableLanguages.find(language => language.value === lang);
-      I18nManager.allowRTL(foundLang?.isRTL ?? false);
-      I18nManager.forceRTL(foundLang?.isRTL ?? false);
-    }
-    await setDateTimeLocale();
   } else {
     const locales = RNLocalize.getLocales();
-    if (Object.values(AvailableLanguages).some(language => language.value === locales[0].languageCode)) {
-      await saveLanguage(locales[0].languageCode);
-      await loc.setLanguage(locales[0].languageCode);
-      if (process.env.JEST_WORKER_ID === undefined) {
-        I18nManager.allowRTL(locales[0].isRTL ?? false);
-        I18nManager.forceRTL(locales[0].isRTL ?? false);
-      }
+    const detected = locales[0]?.languageCode;
+    if (detected && AvailableLanguages.some(language => language.value === detected)) {
+      await saveLanguage(detected);
     } else {
       await saveLanguage('en');
-      await loc.setLanguage('en');
-      if (process.env.JEST_WORKER_ID === undefined) {
-        I18nManager.allowRTL(false);
-        I18nManager.forceRTL(false);
-      }
     }
-    await setDateTimeLocale();
   }
 };
 init();
 
-const loc: ILocalization = new Localization({
-  en: enJson,
-  ar: require('./ar.json'),
-  be: require('./be@tarask.json'),
-  bg_bg: require('./bg_bg.json'),
-  bqi: require('./bqi.json'),
-  ca: require('./ca.json'),
-  cs_cz: require('./cs_cz.json'),
-  cy: require('./cy.json'),
-  da_dk: require('./da_dk.json'),
-  de_de: require('./de_de.json'),
-  el: require('./el.json'),
-  es: require('./es.json'),
-  es_419: require('./es_419.json'),
-  et: require('./et_EE.json'),
-  fa: require('./fa.json'),
-  fi_fi: require('./fi_fi.json'),
-  fo: require('./fo.json'),
-  fr_fr: require('./fr_fr.json'),
-  he: require('./he.json'),
-  hr_hr: require('./hr_hr.json'),
-  hu_hu: require('./hu_hu.json'),
-  id_id: require('./id_id.json'),
-  it: require('./it.json'),
-  jp_jp: require('./jp_jp.json'),
-  'kk@Cyrl': require('./kk@Cyrl.json'),
-  kn: require('./kn.json'),
-  ko_kr: require('./ko_KR.json'),
-  lrc: require('./lrc.json'),
-  ms: require('./ms.json'),
-  nb_no: require('./nb_no.json'),
-  ne: require('./ne.json'),
-  nl_nl: require('./nl_nl.json'),
-  pcm: require('./pcm.json'),
-  pl: require('./pl.json'),
-  pt_br: require('./pt_br.json'),
-  pt_pt: require('./pt_pt.json'),
-  ro: require('./ro.json'),
-  ru: require('./ru.json'),
-  si_lk: require('./si_LK.json'),
-  sk_sk: require('./sk_sk.json'),
-  sl_si: require('./sl_SI.json'),
-  sq_AL: require('./sq_AL.json'),
-  sr_rs: require('./sr_RS.json'),
-  sv_se: require('./sv_se.json'),
-  th_th: require('./th_th.json'),
-  tr_tr: require('./tr_tr.json'),
-  ua: require('./ua.json'),
-  vi_vn: require('./vi_vn.json'),
-  zar_afr: require('./zar_afr.json'),
-  zar_xho: require('./zar_xho.json'),
-  zh_cn: require('./zh_cn.json'),
-  zh_tw: require('./zh_tw.json'),
-});
-
 export const saveLanguage = async (lang: string) => {
   await AsyncStorage.setItem(STORAGE_KEY, lang);
-  loc.setLanguage(lang);
+  applyLanguage(lang);
   // even tho it makes no effect changing it in this run, it will on the next run, so we are doign it here:
   if (process.env.JEST_WORKER_ID === undefined) {
     const foundLang = AvailableLanguages.find(language => language.value === lang);

--- a/loc/languages.ts
+++ b/loc/languages.ts
@@ -1,4 +1,11 @@
-export const AvailableLanguages: Readonly<TLanguage[]> = Object.freeze([
+export type TLanguage = {
+  label: string;
+  value: string;
+  isRTL?: boolean;
+};
+
+// Literal-typed tuple so `LangCode` is a literal union; widened on re-export.
+const _availableLanguages = Object.freeze([
   { label: 'English', value: 'en' },
   { label: 'Afrikaans (AFR)', value: 'zar_afr' },
   { label: 'العربية (AR)', value: 'ar', isRTL: true },
@@ -51,10 +58,9 @@ export const AvailableLanguages: Readonly<TLanguage[]> = Object.freeze([
   { label: 'Українська (UA)', value: 'ua' },
   { label: 'Türkçe (TR)', value: 'tr_tr' },
   { label: 'Xhosa (XHO)', value: 'zar_xho' },
-]);
+] as const) satisfies readonly TLanguage[];
 
-export type TLanguage = {
-  label: string;
-  value: string;
-  isRTL?: boolean;
-};
+export const AvailableLanguages: readonly TLanguage[] = _availableLanguages;
+
+// Drives the typed loader Record in loc/index.ts so drift becomes a TS error.
+export type LangCode = (typeof _availableLanguages)[number]['value'];

--- a/tests/unit/loc.test.js
+++ b/tests/unit/loc.test.js
@@ -1,11 +1,46 @@
 import assert from 'assert';
 
 import { _setExchangeRate, _setPreferredFiatCurrency, _setSkipUpdateExchangeRate } from '../../blue_modules/currency';
-import { _leaveNumbersAndDots, formatBalance, formatBalancePlain, formatBalanceWithoutSuffix } from '../../loc';
+import loc, {
+  _leaveNumbersAndDots,
+  formatBalance,
+  formatBalancePlain,
+  formatBalanceWithoutSuffix,
+  parsedLanguages,
+  saveLanguage,
+} from '../../loc';
+import enJson from '../../loc/en.json';
+import ruJson from '../../loc/ru.json';
 import { BitcoinUnit } from '../../models/bitcoinUnits';
 import { FiatUnit } from '../../models/fiatUnit';
 
 describe('Localization', () => {
+  it('switches active language and round-trips back to en', async () => {
+    await saveLanguage('en');
+    const enValue = enJson._.never;
+    assert.strictEqual(loc._.never, enValue, 'starts on en');
+
+    await saveLanguage('ru');
+    assert.strictEqual(loc.getLanguage(), 'ru', 'active language is ru');
+    assert.strictEqual(loc._.never, ruJson._.never, 'ru strings applied');
+    assert.notStrictEqual(loc._.never, enValue, 'ru differs from en');
+
+    await saveLanguage('en');
+    assert.strictEqual(loc.getLanguage(), 'en', 'active language back to en');
+    assert.strictEqual(loc._.never, enValue, 'en strings restored');
+  });
+
+  it('caches parsed language dictionaries across toggles', async () => {
+    // fr_fr is untouched by other tests so we observe the first cache fill, not a residue.
+    await saveLanguage('fr_fr');
+    assert.ok('fr_fr' in parsedLanguages, 'fr_fr cached after first switch');
+    const cached = parsedLanguages.fr_fr;
+
+    await saveLanguage('en');
+    await saveLanguage('fr_fr');
+    assert.strictEqual(parsedLanguages.fr_fr, cached, 'cached dict reused, not re-required');
+  });
+
   it('internal formatter', () => {
     assert.strictEqual(_leaveNumbersAndDots('1,00 ₽'), '1');
     assert.strictEqual(_leaveNumbersAndDots('0,50 ₽"'), '0.50');


### PR DESCRIPTION
## What

`loc/index.ts` now constructs the `Localization` instance with only `{ en: enJson }`. Other 50+ language JSONs are wrapped in lazy `require()` thunks and loaded on demand via `loc.setContent(...)` when the user picks a language. Parsed dictionaries are cached.

Metro still inlines every JSON into the bundle, so **bundle/APK size is unchanged**. This is a runtime-heap optimization only.

## Memory gain

`LocalizedStrings._props` holds `{ en, currentLanguage }` instead of all 53 dicts.

Measured on Android: **−3.63 MB PSS median** (≈ −1.2 % of process PSS).

## Loading time gain

**None measurable.** Hermes pre-compiles `JSON.parse(literal)` into bytecode, so eager `require()` was already cheap at startup. Median TotalTime: +21 ms (+0.6 %), well inside one stdev (≈ 157 ms). Treat as noise.

## How tested

- Android emulator: Pixel 3a API 34, release APK, Hermes, ProGuard off, animations off
- 10 cold launches per variant (1 warmup), `am force-stop` + `drop_caches` + 3 s settle between launches, `am start -W` for `TotalTime`, `dumpsys meminfo` at +12 s for PSS
- Same emulator, same boot, both APKs built back-to-back
- Translations corpus: master + PR #8545 JSONs applied (loc/ size 2.6 MB, ~2× normal) to make the eager path more expensive

| Metric | Patched | Baseline | Δ |
|---|---|---|---|
| TotalTime median | 3454 ms | 3432 ms | +21 ms (+0.6 %) |
| PSS median | 300,536 KB | 304,251 KB | **−3,714 KB (−3.63 MB)** |
| PSS stdev | 569 KB | 415 KB | — |

Plus: `npx tsc --noEmit`, `npx eslint loc/index.ts`, `npx jest tests/unit` all pass.
