### PR TITLE
FIX: swap AmountInput zIndex so TextInput sits on top

### DIFF
--- a/components/AmountInput.tsx
+++ b/components/AmountInput.tsx
@@ -555,11 +555,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: INPUT_HORIZONTAL_PADDING,
     paddingVertical: INPUT_VERTICAL_PADDING,
-    zIndex: 2,
+    zIndex: 1,
   },
   inputOverlay: {
     ...StyleSheet.absoluteFill,
-    zIndex: 1,
+    zIndex: 2,
   },
   cryptoCurrency: {
     fontSize: 15,


### PR DESCRIPTION
Follow-up to #8574.

e2e flake on `BitcoinAmountInput`: Detox sees the transparent `TextInput` as occluded by the animated glyph layer (`inputDisplay`, zIndex 2). Swap z-order — `TextInput` on top, 100% visible, `replaceText` lands without retry. No visual change.