### PR TITLE
Add receive addresses labels

### DIFF
--- a/class/blue-app.ts
+++ b/class/blue-app.ts
@@ -54,6 +54,12 @@ export type TCounterpartyMetadata = {
   };
 };
 
+export type TAddressMetadata = {
+  [address: string]: {
+    label: string;
+  };
+};
+
 type TRealmTransaction = {
   internal: boolean;
   index: number;
@@ -64,6 +70,7 @@ type TBucketStorage = {
   wallets: string[]; // array of serialized wallets, not actual wallet objects
   tx_metadata: TTXMetadata;
   counterparty_metadata: TCounterpartyMetadata;
+  address_metadata?: TAddressMetadata; // absent in older buckets
 };
 
 const isReactNative = typeof navigator !== 'undefined' && navigator?.product === 'ReactNative';
@@ -81,12 +88,14 @@ export class BlueApp {
   public cachedPassword?: false | string;
   public tx_metadata: TTXMetadata;
   public counterparty_metadata: TCounterpartyMetadata;
+  public address_metadata: TAddressMetadata;
   public wallets: TWallet[];
 
   constructor() {
     this.wallets = [];
     this.tx_metadata = {};
     this.counterparty_metadata = {};
+    this.address_metadata = {};
     this.cachedPassword = false;
   }
 
@@ -208,6 +217,7 @@ export class BlueApp {
       this.wallets = [];
       this.tx_metadata = {};
       this.counterparty_metadata = {};
+      this.address_metadata = {};
       return this.loadFromDisk();
     } else {
       throw new Error('Incorrect password. Please, try again.');
@@ -238,11 +248,13 @@ export class BlueApp {
     this.wallets = [];
     this.tx_metadata = {};
     this.counterparty_metadata = {};
+    this.address_metadata = {};
 
     const data: TBucketStorage = {
       wallets: [],
       tx_metadata: {},
       counterparty_metadata: {},
+      address_metadata: {},
     };
 
     let buckets = await this.getItem('data');
@@ -379,6 +391,11 @@ export class BlueApp {
       const data: TBucketStorage = JSON.parse(dataRaw);
       if (!data.wallets) return false;
       const wallets = data.wallets;
+      // Bucket-wide, not per-wallet, so hoisted out of the loop: an empty wallets array must still
+      // load it. `?? {}` because older buckets predate some of these fields.
+      this.tx_metadata = data.tx_metadata ?? {};
+      this.counterparty_metadata = data.counterparty_metadata ?? {};
+      this.address_metadata = data.address_metadata ?? {};
       for (const key of wallets) {
         // deciding which type is wallet and instantiating correct object
         const tempObj = JSON.parse(key);
@@ -486,8 +503,6 @@ export class BlueApp {
         const ID = unserializedWallet.getID();
         if (!this.wallets.some(wallet => wallet.getID() === ID)) {
           this.wallets.push(unserializedWallet);
-          this.tx_metadata = data.tx_metadata;
-          this.counterparty_metadata = data.counterparty_metadata;
         }
       }
       if (realm) realm.close();
@@ -654,6 +669,7 @@ export class BlueApp {
         wallets: walletsToSave,
         tx_metadata: this.tx_metadata,
         counterparty_metadata: this.counterparty_metadata,
+        address_metadata: this.address_metadata,
       };
 
       if (this.cachedPassword) {

--- a/class/blue-app.ts
+++ b/class/blue-app.ts
@@ -54,6 +54,12 @@ export type TCounterpartyMetadata = {
   };
 };
 
+export type TAddressMetadata = {
+  [address: string]: {
+    label: string;
+  };
+};
+
 type TRealmTransaction = {
   internal: boolean;
   index: number;
@@ -64,6 +70,7 @@ type TBucketStorage = {
   wallets: string[]; // array of serialized wallets, not actual wallet objects
   tx_metadata: TTXMetadata;
   counterparty_metadata: TCounterpartyMetadata;
+  address_metadata?: TAddressMetadata; // absent in older buckets
 };
 
 const isReactNative = typeof navigator !== 'undefined' && navigator?.product === 'ReactNative';
@@ -81,12 +88,14 @@ export class BlueApp {
   public cachedPassword?: false | string;
   public tx_metadata: TTXMetadata;
   public counterparty_metadata: TCounterpartyMetadata;
+  public address_metadata: TAddressMetadata;
   public wallets: TWallet[];
 
   constructor() {
     this.wallets = [];
     this.tx_metadata = {};
     this.counterparty_metadata = {};
+    this.address_metadata = {};
     this.cachedPassword = false;
   }
 
@@ -208,6 +217,7 @@ export class BlueApp {
       this.wallets = [];
       this.tx_metadata = {};
       this.counterparty_metadata = {};
+      this.address_metadata = {};
       return this.loadFromDisk();
     } else {
       throw new Error('Incorrect password. Please, try again.');
@@ -238,11 +248,13 @@ export class BlueApp {
     this.wallets = [];
     this.tx_metadata = {};
     this.counterparty_metadata = {};
+    this.address_metadata = {};
 
     const data: TBucketStorage = {
       wallets: [],
       tx_metadata: {},
       counterparty_metadata: {},
+      address_metadata: {},
     };
 
     let buckets = await this.getItem('data');
@@ -379,6 +391,11 @@ export class BlueApp {
       const data: TBucketStorage = JSON.parse(dataRaw);
       if (!data.wallets) return false;
       const wallets = data.wallets;
+      // Bucket-wide, not per-wallet, so hoisted out of the loop: an empty wallets array must still
+      // load it. `?? {}` because older buckets predate some of these fields.
+      this.tx_metadata = data.tx_metadata ?? {};
+      this.counterparty_metadata = data.counterparty_metadata ?? {};
+      this.address_metadata = data.address_metadata ?? {};
       for (const key of wallets) {
         // deciding which type is wallet and instantiating correct object
         const tempObj = JSON.parse(key);
@@ -486,8 +503,6 @@ export class BlueApp {
         const ID = unserializedWallet.getID();
         if (!this.wallets.some(wallet => wallet.getID() === ID)) {
           this.wallets.push(unserializedWallet);
-          this.tx_metadata = data.tx_metadata ?? {};
-          this.counterparty_metadata = data.counterparty_metadata;
         }
       }
       if (realm) realm.close();
@@ -654,6 +669,7 @@ export class BlueApp {
         wallets: walletsToSave,
         tx_metadata: this.tx_metadata,
         counterparty_metadata: this.counterparty_metadata,
+        address_metadata: this.address_metadata,
       };
 
       if (this.cachedPassword) {

--- a/components/AddressLabelBadge.tsx
+++ b/components/AddressLabelBadge.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { StyleProp, StyleSheet, Text, TouchableOpacity, View, ViewStyle } from 'react-native';
+
+import { useTheme } from './themes';
+
+interface AddressLabelBadgeProps {
+  label: string;
+  style?: StyleProp<ViewStyle>;
+  onPress?: () => void;
+  accessibilityLabel?: string;
+  testID?: string;
+}
+
+const AddressLabelBadge: React.FC<AddressLabelBadgeProps> = ({ label, style, onPress, accessibilityLabel, testID }) => {
+  const { colors } = useTheme();
+
+  const stylesHook = StyleSheet.create({
+    badge: { backgroundColor: colors.success },
+    text: { color: colors.successCheck },
+  });
+
+  const content = (
+    <Text style={[styles.text, stylesHook.text]} numberOfLines={1}>
+      {label}
+    </Text>
+  );
+
+  return onPress ? (
+    <TouchableOpacity
+      onPress={onPress}
+      style={[styles.badge, stylesHook.badge, style]}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      testID={testID}
+    >
+      {content}
+    </TouchableOpacity>
+  ) : (
+    <View style={[styles.badge, stylesHook.badge, style]} testID={testID}>
+      {content}
+    </View>
+  );
+};
+
+export default AddressLabelBadge;
+
+const styles = StyleSheet.create({
+  badge: {
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderRadius: 20,
+  },
+  text: {
+    fontSize: 12,
+    textAlign: 'center',
+  },
+});

--- a/components/Context/StorageProvider.tsx
+++ b/components/Context/StorageProvider.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { BlueApp as BlueAppClass, TCounterpartyMetadata, TTXMetadata } from '../../class/blue-app';
+import { BlueApp as BlueAppClass, TCounterpartyMetadata, TTXMetadata, TAddressMetadata } from '../../class/blue-app';
 import { LegacyWallet } from '../../class/wallets/legacy-wallet';
 import { LightningArkWallet } from '../../class/wallets/lightning-ark-wallet';
 import { WatchOnlyWallet } from '../../class/wallets/watch-only-wallet';
@@ -26,6 +26,7 @@ interface StorageContextType {
   setWalletsWithNewOrder: (wallets: TWallet[]) => void;
   txMetadata: TTXMetadata;
   counterpartyMetadata: TCounterpartyMetadata;
+  addressMetadata: TAddressMetadata;
   saveToDisk: (force?: boolean) => Promise<void>;
   selectedWalletID: () => string | undefined; // Change from string|undefined to a function
   addWallet: (wallet: TWallet) => void;
@@ -69,6 +70,7 @@ export const StorageContext = createContext<StorageContextType>(undefined);
 export const StorageProvider = ({ children }: { children: React.ReactNode }) => {
   const txMetadata = useRef<TTXMetadata>(BlueApp.tx_metadata);
   const counterpartyMetadata = useRef<TCounterpartyMetadata>(BlueApp.counterparty_metadata || {}); // init
+  const addressMetadata = useRef<TAddressMetadata>(BlueApp.address_metadata || {});
 
   const [wallets, setWallets] = useState<TWallet[]>([]);
   const [walletTransactionUpdateStatus, setWalletTransactionUpdateStatus] = useState<WalletTransactionsStatus | string>(
@@ -76,6 +78,8 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
   );
   const [walletsInitialized, setWalletsInitialized] = useState<boolean>(false);
   const [currentSharedCosigner, setCurrentSharedCosigner] = useState<string>('');
+  // Metadata refs are mutated in place, so their identity never changes; bumped on save to rebuild the context value.
+  const [metadataVersion, setMetadataVersion] = useState(0);
 
   const selectedWalletID = useCallback((): string | undefined => {
     if (!navigationRef.current || !navigationRef.current.isReady()) return undefined;
@@ -160,12 +164,14 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
       }
       BlueApp.tx_metadata = txMetadata.current;
       BlueApp.counterparty_metadata = counterpartyMetadata.current;
+      BlueApp.address_metadata = addressMetadata.current;
       await BlueApp.saveToDisk();
       const w: TWallet[] = [...BlueApp.getWallets()];
       setWallets(w);
+      setMetadataVersion(v => v + 1);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [txMetadata.current, counterpartyMetadata.current],
+    [txMetadata.current, counterpartyMetadata.current, addressMetadata.current],
   );
 
   const addWallet = useCallback((wallet: TWallet) => {
@@ -316,8 +322,9 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
   // Initialize wallets
   useEffect(() => {
     if (walletsInitialized) {
-      txMetadata.current = BlueApp.tx_metadata;
-      counterpartyMetadata.current = BlueApp.counterparty_metadata;
+      txMetadata.current = BlueApp.tx_metadata ?? {};
+      counterpartyMetadata.current = BlueApp.counterparty_metadata ?? {};
+      addressMetadata.current = BlueApp.address_metadata ?? {};
       const loaded = BlueApp.getWallets();
       setWallets(loaded);
       if (loaded.some(w => w.type === LightningArkWallet.type)) {
@@ -532,6 +539,7 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
       setWalletsWithNewOrder,
       txMetadata: txMetadata.current,
       counterpartyMetadata: counterpartyMetadata.current,
+      addressMetadata: addressMetadata.current,
       saveToDisk,
       getTransactions: BlueApp.getTransactions,
       selectedWalletID,
@@ -563,6 +571,8 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
       handleWalletDeletion,
       confirmWalletDeletion,
     }),
+    // metadataVersion is deliberate: it is what rebuilds this value after an in-place metadata edit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       wallets,
       setWalletsWithNewOrder,
@@ -579,6 +589,7 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
       resetWallets,
       walletTransactionUpdateStatus,
       handleWalletDeletion,
+      metadataVersion,
     ],
   );
 

--- a/components/Context/StorageProvider.tsx
+++ b/components/Context/StorageProvider.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { BlueApp as BlueAppClass, TCounterpartyMetadata, TTXMetadata } from '../../class/blue-app';
+import { BlueApp as BlueAppClass, TCounterpartyMetadata, TTXMetadata, TAddressMetadata } from '../../class/blue-app';
 import { LegacyWallet } from '../../class/wallets/legacy-wallet';
 import { LightningArkWallet } from '../../class/wallets/lightning-ark-wallet';
 import { WatchOnlyWallet } from '../../class/wallets/watch-only-wallet';
@@ -26,6 +26,7 @@ interface StorageContextType {
   setWalletsWithNewOrder: (wallets: TWallet[]) => void;
   txMetadata: TTXMetadata;
   counterpartyMetadata: TCounterpartyMetadata;
+  addressMetadata: TAddressMetadata;
   saveToDisk: (force?: boolean) => Promise<void>;
   selectedWalletID: () => string | undefined; // Change from string|undefined to a function
   addWallet: (wallet: TWallet) => void;
@@ -69,6 +70,7 @@ export const StorageContext = createContext<StorageContextType>(undefined);
 export const StorageProvider = ({ children }: { children: React.ReactNode }) => {
   const txMetadata = useRef<TTXMetadata>(BlueApp.tx_metadata ?? {});
   const counterpartyMetadata = useRef<TCounterpartyMetadata>(BlueApp.counterparty_metadata || {}); // init
+  const addressMetadata = useRef<TAddressMetadata>(BlueApp.address_metadata || {});
 
   const [wallets, setWallets] = useState<TWallet[]>([]);
   const [walletTransactionUpdateStatus, setWalletTransactionUpdateStatus] = useState<WalletTransactionsStatus | string>(
@@ -76,6 +78,8 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
   );
   const [walletsInitialized, setWalletsInitialized] = useState<boolean>(false);
   const [currentSharedCosigner, setCurrentSharedCosigner] = useState<string>('');
+  // Metadata refs are mutated in place, so their identity never changes; bumped on save to rebuild the context value.
+  const [metadataVersion, setMetadataVersion] = useState(0);
 
   const selectedWalletID = useCallback((): string | undefined => {
     if (!navigationRef.current || !navigationRef.current.isReady()) return undefined;
@@ -160,12 +164,14 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
       }
       BlueApp.tx_metadata = txMetadata.current;
       BlueApp.counterparty_metadata = counterpartyMetadata.current;
+      BlueApp.address_metadata = addressMetadata.current;
       await BlueApp.saveToDisk();
       const w: TWallet[] = [...BlueApp.getWallets()];
       setWallets(w);
+      setMetadataVersion(v => v + 1);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [txMetadata.current, counterpartyMetadata.current],
+    [txMetadata.current, counterpartyMetadata.current, addressMetadata.current],
   );
 
   const addWallet = useCallback((wallet: TWallet) => {
@@ -240,7 +246,8 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
     if (walletsInitialized) {
       txMetadata.current = BlueApp.tx_metadata ?? {};
       BlueApp.tx_metadata = txMetadata.current;
-      counterpartyMetadata.current = BlueApp.counterparty_metadata;
+      counterpartyMetadata.current = BlueApp.counterparty_metadata ?? {};
+      addressMetadata.current = BlueApp.address_metadata ?? {};
       const loaded = BlueApp.getWallets();
       setWallets(loaded);
       if (loaded.some(w => w.type === LightningArkWallet.type)) {
@@ -455,6 +462,7 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
       setWalletsWithNewOrder,
       txMetadata: txMetadata.current,
       counterpartyMetadata: counterpartyMetadata.current,
+      addressMetadata: addressMetadata.current,
       saveToDisk,
       getTransactions: BlueApp.getTransactions,
       selectedWalletID,
@@ -486,6 +494,8 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
       handleWalletDeletion,
       confirmWalletDeletion,
     }),
+    // metadataVersion is deliberate: it is what rebuilds this value after an in-place metadata edit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       wallets,
       setWalletsWithNewOrder,
@@ -502,6 +512,7 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
       resetWallets,
       walletTransactionUpdateStatus,
       handleWalletDeletion,
+      metadataVersion,
     ],
   );
 

--- a/components/TransactionListItem.tsx
+++ b/components/TransactionListItem.tsx
@@ -127,7 +127,7 @@ const TransactionListItemComponent: React.FC<TransactionListItemProps> = ({
 }: TransactionListItemProps) => {
   const { colors } = useTheme();
   const { navigate } = useExtendedNavigation<NavigationProps>();
-  const { txMetadata, counterpartyMetadata, wallets } = useStorage();
+  const { txMetadata, counterpartyMetadata, addressMetadata, wallets } = useStorage();
   const { language, selectedBlockExplorer } = useSettings();
   const insets = useSafeAreaInsets();
   const { fontScale } = useWindowDimensions();
@@ -152,6 +152,25 @@ const TransactionListItemComponent: React.FC<TransactionListItemProps> = ({
   }
   const txMemo = (counterparty ? `[${shortenContactName(counterparty)}] ` : '') + (txMetadata[item.hash]?.memo ?? '');
   const noteForCopy = (txMemo || item.memo || '').trim() || undefined;
+
+  // Labels of every address in this tx, comma separated. Not memoized: addressMetadata is mutated in
+  // place, so a useMemo keyed on it would return a stale label after every edit.
+  const addressLabel = ((): string | undefined => {
+    if (Object.keys(addressMetadata).length === 0) return undefined;
+    const labels = new Set<string>();
+    const txAddresses = [
+      ...(item.outputs ?? []).flatMap(o => o?.scriptPubKey?.addresses ?? []),
+      ...(item.inputs ?? []).flatMap(i => i?.addresses ?? (i?.address ? [i.address] : [])),
+    ];
+    for (const addr of txAddresses) {
+      const label = addressMetadata[addr]?.label;
+      if (label) labels.add(label);
+    }
+    return labels.size > 0 ? [...labels].join(', ') : undefined;
+  })();
+
+  // Priority: contact > memo/note > address label > empty.
+  const rightSubtitle = counterparty ? noteForCopy : (txMetadata[item.hash]?.memo || item.memo || '').trim() || addressLabel;
 
   // For LightningArkWallet rows, prepend a kind tag to the date subtitle. Such a
   // wallet transacts entirely via Boltz swaps, so every row is Lightning; the
@@ -553,7 +572,7 @@ const TransactionListItemComponent: React.FC<TransactionListItemProps> = ({
           chevron={false}
           rightTitle={rowTitle}
           rightTitleStyle={rowTitleStyle}
-          rightSubtitle={noteForCopy}
+          rightSubtitle={rightSubtitle}
           rightSubtitleStyle={styles.rightColumn}
           containerStyle={combinedStyle}
           testID="TransactionListItem"

--- a/components/TransactionListItem.tsx
+++ b/components/TransactionListItem.tsx
@@ -127,7 +127,7 @@ const TransactionListItemComponent: React.FC<TransactionListItemProps> = ({
 }: TransactionListItemProps) => {
   const { colors } = useTheme();
   const { navigate } = useNavigation<NavigationProps>();
-  const { txMetadata, counterpartyMetadata, wallets } = useStorage();
+  const { txMetadata, counterpartyMetadata, addressMetadata, wallets } = useStorage();
   const { language, selectedBlockExplorer } = useSettings();
   const insets = useSafeAreaInsets();
   const { fontScale } = useWindowDimensions();
@@ -152,6 +152,25 @@ const TransactionListItemComponent: React.FC<TransactionListItemProps> = ({
   }
   const txMemo = (counterparty ? `[${shortenContactName(counterparty)}] ` : '') + (txMetadata?.[item.hash]?.memo ?? '');
   const noteForCopy = (txMemo || item.memo || '').trim() || undefined;
+
+  // Labels of every address in this tx, comma separated. Not memoized: addressMetadata is mutated in
+  // place, so a useMemo keyed on it would return a stale label after every edit.
+  const addressLabel = ((): string | undefined => {
+    if (!addressMetadata || Object.keys(addressMetadata).length === 0) return undefined;
+    const labels = new Set<string>();
+    const txAddresses = [
+      ...(item.outputs ?? []).flatMap(o => o?.scriptPubKey?.addresses ?? []),
+      ...(item.inputs ?? []).flatMap(i => i?.addresses ?? (i?.address ? [i.address] : [])),
+    ];
+    for (const addr of txAddresses) {
+      const label = addressMetadata[addr]?.label;
+      if (label) labels.add(label);
+    }
+    return labels.size > 0 ? [...labels].join(', ') : undefined;
+  })();
+
+  // Priority: contact > memo/note > address label > empty.
+  const rightSubtitle = counterparty ? noteForCopy : (txMetadata?.[item.hash]?.memo || item.memo || '').trim() || addressLabel;
 
   // For LightningArkWallet rows, prepend a kind tag to the date subtitle. Such a
   // wallet transacts entirely via Boltz swaps, so every row is Lightning; the
@@ -553,7 +572,7 @@ const TransactionListItemComponent: React.FC<TransactionListItemProps> = ({
           chevron={false}
           rightTitle={rowTitle}
           rightTitleStyle={rowTitleStyle}
-          rightSubtitle={noteForCopy}
+          rightSubtitle={rightSubtitle}
           rightSubtitleStyle={styles.rightColumn}
           containerStyle={combinedStyle}
           testID="TransactionListItem"

--- a/components/addresses/AddressItem.tsx
+++ b/components/addresses/AddressItem.tsx
@@ -9,6 +9,7 @@ import loc, { formatBalance } from '../../loc';
 import { BitcoinUnit } from '../../models/bitcoinUnits';
 import presentAlert from '../Alert';
 import { useTheme } from '../themes';
+import AddressLabelBadge from '../AddressLabelBadge';
 import { AddressTypeBadge } from './AddressTypeBadge';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { DetailViewStackParamList } from '../../navigation/DetailViewStackParamList';
@@ -40,7 +41,8 @@ const AddressItem = ({
   searchQuery = '',
   renderHighlightedText,
 }: AddressItemProps) => {
-  const { wallets } = useStorage();
+  const { wallets, addressMetadata } = useStorage();
+  const addressLabel = addressMetadata[item.address]?.label;
   const { colors, dark } = useTheme();
   const { isBiometricUseCapableAndEnabled } = useBiometrics();
   const balanceOpacity = useSharedValue(1);
@@ -214,7 +216,10 @@ const AddressItem = ({
           </View>
         </View>
         <View style={styles.rightContainer}>
-          <AddressTypeBadge isInternal={item.isInternal} hasTransactions={hasTransactions} />
+          <View style={styles.badgesRow}>
+            <AddressTypeBadge isInternal={item.isInternal} hasTransactions={hasTransactions} />
+            {addressLabel ? <AddressLabelBadge label={addressLabel} style={styles.labelBadge} /> : null}
+          </View>
           <Text style={[stylesHook.balance, styles.balance]}>
             {loc.addresses.transactions}: {item.transactions ?? 0}
           </Text>
@@ -235,6 +240,14 @@ const styles = StyleSheet.create({
   address: {
     fontWeight: 'bold',
     marginHorizontal: 4,
+  },
+  badgesRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  labelBadge: {
+    maxWidth: 110,
   },
   tooltipButton: {
     width: '100%',

--- a/components/addresses/AddressItem.tsx
+++ b/components/addresses/AddressItem.tsx
@@ -10,6 +10,7 @@ import loc, { formatBalance } from '../../loc';
 import { BitcoinUnit } from '../../models/bitcoinUnits';
 import presentAlert from '../Alert';
 import { useTheme } from '../themes';
+import AddressLabelBadge from '../AddressLabelBadge';
 import { AddressTypeBadge } from './AddressTypeBadge';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { DetailViewStackParamList } from '../../navigation/DetailViewStackParamList';
@@ -40,7 +41,8 @@ const AddressItem = ({
   searchQuery = '',
   renderHighlightedText,
 }: AddressItemProps) => {
-  const { wallets } = useStorage();
+  const { wallets, addressMetadata } = useStorage();
+  const addressLabel = addressMetadata[item.address]?.label;
   const { colors, dark } = useTheme();
   const { isBiometricUseCapableAndEnabled } = useBiometrics();
   const balanceOpacity = useSharedValue(1);
@@ -214,7 +216,10 @@ const AddressItem = ({
           </View>
         </View>
         <View style={styles.rightContainer}>
-          <AddressTypeBadge isInternal={item.isInternal} hasTransactions={hasTransactions} />
+          <View style={styles.badgesRow}>
+            <AddressTypeBadge isInternal={item.isInternal} hasTransactions={hasTransactions} />
+            {addressLabel ? <AddressLabelBadge label={addressLabel} style={styles.labelBadge} /> : null}
+          </View>
           <Text style={[stylesHook.balance, styles.balance]}>
             {loc.addresses.transactions}: {item.transactions ?? 0}
           </Text>
@@ -235,6 +240,14 @@ const styles = StyleSheet.create({
   address: {
     fontWeight: 'bold',
     marginHorizontal: 4,
+  },
+  badgesRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  labelBadge: {
+    maxWidth: 110,
   },
   tooltipButton: {
     width: '100%',

--- a/components/navigationStyle.tsx
+++ b/components/navigationStyle.tsx
@@ -184,5 +184,15 @@ const navigationStyle = (
     };
 };
 
+// Shared by the receive form sheets, registered in both ReceiveDetailsStack and DetailViewScreensStack.
+const receiveSheetOptions = (headerTitle: string, androidDetent = 0.5) =>
+  navigationStyle({
+    presentation: 'formSheet',
+    sheetAllowedDetents: Platform.OS === 'ios' ? 'fitToContents' : [androidDetent],
+    headerTitle,
+    sheetGrabberVisible: true,
+    closeButtonPosition: CloseButtonPosition.Right,
+  });
+
 export default navigationStyle;
-export { CloseButtonPosition, withRouteParamHeaderOptions };
+export { CloseButtonPosition, withRouteParamHeaderOptions, receiveSheetOptions };

--- a/loc/en.json
+++ b/loc/en.json
@@ -104,9 +104,14 @@
     "title": "Your wallet has been created."
   },
   "receive": {
-    "details_create": "Create",
+    "details_add": "Add",
+    "details_save": "Save",
     "details_label": "Description",
     "details_setAmount": "Receive with amount",
+    "details_more_options": "More options",
+    "option_amount_subtitle": "Receiver sees suggested amount and description",
+    "option_label": "Label",
+    "option_label_subtitle": "Tag this address for future reference",
     "details_share": "Share...",
     "address_not_found": "Unable to generate receiving address.",
     "header": "Receive",

--- a/loc/en.json
+++ b/loc/en.json
@@ -347,6 +347,7 @@
     "blocks_confirmed_summary": "Included in block {blockHeight}.",
     "blocks_confirmed_fee_summary": "With a size of {vsize} and a fee rate of {feeRate}, paying {fee} fee.",
     "expand_note": "Expand Note",
+    "address_label_placeholder": "Label for this address",
     "cpfp_create": "Create",
     "cpfp_exp": "We will create another transaction that spends your unconfirmed transaction. The total fee will be higher than the original transaction fee, so it should be mined faster. This is called CPFP—Child Pays for Parent.",
     "cpfp_no_bump": "This transaction is not bumpable.",

--- a/loc/en.json
+++ b/loc/en.json
@@ -349,6 +349,7 @@
     "blocks_confirmed_summary": "Included in block {blockHeight}.",
     "blocks_confirmed_fee_summary": "With a size of {vsize} and a fee rate of {feeRate}, paying {fee} fee.",
     "expand_note": "Expand Note",
+    "address_label_placeholder": "Label for this address",
     "cpfp_create": "Create",
     "cpfp_exp": "We will create another transaction that spends your unconfirmed transaction. The total fee will be higher than the original transaction fee, so it should be mined faster. This is called CPFP—Child Pays for Parent.",
     "cpfp_no_bump": "This transaction is not bumpable.",

--- a/navigation/DetailViewScreensStack.tsx
+++ b/navigation/DetailViewScreensStack.tsx
@@ -655,9 +655,6 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '700',
   },
-  receiveHeaderEmptyLeftSlot: {
-    width: 40,
-  },
 });
 
 const createReceiveDetailsOptions = (theme: ReturnType<typeof useTheme>) =>
@@ -678,36 +675,15 @@ const createReceiveDetailsOptions = (theme: ReturnType<typeof useTheme>) =>
 
       const actions: Action[] = [{ ...CommonToolTipActions.PaymentsCode, menuState: isBIP47Enabled }];
       const headerMenuOptions = createEllipsisHeaderMenuOptions({ actions, onPressMenuItem });
-      const emptyLeft = () => React.createElement(View, { style: styles.receiveHeaderEmptyLeftSlot });
 
       if (showBip47Menu) {
         return {
           ...options,
-          headerLeft: options.headerLeft,
           headerRight: headerMenuOptions.headerRight,
-          unstable_headerLeftItems: options.unstable_headerLeftItems,
           unstable_headerRightItems: headerMenuOptions.unstable_headerRightItems,
         };
       }
 
-      const renderCloseRight = () => (
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={loc._.close}
-          style={({ pressed }) => [styles.headerIconButton, pressed && styles.headerIconButtonPressed]}
-          onPress={navigation.goBack}
-          testID="NavigationCloseButton"
-        >
-          <Image source={theme.closeImage} />
-        </Pressable>
-      );
-
-      return {
-        ...options,
-        headerLeft: emptyLeft,
-        headerRight: renderCloseRight,
-        unstable_headerLeftItems: () => [],
-        unstable_headerRightItems: options.unstable_headerRightItems,
-      };
+      return options;
     },
   )(theme);

--- a/navigation/DetailViewScreensStack.tsx
+++ b/navigation/DetailViewScreensStack.tsx
@@ -2,7 +2,7 @@ import React, { lazy, useCallback, useEffect, useMemo, useRef, useState } from '
 import { Animated, AppState, View, Platform, Text, StyleSheet, Pressable, Image } from 'react-native';
 import type { NativeStackHeaderItem, NativeStackNavigationOptions } from '@react-navigation/native-stack';
 import { createEllipsisHeaderMenuOptions } from '../components/headerMenuOptions';
-import navigationStyle, { CloseButtonPosition, withRouteParamHeaderOptions } from '../components/navigationStyle';
+import navigationStyle, { CloseButtonPosition, withRouteParamHeaderOptions, receiveSheetOptions } from '../components/navigationStyle';
 import { useTheme } from '../components/themes';
 import { Action } from '../components/types';
 import { useExtendedNavigation } from '../hooks/useExtendedNavigation';
@@ -61,6 +61,8 @@ import ManageWallets from '../screen/wallets/ManageWallets';
 import ReceiveDetails from '../screen/receive/ReceiveDetails';
 import ReceiveCustomAmountSheet from '../screen/receive/ReceiveCustomAmountSheet';
 import { CommonToolTipActions } from '../typings/CommonToolTipActions';
+import ReceiveMoreOptionsSheet from '../screen/receive/ReceiveMoreOptionsSheet';
+import ReceiveAddressLabelSheet from '../screen/receive/ReceiveAddressLabelSheet';
 
 type HeaderRightItem = ReturnType<NonNullable<NativeStackNavigationOptions['unstable_headerRightItems']>>[number];
 
@@ -599,13 +601,17 @@ const DetailViewStackScreensStack = () => {
         <DetailViewStack.Screen
           name="ReceiveCustomAmount"
           component={ReceiveCustomAmountSheet}
-          options={navigationStyle({
-            presentation: 'formSheet',
-            sheetAllowedDetents: Platform.OS === 'ios' ? 'fitToContents' : [0.9],
-            headerTitle: loc.receive.details_setAmount,
-            sheetGrabberVisible: true,
-            closeButtonPosition: CloseButtonPosition.Right,
-          })(theme)}
+          options={receiveSheetOptions(loc.receive.details_setAmount, 0.9)(theme)}
+        />
+        <DetailViewStack.Screen
+          name="ReceiveMoreOptions"
+          component={ReceiveMoreOptionsSheet}
+          options={receiveSheetOptions(loc.receive.details_more_options)(theme)}
+        />
+        <DetailViewStack.Screen
+          name="ReceiveAddressLabel"
+          component={ReceiveAddressLabelSheet}
+          options={receiveSheetOptions(loc.receive.option_label)(theme)}
         />
       </DetailViewStack.Navigator>
     </ConnectionPollContext.Provider>

--- a/navigation/DetailViewScreensStack.tsx
+++ b/navigation/DetailViewScreensStack.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from '@react-navigation/native';
 import React, { lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, AppState, View, Platform, Text, StyleSheet, Pressable, Image } from 'react-native';
 import type { NativeStackHeaderItem, NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import navigationStyle, { CloseButtonPosition, withRouteParamHeaderOptions } from '../components/navigationStyle';
+import navigationStyle, { CloseButtonPosition, withRouteParamHeaderOptions, receiveSheetOptions } from '../components/navigationStyle';
 import { useTheme } from '../components/themes';
 import loc from '../loc';
 import LNDViewAdditionalInvoicePreImage from '../screen/lnd/lndViewAdditionalInvoicePreImage';
@@ -59,6 +59,8 @@ import { ConnectionPollContext } from './ConnectionPollContext';
 import ManageWallets from '../screen/wallets/ManageWallets';
 import ReceiveDetails from '../screen/receive/ReceiveDetails';
 import ReceiveCustomAmountSheet from '../screen/receive/ReceiveCustomAmountSheet';
+import ReceiveMoreOptionsSheet from '../screen/receive/ReceiveMoreOptionsSheet';
+import ReceiveAddressLabelSheet from '../screen/receive/ReceiveAddressLabelSheet';
 
 type HeaderRightItem = ReturnType<NonNullable<NativeStackNavigationOptions['unstable_headerRightItems']>>[number];
 
@@ -561,13 +563,17 @@ const DetailViewStackScreensStack = () => {
         <DetailViewStack.Screen
           name="ReceiveCustomAmount"
           component={ReceiveCustomAmountSheet}
-          options={navigationStyle({
-            presentation: 'formSheet',
-            sheetAllowedDetents: Platform.OS === 'ios' ? 'fitToContents' : [0.9],
-            headerTitle: loc.receive.details_setAmount,
-            sheetGrabberVisible: true,
-            closeButtonPosition: CloseButtonPosition.Right,
-          })(theme)}
+          options={receiveSheetOptions(loc.receive.details_setAmount, 0.9)(theme)}
+        />
+        <DetailViewStack.Screen
+          name="ReceiveMoreOptions"
+          component={ReceiveMoreOptionsSheet}
+          options={receiveSheetOptions(loc.receive.details_more_options)(theme)}
+        />
+        <DetailViewStack.Screen
+          name="ReceiveAddressLabel"
+          component={ReceiveAddressLabelSheet}
+          options={receiveSheetOptions(loc.receive.option_label)(theme)}
         />
       </DetailViewStack.Navigator>
     </ConnectionPollContext.Provider>

--- a/navigation/DetailViewStackParamList.ts
+++ b/navigation/DetailViewStackParamList.ts
@@ -159,6 +159,16 @@ export type DetailViewStackParamList = {
     currentUnit?: BitcoinUnit;
     preferredUnit?: BitcoinUnit;
   };
+  ReceiveMoreOptions: {
+    address: string;
+    currentLabel?: string;
+    currentAmount?: string;
+    currentUnit?: BitcoinUnit;
+    preferredUnit?: BitcoinUnit;
+  };
+  ReceiveAddressLabel: {
+    address: string;
+  };
   ScanQRCode: ScanQRCodeParamList;
   PaymentCodeList: {
     paymentCode: string;

--- a/navigation/ReceiveDetailsStack.tsx
+++ b/navigation/ReceiveDetailsStack.tsx
@@ -3,10 +3,11 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTheme } from '../components/themes';
 import loc from '../loc';
 import ReceiveDetails from '../screen/receive/ReceiveDetails';
-import navigationStyle, { CloseButtonPosition, withRouteParamHeaderOptions } from '../components/navigationStyle';
+import navigationStyle, { CloseButtonPosition, withRouteParamHeaderOptions, receiveSheetOptions } from '../components/navigationStyle';
 import { ReceiveDetailsStackParamList } from './ReceiveDetailsStackParamList';
 import ReceiveCustomAmountSheet from '../screen/receive/ReceiveCustomAmountSheet';
-import { Platform } from 'react-native';
+import ReceiveMoreOptionsSheet from '../screen/receive/ReceiveMoreOptionsSheet';
+import ReceiveAddressLabelSheet from '../screen/receive/ReceiveAddressLabelSheet';
 
 const Stack = createNativeStackNavigator<ReceiveDetailsStackParamList>();
 
@@ -30,13 +31,17 @@ const ReceiveDetailsStack = () => {
       <Stack.Screen
         name="ReceiveCustomAmount"
         component={ReceiveCustomAmountSheet}
-        options={navigationStyle({
-          presentation: 'formSheet',
-          sheetAllowedDetents: Platform.OS === 'ios' ? 'fitToContents' : [0.9],
-          headerTitle: loc.receive.details_setAmount,
-          sheetGrabberVisible: true,
-          closeButtonPosition: CloseButtonPosition.Right,
-        })(theme)}
+        options={receiveSheetOptions(loc.receive.details_setAmount, 0.9)(theme)}
+      />
+      <Stack.Screen
+        name="ReceiveMoreOptions"
+        component={ReceiveMoreOptionsSheet}
+        options={receiveSheetOptions(loc.receive.details_more_options)(theme)}
+      />
+      <Stack.Screen
+        name="ReceiveAddressLabel"
+        component={ReceiveAddressLabelSheet}
+        options={receiveSheetOptions(loc.receive.option_label)(theme)}
       />
     </Stack.Navigator>
   );

--- a/navigation/ReceiveDetailsStackParamList.ts
+++ b/navigation/ReceiveDetailsStackParamList.ts
@@ -26,4 +26,14 @@ export type ReceiveDetailsStackParamList = {
     currentUnit?: import('../models/bitcoinUnits').BitcoinUnit;
     preferredUnit?: import('../models/bitcoinUnits').BitcoinUnit;
   };
+  ReceiveMoreOptions: {
+    address: string;
+    currentLabel?: string;
+    currentAmount?: string;
+    currentUnit?: import('../models/bitcoinUnits').BitcoinUnit;
+    preferredUnit?: import('../models/bitcoinUnits').BitcoinUnit;
+  };
+  ReceiveAddressLabel: {
+    address: string;
+  };
 };

--- a/screen/receive/ReceiveAddressLabelSheet.tsx
+++ b/screen/receive/ReceiveAddressLabelSheet.tsx
@@ -1,0 +1,105 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { StyleSheet, TextInput, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+
+import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
+import { BlueSpacing20 } from '../../components/BlueSpacing';
+import Button from '../../components/Button';
+import { useTheme } from '../../components/themes';
+import { useStorage } from '../../hooks/context/useStorage';
+import loc from '../../loc';
+import { ReceiveDetailsStackParamList } from '../../navigation/ReceiveDetailsStackParamList';
+
+const ReceiveAddressLabelSheet = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<ReceiveDetailsStackParamList, 'ReceiveAddressLabel'>>();
+  const route = useRoute<RouteProp<ReceiveDetailsStackParamList, 'ReceiveAddressLabel'>>();
+  const { addressMetadata, saveToDisk } = useStorage();
+  const { colors } = useTheme();
+  const { address } = route.params;
+  const [label, setLabel] = useState(addressMetadata[address]?.label ?? '');
+
+  const stylesHook = useMemo(
+    () => ({
+      input: {
+        borderColor: colors.formBorder,
+        borderBottomColor: colors.formBorder,
+        backgroundColor: colors.inputBackgroundColor,
+      },
+      inputText: {
+        color: colors.foregroundColor,
+      },
+    }),
+    [colors],
+  );
+
+  // Saving an empty label clears it.
+  const handleSave = useCallback(async () => {
+    const trimmed = label.trim();
+    if (trimmed !== (addressMetadata[address]?.label ?? '')) {
+      if (trimmed) {
+        addressMetadata[address] = { label: trimmed };
+      } else {
+        delete addressMetadata[address];
+      }
+      await saveToDisk();
+      triggerHapticFeedback(HapticFeedbackTypes.NotificationSuccess);
+    }
+    navigation.goBack();
+  }, [label, address, addressMetadata, saveToDisk, navigation]);
+
+  return (
+    <SafeAreaView style={styles.safeArea} edges={['bottom', 'left', 'right']}>
+      <View style={[styles.input, stylesHook.input]}>
+        <TextInput
+          onChangeText={setLabel}
+          placeholder={loc.transactions.address_label_placeholder}
+          placeholderTextColor={colors.placeholderTextColor}
+          value={label}
+          maxLength={100}
+          numberOfLines={1}
+          autoFocus
+          returnKeyType="done"
+          onSubmitEditing={handleSave}
+          style={[styles.inputText, stylesHook.inputText]}
+          testID="AddressLabelInput"
+        />
+      </View>
+      <BlueSpacing20 />
+      <View style={styles.buttonContainer}>
+        <Button testID="AddressLabelSaveButton" title={loc.receive.details_save} onPress={handleSave} />
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default ReceiveAddressLabelSheet;
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+  },
+  input: {
+    flexDirection: 'row',
+    borderWidth: 1.0,
+    borderBottomWidth: 0.5,
+    minHeight: 44,
+    height: 44,
+    marginHorizontal: 20,
+    alignItems: 'center',
+    marginVertical: 8,
+    borderRadius: 4,
+  },
+  inputText: {
+    flex: 1,
+    marginHorizontal: 8,
+    minHeight: 33,
+    fontSize: 15,
+    lineHeight: 19,
+  },
+  buttonContainer: {
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+  },
+});

--- a/screen/receive/ReceiveCustomAmountSheet.tsx
+++ b/screen/receive/ReceiveCustomAmountSheet.tsx
@@ -5,6 +5,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 
 import * as AmountInput from '../../components/AmountInput';
+import BlueButtonLink from '../../components/BlueButtonLink';
 import { BlueSpacing20 } from '../../components/BlueSpacing';
 import Button from '../../components/Button';
 import { useTheme } from '../../components/themes';
@@ -140,25 +141,8 @@ const ReceiveCustomAmountSheet = () => {
         <BlueSpacing20 />
         <BlueSpacing20 />
         <View style={styles.modalButtonContainer}>
-          <View style={styles.modalButton}>
-            <Button
-              testID="CustomAmountResetButton"
-              backgroundColor={colors.modalButton}
-              buttonTextColor={colors.foregroundColor}
-              title={loc.receive.reset}
-              onPress={handleReset}
-            />
-          </View>
-          <View style={styles.modalButtonSpacing} />
-          <View style={styles.modalButton}>
-            <Button
-              testID="CustomAmountSaveButton"
-              backgroundColor={colors.modalButton}
-              buttonTextColor={colors.foregroundColor}
-              title={loc.receive.details_create}
-              onPress={handleSave}
-            />
-          </View>
+          <Button testID="CustomAmountSaveButton" title={loc.receive.details_add} onPress={handleSave} />
+          <BlueButtonLink testID="CustomAmountResetButton" style={styles.resetLink} title={loc.receive.reset} onPress={handleReset} />
         </View>
       </View>
     </SafeAreaView>
@@ -185,18 +169,14 @@ const styles = StyleSheet.create({
     marginVertical: 8,
     borderRadius: 4,
   },
-  modalButton: {
-    flex: 0.5,
-  },
   modalButtonContainer: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
     paddingHorizontal: 16,
     paddingBottom: 12,
     width: '100%',
   },
-  modalButtonSpacing: {
-    width: 16,
+  resetLink: {
+    marginTop: 12,
+    alignSelf: 'center',
   },
   customAmountText: {
     flex: 1,

--- a/screen/receive/ReceiveDetails.tsx
+++ b/screen/receive/ReceiveDetails.tsx
@@ -147,7 +147,7 @@ type RouteProps = RouteProp<ReceiveDetailsStackParamList, 'ReceiveDetails'>;
 const ReceiveDetails = () => {
   const route = useRoute<RouteProps>();
   const { walletID, address } = route.params;
-  const { wallets, saveToDisk, sleep, fetchAndSaveWalletTransactions } = useStorage();
+  const { wallets, saveToDisk, sleep, fetchAndSaveWalletTransactions, addressMetadata } = useStorage();
   const { isElectrumDisabled } = useSettings();
   const { colors } = useTheme();
   const isDarkTheme = useColorScheme() === 'dark';
@@ -198,6 +198,12 @@ const ReceiveDetails = () => {
     },
     qrPlaceholderFill: {
       backgroundColor: isDarkTheme ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)',
+    },
+    addressLabelPill: {
+      backgroundColor: colors.success,
+    },
+    addressLabelText: {
+      color: colors.successCheck,
     },
   });
 
@@ -291,14 +297,6 @@ const ReceiveDetails = () => {
     }
   }, [wallet, saveToDisk, address, setAddressBIP21Encoded, isElectrumDisabled, sleep]);
 
-  const onEnablePaymentsCodeSwitchValue = useCallback(() => {
-    if (wallet && wallet.allowBIP47()) {
-      wallet.switchBIP47(!wallet.isBIP47Enabled());
-    }
-    saveToDisk();
-    obtainWalletAddress();
-  }, [wallet, saveToDisk, obtainWalletAddress]);
-
   useEffect(() => {
     if (showConfirmedBalance) {
       triggerHapticFeedback(HapticFeedbackTypes.NotificationSuccess);
@@ -310,6 +308,22 @@ const ReceiveDetails = () => {
       setAddressBIP21Encoded(address);
     }
   }, [address, isCustom, setAddressBIP21Encoded]);
+
+  // Derived read: the label sheet mutates addressMetadata in place, and saving re-renders this screen.
+  const addressLabel = address ? (addressMetadata[address]?.label ?? '') : '';
+
+  const navigateToAddressLabel = useCallback(() => {
+    if (!address) return;
+    navigate('ReceiveAddressLabel', { address });
+  }, [address, navigate]);
+
+  const onEnablePaymentsCodeSwitchValue = useCallback(() => {
+    if (wallet && wallet.allowBIP47()) {
+      wallet.switchBIP47(!wallet.isBIP47Enabled());
+    }
+    saveToDisk();
+    obtainWalletAddress();
+  }, [wallet, saveToDisk, obtainWalletAddress]);
 
   useEffect(() => {
     setParams({
@@ -636,9 +650,9 @@ const ReceiveDetails = () => {
     }, [wallet, address, obtainWalletAddress, setAddressBIP21Encoded, isCustom, hasIncomingCustomParams]),
   );
 
-  const showCustomAmountModal = useCallback(() => {
+  const showMoreOptionsSheet = useCallback(() => {
     if (!address) return;
-    navigate('ReceiveCustomAmount', {
+    navigate('ReceiveMoreOptions', {
       address,
       currentLabel: customLabel,
       currentAmount: customAmount,
@@ -738,6 +752,19 @@ const ReceiveDetails = () => {
         onLayout={onScrollViewLayout}
       >
         {showAddress && renderReceiveCard()}
+        {showAddress && currentTab === segmentControlValues[0] && addressLabel ? (
+          <Pressable
+            onPress={navigateToAddressLabel}
+            style={[styles.addressLabelPill, stylesHook.addressLabelPill]}
+            accessibilityRole="button"
+            accessibilityLabel={`${loc.receive.option_label}: ${addressLabel}`}
+            testID="ReceiveAddressLabel"
+          >
+            <Text numberOfLines={1} style={[styles.addressLabelText, stylesHook.addressLabelText]}>
+              {addressLabel}
+            </Text>
+          </Pressable>
+        ) : null}
         {showReceiveSkeleton && renderReceiveSkeleton()}
         {showAddress && address !== undefined && (
           <HandOffComponent title={loc.send.details_address} type={HandOffActivityType.ReceiveOnchain} userInfo={{ address }} />
@@ -756,9 +783,9 @@ const ReceiveDetails = () => {
             {showAddress && currentTab === loc.wallets.details_address && (
               <BlueButtonLink
                 style={styles.link}
-                testID="SetCustomAmountButton"
-                title={loc.receive.details_setAmount}
-                onPress={showCustomAmountModal}
+                testID="ReceiveMoreOptionsButton"
+                title={loc.receive.details_more_options}
+                onPress={showMoreOptionsSheet}
               />
             )}
             <Button
@@ -861,6 +888,19 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     minHeight: 48,
     justifyContent: 'center',
+  },
+  addressLabelPill: {
+    alignSelf: 'center',
+    maxWidth: '86%',
+    borderRadius: 20,
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    marginTop: 8,
+  },
+  addressLabelText: {
+    fontSize: 14,
+    fontWeight: '500',
+    textAlign: 'center',
   },
   bip47NotFoundContainer: {
     paddingVertical: 40,

--- a/screen/receive/ReceiveDetails.tsx
+++ b/screen/receive/ReceiveDetails.tsx
@@ -8,6 +8,7 @@ import * as BlueElectrum from '../../blue_modules/BlueElectrum';
 import { fiatToBTC, satoshiToBTC } from '../../blue_modules/currency';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
 import { majorTomToGroundControl, tryToObtainPermissions } from '../../blue_modules/notifications';
+import AddressLabelBadge from '../../components/AddressLabelBadge';
 import BlueButtonLink from '../../components/BlueButtonLink';
 import BlueCard from '../../components/BlueCard';
 import BlueText from '../../components/BlueText';
@@ -198,12 +199,6 @@ const ReceiveDetails = () => {
     },
     qrPlaceholderFill: {
       backgroundColor: isDarkTheme ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)',
-    },
-    addressLabelPill: {
-      backgroundColor: colors.success,
-    },
-    addressLabelText: {
-      color: colors.successCheck,
     },
   });
 
@@ -753,17 +748,13 @@ const ReceiveDetails = () => {
       >
         {showAddress && renderReceiveCard()}
         {showAddress && currentTab === segmentControlValues[0] && addressLabel ? (
-          <Pressable
+          <AddressLabelBadge
+            label={addressLabel}
+            style={styles.addressLabelPill}
             onPress={navigateToAddressLabel}
-            style={[styles.addressLabelPill, stylesHook.addressLabelPill]}
-            accessibilityRole="button"
             accessibilityLabel={`${loc.receive.option_label}: ${addressLabel}`}
             testID="ReceiveAddressLabel"
-          >
-            <Text numberOfLines={1} style={[styles.addressLabelText, stylesHook.addressLabelText]}>
-              {addressLabel}
-            </Text>
-          </Pressable>
+          />
         ) : null}
         {showReceiveSkeleton && renderReceiveSkeleton()}
         {showAddress && address !== undefined && (
@@ -892,15 +883,9 @@ const styles = StyleSheet.create({
   addressLabelPill: {
     alignSelf: 'center',
     maxWidth: '86%',
-    borderRadius: 20,
     paddingHorizontal: 14,
     paddingVertical: 7,
     marginTop: 8,
-  },
-  addressLabelText: {
-    fontSize: 14,
-    fontWeight: '500',
-    textAlign: 'center',
   },
   bip47NotFoundContainer: {
     paddingVertical: 40,

--- a/screen/receive/ReceiveDetails.tsx
+++ b/screen/receive/ReceiveDetails.tsx
@@ -8,6 +8,7 @@ import * as BlueElectrum from '../../blue_modules/BlueElectrum';
 import { fiatToBTC, satoshiToBTC } from '../../blue_modules/currency';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
 import { majorTomToGroundControl, tryToObtainPermissions } from '../../blue_modules/notifications';
+import AddressLabelBadge from '../../components/AddressLabelBadge';
 import BlueButtonLink from '../../components/BlueButtonLink';
 import BlueCard from '../../components/BlueCard';
 import BlueText from '../../components/BlueText';
@@ -197,12 +198,6 @@ const ReceiveDetails = () => {
     },
     qrPlaceholderFill: {
       backgroundColor: isDarkTheme ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)',
-    },
-    addressLabelPill: {
-      backgroundColor: colors.success,
-    },
-    addressLabelText: {
-      color: colors.successCheck,
     },
   });
 
@@ -724,17 +719,13 @@ const ReceiveDetails = () => {
       >
         {showAddress && renderReceiveCard()}
         {showAddress && currentTab === segmentControlValues[0] && addressLabel ? (
-          <Pressable
+          <AddressLabelBadge
+            label={addressLabel}
+            style={styles.addressLabelPill}
             onPress={navigateToAddressLabel}
-            style={[styles.addressLabelPill, stylesHook.addressLabelPill]}
-            accessibilityRole="button"
             accessibilityLabel={`${loc.receive.option_label}: ${addressLabel}`}
             testID="ReceiveAddressLabel"
-          >
-            <Text numberOfLines={1} style={[styles.addressLabelText, stylesHook.addressLabelText]}>
-              {addressLabel}
-            </Text>
-          </Pressable>
+          />
         ) : null}
         {showReceiveSkeleton && renderReceiveSkeleton()}
         {showAddress && address !== undefined && (
@@ -863,15 +854,9 @@ const styles = StyleSheet.create({
   addressLabelPill: {
     alignSelf: 'center',
     maxWidth: '86%',
-    borderRadius: 20,
     paddingHorizontal: 14,
     paddingVertical: 7,
     marginTop: 8,
-  },
-  addressLabelText: {
-    fontSize: 14,
-    fontWeight: '500',
-    textAlign: 'center',
   },
   bip47NotFoundContainer: {
     paddingVertical: 40,

--- a/screen/receive/ReceiveDetails.tsx
+++ b/screen/receive/ReceiveDetails.tsx
@@ -146,7 +146,7 @@ type RouteProps = RouteProp<ReceiveDetailsStackParamList, 'ReceiveDetails'>;
 const ReceiveDetails = () => {
   const route = useRoute<RouteProps>();
   const { walletID, address } = route.params;
-  const { wallets, saveToDisk, sleep, fetchAndSaveWalletTransactions } = useStorage();
+  const { wallets, saveToDisk, sleep, fetchAndSaveWalletTransactions, addressMetadata } = useStorage();
   const { isElectrumDisabled } = useSettings();
   const { colors } = useTheme();
   const isDarkTheme = useColorScheme() === 'dark';
@@ -197,6 +197,12 @@ const ReceiveDetails = () => {
     },
     qrPlaceholderFill: {
       backgroundColor: isDarkTheme ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)',
+    },
+    addressLabelPill: {
+      backgroundColor: colors.success,
+    },
+    addressLabelText: {
+      color: colors.successCheck,
     },
   });
 
@@ -301,6 +307,14 @@ const ReceiveDetails = () => {
       setAddressBIP21Encoded(address);
     }
   }, [address, isCustom, setAddressBIP21Encoded]);
+
+  // Derived read: the label sheet mutates addressMetadata in place, and saving re-renders this screen.
+  const addressLabel = address ? (addressMetadata[address]?.label ?? '') : '';
+
+  const navigateToAddressLabel = useCallback(() => {
+    if (!address) return;
+    navigate('ReceiveAddressLabel', { address });
+  }, [address, navigate]);
 
   // re-fetching address balance periodically
   useEffect(() => {
@@ -607,9 +621,9 @@ const ReceiveDetails = () => {
     }, [wallet, address, obtainWalletAddress, setAddressBIP21Encoded, isCustom, hasIncomingCustomParams]),
   );
 
-  const showCustomAmountModal = useCallback(() => {
+  const showMoreOptionsSheet = useCallback(() => {
     if (!address) return;
-    navigate('ReceiveCustomAmount', {
+    navigate('ReceiveMoreOptions', {
       address,
       currentLabel: customLabel,
       currentAmount: customAmount,
@@ -709,6 +723,19 @@ const ReceiveDetails = () => {
         onLayout={onScrollViewLayout}
       >
         {showAddress && renderReceiveCard()}
+        {showAddress && currentTab === segmentControlValues[0] && addressLabel ? (
+          <Pressable
+            onPress={navigateToAddressLabel}
+            style={[styles.addressLabelPill, stylesHook.addressLabelPill]}
+            accessibilityRole="button"
+            accessibilityLabel={`${loc.receive.option_label}: ${addressLabel}`}
+            testID="ReceiveAddressLabel"
+          >
+            <Text numberOfLines={1} style={[styles.addressLabelText, stylesHook.addressLabelText]}>
+              {addressLabel}
+            </Text>
+          </Pressable>
+        ) : null}
         {showReceiveSkeleton && renderReceiveSkeleton()}
         {showAddress && address !== undefined && (
           <HandOffComponent title={loc.send.details_address} type={HandOffActivityType.ReceiveOnchain} userInfo={{ address }} />
@@ -727,9 +754,9 @@ const ReceiveDetails = () => {
             {showAddress && currentTab === loc.wallets.details_address && (
               <BlueButtonLink
                 style={styles.link}
-                testID="SetCustomAmountButton"
-                title={loc.receive.details_setAmount}
-                onPress={showCustomAmountModal}
+                testID="ReceiveMoreOptionsButton"
+                title={loc.receive.details_more_options}
+                onPress={showMoreOptionsSheet}
               />
             )}
             <Button
@@ -832,6 +859,19 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     minHeight: 48,
     justifyContent: 'center',
+  },
+  addressLabelPill: {
+    alignSelf: 'center',
+    maxWidth: '86%',
+    borderRadius: 20,
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    marginTop: 8,
+  },
+  addressLabelText: {
+    fontSize: 14,
+    fontWeight: '500',
+    textAlign: 'center',
   },
   bip47NotFoundContainer: {
     paddingVertical: 40,

--- a/screen/receive/ReceiveMoreOptionsSheet.tsx
+++ b/screen/receive/ReceiveMoreOptionsSheet.tsx
@@ -1,0 +1,52 @@
+import React, { useCallback } from 'react';
+import { StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+
+import ListItem from '../../components/ListItem';
+import loc from '../../loc';
+import { ReceiveDetailsStackParamList } from '../../navigation/ReceiveDetailsStackParamList';
+
+const ReceiveMoreOptionsSheet = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<ReceiveDetailsStackParamList, 'ReceiveMoreOptions'>>();
+  const route = useRoute<RouteProp<ReceiveDetailsStackParamList, 'ReceiveMoreOptions'>>();
+  const { address, currentLabel, currentAmount, currentUnit, preferredUnit } = route.params;
+
+  const navigateToCustomAmount = useCallback(() => {
+    navigation.replace('ReceiveCustomAmount', { address, currentLabel, currentAmount, currentUnit, preferredUnit });
+  }, [navigation, address, currentLabel, currentAmount, currentUnit, preferredUnit]);
+
+  const navigateToAddressLabel = useCallback(() => {
+    navigation.replace('ReceiveAddressLabel', { address });
+  }, [navigation, address]);
+
+  return (
+    <SafeAreaView style={styles.root} edges={['bottom', 'left', 'right']}>
+      <ListItem
+        title={loc.receive.details_setAmount}
+        subtitle={loc.receive.option_amount_subtitle}
+        chevron
+        onPress={navigateToCustomAmount}
+        testID="ReceiveWithAmountOption"
+      />
+      <ListItem
+        title={loc.receive.option_label}
+        subtitle={loc.receive.option_label_subtitle}
+        chevron
+        bottomDivider={false}
+        onPress={navigateToAddressLabel}
+        testID="AddressLabelOption"
+      />
+    </SafeAreaView>
+  );
+};
+
+export default ReceiveMoreOptionsSheet;
+
+const styles = StyleSheet.create({
+  root: {
+    paddingHorizontal: 8,
+    paddingBottom: 16,
+  },
+});

--- a/screen/transactions/TransactionStatus.tsx
+++ b/screen/transactions/TransactionStatus.tsx
@@ -21,6 +21,7 @@ import * as BlueElectrum from '../../blue_modules/BlueElectrum';
 import { satoshiToLocalCurrency } from '../../blue_modules/currency';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
 import { uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
+import AddressLabelBadge from '../../components/AddressLabelBadge';
 import BlueText from '../../components/BlueText';
 import { HDSegwitBech32Transaction } from '../../class/hd-segwit-bech32-transaction';
 import { HDSegwitBech32Wallet } from '../../class/wallets/hd-segwit-bech32-wallet';
@@ -170,7 +171,7 @@ const TransactionStatus: React.FC = () => {
     isLoading: !initialTx,
   });
   const { isCPFPPossible, isRBFBumpFeePossible, isRBFCancelPossible, tx, isLoading, eta, intervalMs, wallet, loadingError } = state;
-  const { wallets, txMetadata, counterpartyMetadata, fetchAndSaveWalletTransactions, saveToDisk } = useStorage();
+  const { wallets, txMetadata, counterpartyMetadata, addressMetadata, fetchAndSaveWalletTransactions, saveToDisk } = useStorage();
   const subscribedWallet = useWalletSubscribe(walletID);
   const { navigate, goBack, setOptions } = useExtendedNavigation<NavigationProps>();
   const { colors } = useTheme();
@@ -792,6 +793,13 @@ const TransactionStatus: React.FC = () => {
     }
   }, [tx, txMetadata, saveToDisk]);
 
+  const handleAddressLabelPress = useCallback(
+    (address: string) => {
+      navigate('ReceiveAddressLabel', { address });
+    },
+    [navigate],
+  );
+
   const handleOpenBlockExplorer = useCallback(() => {
     if (!tx?.hash || !selectedBlockExplorer) return;
     const url = `${selectedBlockExplorer.url}/tx/${tx.hash}`;
@@ -867,14 +875,22 @@ const TransactionStatus: React.FC = () => {
   const renderSection = (array: any[]) => {
     const fromArray = [];
 
-    for (const [index, address] of array.entries()) {
+    for (const address of array) {
       const isWeOwnAddress = weOwnAddress(address);
       const addressStyle = isWeOwnAddress ? [styles.weOwnAddress, stylesHook.rowValue] : [stylesHook.rowValue];
+      const label = addressMetadata[address]?.label;
 
       fromArray.push(
         <View key={address} style={styles.addressRow}>
           <CopyTextToClipboard text={address} style={StyleSheet.flatten(addressStyle)} />
-          {index !== array.length - 1 && <BlueText style={addressStyle}>,</BlueText>}
+          {label ? (
+            <AddressLabelBadge
+              label={label}
+              style={styles.addressLabelPill}
+              onPress={() => handleAddressLabelPress(address)}
+              accessibilityLabel={`${loc.receive.option_label}: ${label}`}
+            />
+          ) : null}
         </View>,
       );
     }
@@ -1701,9 +1717,13 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   addressRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flexWrap: 'wrap',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    marginBottom: 8,
+  },
+  addressLabelPill: {
+    maxWidth: '86%',
+    marginTop: 4,
   },
   detailValue: {
     fontSize: 15,

--- a/screen/transactions/TransactionStatus.tsx
+++ b/screen/transactions/TransactionStatus.tsx
@@ -21,6 +21,7 @@ import * as BlueElectrum from '../../blue_modules/BlueElectrum';
 import { satoshiToLocalCurrency } from '../../blue_modules/currency';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../blue_modules/hapticFeedback';
 import { uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
+import AddressLabelBadge from '../../components/AddressLabelBadge';
 import BlueText from '../../components/BlueText';
 import { HDSegwitBech32Transaction } from '../../class/hd-segwit-bech32-transaction';
 import { HDSegwitBech32Wallet } from '../../class/wallets/hd-segwit-bech32-wallet';
@@ -167,7 +168,7 @@ const TransactionStatus: React.FC = () => {
     isLoading: !initialTx,
   });
   const { isCPFPPossible, isRBFBumpFeePossible, isRBFCancelPossible, tx, isLoading, eta, intervalMs, wallet, loadingError } = state;
-  const { wallets, txMetadata, counterpartyMetadata, fetchAndSaveWalletTransactions, saveToDisk } = useStorage();
+  const { wallets, txMetadata, counterpartyMetadata, addressMetadata, fetchAndSaveWalletTransactions, saveToDisk } = useStorage();
   const subscribedWallet = useWalletSubscribe(walletID);
   const { navigate, goBack, setOptions } = useNavigation<NavigationProps>();
   const { colors } = useTheme();
@@ -794,6 +795,13 @@ const TransactionStatus: React.FC = () => {
     }
   }, [tx, txMetadata, saveToDisk]);
 
+  const handleAddressLabelPress = useCallback(
+    (address: string) => {
+      navigate('ReceiveAddressLabel', { address });
+    },
+    [navigate],
+  );
+
   const handleOpenBlockExplorer = useCallback(() => {
     if (!tx?.hash || !selectedBlockExplorer) return;
     const url = `${selectedBlockExplorer.url}/tx/${tx.hash}`;
@@ -851,14 +859,22 @@ const TransactionStatus: React.FC = () => {
   const renderSection = (array: any[]) => {
     const fromArray = [];
 
-    for (const [index, address] of array.entries()) {
+    for (const address of array) {
       const isWeOwnAddress = weOwnAddress(address);
       const addressStyle = isWeOwnAddress ? [styles.weOwnAddress, stylesHook.rowValue] : [stylesHook.rowValue];
+      const label = addressMetadata[address]?.label;
 
       fromArray.push(
         <View key={address} style={styles.addressRow}>
           <CopyTextToClipboard text={address} style={StyleSheet.flatten(addressStyle)} interactive={false} selectable />
-          {index !== array.length - 1 && <BlueText style={addressStyle}>,</BlueText>}
+          {label ? (
+            <AddressLabelBadge
+              label={label}
+              style={styles.addressLabelPill}
+              onPress={() => handleAddressLabelPress(address)}
+              accessibilityLabel={`${loc.receive.option_label}: ${label}`}
+            />
+          ) : null}
         </View>,
       );
     }
@@ -1706,9 +1722,13 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   addressRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flexWrap: 'wrap',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    marginBottom: 8,
+  },
+  addressLabelPill: {
+    maxWidth: '86%',
+    marginTop: 4,
   },
   detailValue: {
     fontSize: 15,

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -264,7 +264,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     process.env.CI && require('fs').writeFileSync(lockFile, '1');
   });
 
-  it('can create wallet, reload app and it persists. then go to receive screen, set custom amount and label. Dismiss modal and go to WalletsList.', async () => {
+  it('can create wallet, reload app and it persists. then go to receive screen, set custom amount with a BIP21 label and a per-address label that persists across restarts. Dismiss modal and go to WalletsList.', async () => {
     const lockFile = '/tmp/travislock.' + hashIt('t3');
     if (process.env.CI) {
       if (require('fs').existsSync(lockFile)) return console.warn('skipping', JSON.stringify('t3'), 'as it previously passed on Travis');
@@ -283,7 +283,8 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await element(by.text('Yes, I have.')).tap();
     await waitForId('BitcoinAddressQRCode');
     await waitForId('CopyTextToClipboard');
-    await element(by.id('SetCustomAmountButton')).tap();
+    await element(by.id('ReceiveMoreOptionsButton')).tap();
+    await element(by.id('ReceiveWithAmountOption')).tap();
     await element(by.id('BitcoinAmountInput')).replaceText('1');
     await element(by.id('CustomAmountDescription')).replaceText('test');
     await element(by.id('CustomAmountDescription')).tapReturnKey();
@@ -294,6 +295,16 @@ describe('BlueWallet UI Tests - no wallets', () => {
 
     await waitForId('BitcoinAddressQRCode');
     await waitForId('CopyTextToClipboard');
+
+    // add per-address label then verify it renders on the receive screen
+    await element(by.id('ReceiveMoreOptionsButton')).tap();
+    await element(by.id('AddressLabelOption')).tap();
+    await element(by.id('AddressLabelInput')).replaceText('my recv label');
+    await element(by.id('AddressLabelInput')).tapReturnKey();
+    await waitForKeyboardToClose();
+    await element(by.id('AddressLabelSaveButton')).tap();
+    await waitForId('ReceiveAddressLabel');
+    await expect(element(by.text('my recv label'))).toBeVisible();
 
     // ManageWallets: relaunch to clear receive modal, then open via long-press, swipe-to-hide, verify persists across restart
     await device.launchApp({ newInstance: true });
@@ -321,6 +332,14 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await element(by.id('SwipeShowBalance')).tap();
     await element(by.id('NavigationCloseButton')).tap();
     await waitForId('WalletsList');
+
+    // address label persisted, reopen receive and verify it's still there
+    await tapAndTapAgainIfElementIsNotVisible('cr34t3d', 'ReceiveButton');
+    await element(by.id('ReceiveButton')).tap();
+    await waitForId('BitcoinAddressQRCode');
+    await waitForId('ReceiveAddressLabel');
+    await expect(element(by.text('my recv label'))).toBeVisible();
+    await goBack();
 
     process.env.CI && require('fs').writeFileSync(lockFile, '1');
   });

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -266,7 +266,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     process.env.CI && require('fs').writeFileSync(lockFile, '1');
   });
 
-  it('can create wallet, reload app and it persists. then go to receive screen, set custom amount and label. Dismiss modal and go to WalletsList.', async () => {
+  it('can create wallet, reload app and it persists. then go to receive screen, set custom amount with a BIP21 label and a per-address label that persists across restarts. Dismiss modal and go to WalletsList.', async () => {
     const lockFile = '/tmp/travislock.' + hashIt('t3');
     if (process.env.CI) {
       if (require('fs').existsSync(lockFile)) return console.warn('skipping', JSON.stringify('t3'), 'as it previously passed on Travis');
@@ -285,7 +285,8 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await element(by.text('Yes, I have.')).tap();
     await waitForId('BitcoinAddressQRCode');
     await waitForId('CopyTextToClipboard');
-    await element(by.id('SetCustomAmountButton')).tap();
+    await element(by.id('ReceiveMoreOptionsButton')).tap();
+    await element(by.id('ReceiveWithAmountOption')).tap();
     await element(by.id('BitcoinAmountInput')).replaceText('1');
     await element(by.id('CustomAmountDescription')).replaceText('test');
     await element(by.id('CustomAmountDescription')).tapReturnKey();
@@ -296,6 +297,16 @@ describe('BlueWallet UI Tests - no wallets', () => {
 
     await waitForId('BitcoinAddressQRCode');
     await waitForId('CopyTextToClipboard');
+
+    // add per-address label then verify it renders on the receive screen
+    await element(by.id('ReceiveMoreOptionsButton')).tap();
+    await element(by.id('AddressLabelOption')).tap();
+    await element(by.id('AddressLabelInput')).replaceText('my recv label');
+    await element(by.id('AddressLabelInput')).tapReturnKey();
+    await waitForKeyboardToClose();
+    await element(by.id('AddressLabelSaveButton')).tap();
+    await waitForId('ReceiveAddressLabel');
+    await expect(element(by.text('my recv label'))).toBeVisible();
 
     // ManageWallets: relaunch to clear receive modal, then open via long-press, swipe-to-hide, verify persists across restart
     await device.launchApp({ newInstance: true });
@@ -323,6 +334,14 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await element(by.id('SwipeShowBalance')).tap();
     await element(by.id('NavigationCloseButton')).tap();
     await waitForId('WalletsList');
+
+    // address label persisted, reopen receive and verify it's still there
+    await tapAndTapAgainIfElementIsNotVisible('cr34t3d', 'ReceiveButton');
+    await element(by.id('ReceiveButton')).tap();
+    await waitForId('BitcoinAddressQRCode');
+    await waitForId('ReceiveAddressLabel');
+    await expect(element(by.text('my recv label'))).toBeVisible();
+    await goBack();
 
     process.env.CI && require('fs').writeFileSync(lockFile, '1');
   });

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -300,9 +300,9 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await element(by.id('ReceiveMoreOptionsButton')).tap();
     await element(by.id('AddressLabelOption')).tap();
     await element(by.id('AddressLabelInput')).replaceText('my recv label');
+    // Done saves the label and closes the sheet.
     await element(by.id('AddressLabelInput')).tapReturnKey();
     await waitForKeyboardToClose();
-    await element(by.id('AddressLabelSaveButton')).tap();
     await waitForId('ReceiveAddressLabel');
     await expect(element(by.text('my recv label'))).toBeVisible();
 

--- a/tests/e2e/bluewallet3.spec.js
+++ b/tests/e2e/bluewallet3.spec.js
@@ -60,7 +60,8 @@ describe('BlueWallet UI Tests - import Watch-only wallet (zpub)', () => {
     await element(by.id('ReceiveButton')).tap();
     await expect(element(by.id('BitcoinAddressQRCode'))).toBeVisible();
     await expect(element(by.label('bc1qgrhr5xc5774maph97d73ydrjlqqmg2v6jjlr29'))).toBeVisible();
-    await element(by.id('SetCustomAmountButton')).tap();
+    await element(by.id('ReceiveMoreOptionsButton')).tap();
+    await element(by.id('ReceiveWithAmountOption')).tap();
     await element(by.id('BitcoinAmountInput')).replaceText('1');
     await element(by.id('CustomAmountDescription')).typeText('Test');
     await element(by.id('CustomAmountDescription')).tapReturnKey();

--- a/tests/e2e/bluewallet3.spec.js
+++ b/tests/e2e/bluewallet3.spec.js
@@ -62,7 +62,8 @@ describe('BlueWallet UI Tests - import Watch-only wallet (zpub)', () => {
     await element(by.id('ReceiveButton')).tap();
     await expect(element(by.id('BitcoinAddressQRCode'))).toBeVisible();
     await expect(element(by.label('bc1qgrhr5xc5774maph97d73ydrjlqqmg2v6jjlr29'))).toBeVisible();
-    await element(by.id('SetCustomAmountButton')).tap();
+    await element(by.id('ReceiveMoreOptionsButton')).tap();
+    await element(by.id('ReceiveWithAmountOption')).tap();
     await element(by.id('BitcoinAmountInput')).replaceText('1');
     await element(by.id('CustomAmountDescription')).typeText('Test');
     await element(by.id('CustomAmountDescription')).tapReturnKey();

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -521,6 +521,23 @@ it('can decrypt storage that is second in a list of buckets; and isPasswordInUse
   assert.strictEqual(Storage7.wallets[0].getLabel(), 'fakewallet');
 });
 
+it('Appstorage - address_metadata labels: set, persist', async () => {
+  const addr = 'bc1qaxxc4gwx6rd6rymq08qwpxhesd4jqu93lvjsyt';
+
+  /** @type {BlueApp} */
+  const Storage = new BlueApp();
+  const w = new SegwitP2SHWallet();
+  await w.generate();
+  Storage.wallets.push(w);
+
+  Storage.address_metadata[addr] = { label: 'rent' };
+  await Storage.saveToDisk();
+
+  const Storage2 = new BlueApp();
+  await Storage2.loadFromDisk();
+  assert.strictEqual(Storage2.address_metadata[addr].label, 'rent');
+});
+
 it('Appstorage - hashIt() works', async () => {
   const storage = new BlueApp();
   assert.strictEqual(storage.hashIt('hello'), '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824');


### PR DESCRIPTION
Lets users attach a short label to a receive address (e.g. "rent", "exchange withdrawal") and see that label in the addresses list, transaction details, and the transaction list.

## What changed

**Storage**
- New address_metadata bucket

**Receive screen**
- The "Receive with amount" link is replaced by a More options button that opens a sheet with two entries: Receive with amount and Label, each opening its own form sheet.
- New ReceiveAddressLabelSheet, a single text input (max 100 chars) plus Save. Saving an empty value clears the label.
- When a label exists, it renders as a tappable pill under the receive card; tapping it reopens the sheet for editing. Hidden when empty, and only on the address tab.
- The custom amount sheet's two side-by-side buttons became a primary Add button with Reset as a link underneath, matching the new sheet layout.
- Sheet nav options were extracted into a shared receiveSheetOptions() helper in ReceiveDetailsStack.tsx, since DetailViewScreensStack registers the same three sheets.

**Addresses list**
- New AddressLabelBadge, a small pill rendered next to the existing address type badge.

**Transaction details**
- Labeled addresses in the From/To sections show the badge below the address; tapping opens the label sheet to edit or clear.
- Address rows changed from inline comma-separated to stacked, so a badge has room without wrapping awkwardly.

**Transaction list**
- The row's right subtitle now resolves in priority order: contact > memo/note > address label > empty. A transaction touching multiple labeled addresses joins them comma-separated.

**Tests**

- Unit (tests/unit/storage.test.js): address_metadata label survives saveToDisk and loadFromDisk.
- E2E (bluewallet.spec.js): set a label through the new sheet flow, verify the pill renders, relaunch the app, reopen Receive, verify the label is still there.
- E2E (bluewallet3.spec.js): updated for the new nav path to the custom amount sheet

<img width="250" alt="Screenshot_1785368374" src="https://github.com/user-attachments/assets/c2362fdf-9a38-48ee-8b8c-af572c774b9f" />
<img width="250" alt="Screenshot_1785367263" src="https://github.com/user-attachments/assets/7be96b2a-a1bf-4f07-b846-2d5881d490c4" />
<img width="250" alt="Screenshot_1785367265" src="https://github.com/user-attachments/assets/c382fd9d-94ed-4a13-afd7-b0afc89e036e" />
<img width="250" alt="Screenshot_1785369389" src="https://github.com/user-attachments/assets/285d7744-4dd9-4efc-8600-50c4d5dd4927" />
<img width="250" alt="Screenshot_1785367295" src="https://github.com/user-attachments/assets/ee117578-1912-4e2d-bf99-8bbb8b19495c" />
<img width="250" alt="Screenshot_1785368712" src="https://github.com/user-attachments/assets/03e0eb03-9827-4dd3-a3f9-c4e6b1166f64" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/20a57264-b095-4c6d-b6c9-760bcce89a3a" />

Related issue: https://github.com/BlueWallet/BlueWallet/issues/3313