### PR TITLE
TST: fix android e2e

### DIFF
--- a/.detoxrc.json
+++ b/.detoxrc.json
@@ -33,7 +33,8 @@
     "simulator": {
       "type": "ios.simulator",
       "device": {
-        "type": "iPhone 17"
+        "type": "iPhone 17",
+        "os": "iOS 26.4"
       }
     },
     "emulator": {

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -119,35 +119,39 @@ describe('BlueWallet UI Tests - no wallets', () => {
 
     // network -> electrum server
     // change electrum server to electrum.blockstream.info and revert it back
-    // skip this test on iOS. HeaderMenuButton tap triggers a keyboard open for some reason.
+    // Skipped on iOS: tapping HeaderMenuButton steals focus and reopens the
+    // soft keyboard, which the iOS Electrum form isn't structured to recover
+    // from cleanly. Android-only for now.
     if (device.getPlatform() === 'android') {
       await element(by.id('ElectrumSettings')).tap();
-      await waitFor(element(by.id('HostInput')))
-        .toBeVisible()
-        .whileElement(by.id('ElectrumSettingsScrollView'))
-        .scroll(500, 'down'); // in case emu screen is small and it doesnt fit
-      await element(by.id('HostInput')).replaceText('electrum.blockstream.info\n');
-      await element(by.id('HostInput')).tapReturnKey();
-      await waitForKeyboardToClose();
-      await element(by.id('PortInput')).replaceText('50001\n');
-      await element(by.id('PortInput')).tapReturnKey();
-      await waitForKeyboardToClose();
-      await waitFor(element(by.id('Save')))
-        .toBeVisible()
-        .whileElement(by.id('ElectrumSettingsScrollView'))
-        .scroll(500, 'down'); // in case emu screen is small and it doesnt fit
+
+      // CI runs Android with a hardware keyboard (waitForKeyboardToClose is a
+      // no-op there), so the form layout shifts unpredictably and inputs that
+      // are nominally on screen can fall just under Detox's 75% visibility
+      // threshold. Scroll each control into view before touching it, and
+      // commit via the explicit Save button rather than IME return-key taps
+      // (which require focus state we can't reliably guarantee here).
+      const scrollIntoView = id =>
+        waitFor(element(by.id(id))).toBeVisible().whileElement(by.id('ElectrumSettingsScrollView')).scroll(300, 'down');
+
+      await scrollIntoView('HostInput');
+      await element(by.id('HostInput')).replaceText('electrum.blockstream.info');
+
+      await scrollIntoView('PortInput');
+      await element(by.id('PortInput')).replaceText('50001');
+
+      await scrollIntoView('Save');
       await element(by.id('Save')).tap();
       await waitForText('OK');
       await element(by.text('OK')).tap();
+
       await element(by.id('HeaderMenuButton')).tap();
       await element(by.text('Reset to default')).tap();
       await element(by.text('RESET TO DEFAULT')).tap();
       await waitForText('OK');
       await element(by.text('OK')).tap();
-      await waitFor(element(by.id('HostInput')))
-        .toBeVisible()
-        .whileElement(by.id('ElectrumSettingsScrollView'))
-        .scroll(500, 'down'); // in case emu screen is small and it doesnt fit
+
+      await scrollIntoView('HostInput');
       await expect(element(by.id('HostInput'))).toHaveText('');
       await expect(element(by.id('PortInput'))).toHaveText('');
       await expect(element(by.id('SSLPortInput'))).toHaveToggleValue(false);

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -120,7 +120,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     // network -> electrum server
     // change electrum server to electrum.blockstream.info and revert it back
     // skip this test on iOS. HeaderMenuButton tap triggers a keyboard open for some reason.
-    if (device.getPlatform() === 'andoid') {
+    if (device.getPlatform() === 'android') {
       await element(by.id('ElectrumSettings')).tap();
       await waitFor(element(by.id('HostInput')))
         .toBeVisible()

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -182,28 +182,28 @@ describe('BlueWallet UI Tests - no wallets', () => {
       await waitFor(element(by.id('NotificationsSwitch')))
         .toBeVisible()
         .withTimeout(10000);
-      await element(by.id('NotificationsSwitch')).tap();
+      // On iOS 26 the simulator's notifications permission grant from
+      // `device.launchApp({ permissions: { notifications: 'YES' } })` no longer
+      // persists, so the app's "You have denied permission" alert reliably
+      // appears — but its render timing varies, sometimes landing well after
+      // the toggle settles. Use a generous window and re-check after each
+      // toggle so the alert never leaks past `goBack()`.
+      const dismissOKAlertIfPresent = async (timeoutMs = 15000) => {
+        try {
+          await waitFor(element(by.text('OK'))).toBeVisible().withTimeout(timeoutMs);
+          await element(by.text('OK')).tap();
+        } catch (_) {
+          // Alert not shown, which is fine - notifications might be enabled.
+        }
+      };
 
-      // If notifications are not enabled on the device, an alert will appear
-      try {
-        await waitFor(element(by.text('OK')))
-          .toBeVisible()
-          .withTimeout(3000);
-        await element(by.text('OK')).tap();
-      } catch (_) {
-        // Alert not shown, which is fine - notifications might be enabled
-      }
       await element(by.id('NotificationsSwitch')).tap();
-
-      // If notifications are not enabled on the device, an alert will appear
-      try {
-        await waitFor(element(by.text('OK')))
-          .toBeVisible()
-          .withTimeout(3000);
-        await element(by.text('OK')).tap();
-      } catch (_) {
-        // Alert not shown, which is fine - notifications might be enabled
-      }
+      await dismissOKAlertIfPresent();
+      await element(by.id('NotificationsSwitch')).tap();
+      await dismissOKAlertIfPresent();
+      // Belt + suspenders: occasionally the alert lands just after the second
+      // dismissal check has resolved; sweep once more with a short timeout.
+      await dismissOKAlertIfPresent(3000);
 
       await goBack();
       await goBack();
@@ -753,12 +753,16 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await sleep(1000);
     await element(by.text('OK')).tap();
 
-    // wait for discovery to be completed
-    await waitFor(element(by.text("m/84'/0'/0'")))
+    // wait for discovery to be completed.
+    // Discovery now surfaces the same path under multiple wallet kinds (e.g.
+    // `m/84'/0'/0'` appears under both BIP84 SegWit and BIP44 Legacy rows), so
+    // `by.text(…)` matches more than one element. Pin to atIndex(0) — we only
+    // need to confirm any one match rendered.
+    await waitFor(element(by.text("m/84'/0'/0'")).atIndex(0))
       .toBeVisible()
       .withTimeout(600 * 1000);
-    await expect(element(by.text("m/44'/0'/1'"))).toBeVisible();
-    await expect(element(by.text("m/49'/0'/0'"))).toBeVisible();
+    await expect(element(by.text("m/44'/0'/1'")).atIndex(0)).toBeVisible();
+    await expect(element(by.text("m/49'/0'/0'")).atIndex(0)).toBeVisible();
     await expect(element(by.id('Loading'))).not.toBeVisible();
 
     // open custom derivation path screen and import the wallet

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -132,7 +132,10 @@ describe('BlueWallet UI Tests - no wallets', () => {
       // commit via the explicit Save button rather than IME return-key taps
       // (which require focus state we can't reliably guarantee here).
       const scrollIntoView = id =>
-        waitFor(element(by.id(id))).toBeVisible().whileElement(by.id('ElectrumSettingsScrollView')).scroll(300, 'down');
+        waitFor(element(by.id(id)))
+          .toBeVisible()
+          .whileElement(by.id('ElectrumSettingsScrollView'))
+          .scroll(300, 'down');
 
       await scrollIntoView('HostInput');
       await element(by.id('HostInput')).replaceText('electrum.blockstream.info');
@@ -194,7 +197,9 @@ describe('BlueWallet UI Tests - no wallets', () => {
       // toggle so the alert never leaks past `goBack()`.
       const dismissOKAlertIfPresent = async (timeoutMs = 15000) => {
         try {
-          await waitFor(element(by.text('OK'))).toBeVisible().withTimeout(timeoutMs);
+          await waitFor(element(by.text('OK')))
+            .toBeVisible()
+            .withTimeout(timeoutMs);
           await element(by.text('OK')).tap();
         } catch (_) {
           // Alert not shown, which is fine - notifications might be enabled.

--- a/tests/e2e/bluewallet2.spec.js
+++ b/tests/e2e/bluewallet2.spec.js
@@ -702,7 +702,9 @@ describe('BlueWallet UI Tests - import BIP84 wallet', () => {
     await element(by.id('FreezeSwitch')).tap(); // freeze switch
     await waitForSwitchValue('FreezeSwitch', true);
     await element(by.id('CoinControlOutputDone')).tap();
-    await waitFor(element(by.id('CoinControlOutputDone'))).not.toBeVisible().withTimeout(20000);
+    await waitFor(element(by.id('CoinControlOutputDone')))
+      .not.toBeVisible()
+      .withTimeout(20000);
     await expect(element(by.id('OutputMemoLabel').and(by.text('Test2')))).toBeVisible();
     await expect(element(by.id('FrozenBadge'))).toBeVisible();
 

--- a/tests/e2e/helperz.js
+++ b/tests/e2e/helperz.js
@@ -361,11 +361,26 @@ export async function goBack() {
   // Try each back/close affordance in order; retry the full set up to 10 times.
   const candidates = [by.id('BackButton'), by.id('NavigationCloseButton'), by.label('Back'), by.text('Close')];
 
+  // iOS 26 trap: a leaked UIAlertController dims the window with
+  // `_alertControllerDimmingViewColor` and intercepts every hit-test, so none of
+  // the back/close candidates can be tapped until the alert itself is dismissed.
+  // When the primary pass fails, fall through to OK/Cancel to clear the alert,
+  // then let the next loop iteration retry back/close.
+  const alertDismissals = [by.text('OK'), by.text('Cancel')];
+
   for (let attempt = 0; attempt < 10; attempt++) {
     for (const matcher of candidates) {
       try {
         await element(matcher).atIndex(0).tap();
         return;
+      } catch (_) {
+        /* try next */
+      }
+    }
+    for (const matcher of alertDismissals) {
+      try {
+        await element(matcher).atIndex(0).tap();
+        break;
       } catch (_) {
         /* try next */
       }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to Detox configuration and E2E test harness logic, primarily to reduce flakiness on CI. Main risk is masking real UI regressions if the new workarounds are too permissive.
> 
> **Overview**
> Improves Detox E2E stability across platforms, especially on CI and iOS 26 simulators.
> 
> Updates `.detoxrc.json` to pin the iOS simulator OS version. Adjusts `bluewallet.spec.js` to (1) run the Electrum server edit flow on Android only and make it more deterministic by scrolling controls into view and relying on explicit Save, (2) harden notification-toggle handling by repeatedly dismissing delayed `OK` permission alerts on iOS 26, and (3) disambiguate account-discovery assertions by using `atIndex(0)` when duplicate derivation-path rows exist.
> 
> Extends `goBack()` in `helperz.js` to detect and dismiss stuck iOS alerts (`OK`/`Cancel`) before retrying back/close taps, and applies minor wait formatting cleanup in `bluewallet2.spec.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3231548cd3e770439d068487bb4712b68445eeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->