### PR TITLE
R6mez recieve addresses labels

### DIFF
--- a/class/blue-app.ts
+++ b/class/blue-app.ts
@@ -54,6 +54,12 @@ export type TCounterpartyMetadata = {
   };
 };
 
+export type TAddressMetadata = {
+  [address: string]: {
+    label: string;
+  };
+};
+
 type TRealmTransaction = {
   internal: boolean;
   index: number;
@@ -64,6 +70,7 @@ type TBucketStorage = {
   wallets: string[]; // array of serialized wallets, not actual wallet objects
   tx_metadata: TTXMetadata;
   counterparty_metadata: TCounterpartyMetadata;
+  address_metadata: TAddressMetadata;
 };
 
 const isReactNative = typeof navigator !== 'undefined' && navigator?.product === 'ReactNative';
@@ -81,12 +88,14 @@ export class BlueApp {
   public cachedPassword?: false | string;
   public tx_metadata: TTXMetadata;
   public counterparty_metadata: TCounterpartyMetadata;
+  public address_metadata: TAddressMetadata;
   public wallets: TWallet[];
 
   constructor() {
     this.wallets = [];
     this.tx_metadata = {};
     this.counterparty_metadata = {};
+    this.address_metadata = {};
     this.cachedPassword = false;
   }
 
@@ -209,6 +218,7 @@ export class BlueApp {
       this.wallets = [];
       this.tx_metadata = {};
       this.counterparty_metadata = {};
+      this.address_metadata = {};
       return this.loadFromDisk();
     } else {
       throw new Error('Incorrect password. Please, try again.');
@@ -239,11 +249,13 @@ export class BlueApp {
     this.wallets = [];
     this.tx_metadata = {};
     this.counterparty_metadata = {};
+    this.address_metadata = {};
 
     const data: TBucketStorage = {
       wallets: [],
       tx_metadata: {},
       counterparty_metadata: {},
+      address_metadata: {},
     };
 
     let buckets = await this.getItem('data');
@@ -489,6 +501,7 @@ export class BlueApp {
           this.wallets.push(unserializedWallet);
           this.tx_metadata = data.tx_metadata;
           this.counterparty_metadata = data.counterparty_metadata;
+          this.address_metadata = data.address_metadata ?? {};
         }
       }
       if (realm) realm.close();
@@ -684,6 +697,7 @@ export class BlueApp {
         wallets: walletsToSave,
         tx_metadata: this.tx_metadata,
         counterparty_metadata: this.counterparty_metadata,
+        address_metadata: this.address_metadata,
       };
 
       if (this.cachedPassword) {

--- a/components/Context/StorageProvider.tsx
+++ b/components/Context/StorageProvider.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { BlueApp as BlueAppClass, TCounterpartyMetadata, TTXMetadata } from '../../class/blue-app';
+import { BlueApp as BlueAppClass, TCounterpartyMetadata, TTXMetadata, TAddressMetadata } from '../../class/blue-app';
 import { LegacyWallet } from '../../class/wallets/legacy-wallet';
 import { WatchOnlyWallet } from '../../class/wallets/watch-only-wallet';
 import type { TWallet } from '../../class/wallets/types';
@@ -24,6 +24,7 @@ interface StorageContextType {
   setWalletsWithNewOrder: (wallets: TWallet[]) => void;
   txMetadata: TTXMetadata;
   counterpartyMetadata: TCounterpartyMetadata;
+  addressMetadata: TAddressMetadata;
   saveToDisk: (force?: boolean) => Promise<void>;
   selectedWalletID: () => string | undefined; // Change from string|undefined to a function
   addWallet: (wallet: TWallet) => void;
@@ -67,6 +68,7 @@ export const StorageContext = createContext<StorageContextType>(undefined);
 export const StorageProvider = ({ children }: { children: React.ReactNode }) => {
   const txMetadata = useRef<TTXMetadata>(BlueApp.tx_metadata);
   const counterpartyMetadata = useRef<TCounterpartyMetadata>(BlueApp.counterparty_metadata || {}); // init
+  const addressMetadata = useRef<TAddressMetadata>(BlueApp.address_metadata || {});
 
   const [wallets, setWallets] = useState<TWallet[]>([]);
   const [walletTransactionUpdateStatus, setWalletTransactionUpdateStatus] = useState<WalletTransactionsStatus | string>(
@@ -158,12 +160,13 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
       }
       BlueApp.tx_metadata = txMetadata.current;
       BlueApp.counterparty_metadata = counterpartyMetadata.current;
+      BlueApp.address_metadata = addressMetadata.current;
       await BlueApp.saveToDisk();
       const w: TWallet[] = [...BlueApp.getWallets()];
       setWallets(w);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [txMetadata.current, counterpartyMetadata.current],
+    [txMetadata.current, counterpartyMetadata.current, addressMetadata.current],
   );
 
   const addWallet = useCallback((wallet: TWallet) => {
@@ -307,6 +310,7 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
     if (walletsInitialized) {
       txMetadata.current = BlueApp.tx_metadata;
       counterpartyMetadata.current = BlueApp.counterparty_metadata;
+      addressMetadata.current = BlueApp.address_metadata ?? {};
       setWallets(BlueApp.getWallets());
     }
   }, [walletsInitialized]);
@@ -513,6 +517,7 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
       setWalletsWithNewOrder,
       txMetadata: txMetadata.current,
       counterpartyMetadata: counterpartyMetadata.current,
+      addressMetadata: addressMetadata.current,
       saveToDisk,
       getTransactions: BlueApp.getTransactions,
       selectedWalletID,

--- a/components/addresses/AddressItem.tsx
+++ b/components/addresses/AddressItem.tsx
@@ -40,7 +40,8 @@ const AddressItem = ({
   searchQuery = '',
   renderHighlightedText,
 }: AddressItemProps) => {
-  const { wallets } = useStorage();
+  const { wallets, addressMetadata } = useStorage();
+  const addressLabel = addressMetadata?.[item.address]?.label;
   const { colors, dark } = useTheme();
   const { isBiometricUseCapableAndEnabled } = useBiometrics();
   const balanceOpacity = useSharedValue(1);
@@ -64,6 +65,9 @@ const AddressItem = ({
     },
     address: {
       color: dark ? colors.foregroundColor : colors.darkGray,
+    },
+    label: {
+      color: colors.foregroundColor,
     },
   });
 
@@ -210,6 +214,11 @@ const AddressItem = ({
           </View>
           <View style={styles.middleSection}>
             {renderAddressContent()}
+            {addressLabel ? (
+              <Text style={[stylesHook.label, styles.label]} numberOfLines={1} ellipsizeMode="tail">
+                {addressLabel}
+              </Text>
+            ) : null}
             <Text style={[stylesHook.balance, styles.balance]}>{balance}</Text>
           </View>
         </View>
@@ -235,6 +244,12 @@ const styles = StyleSheet.create({
   address: {
     fontWeight: 'bold',
     marginHorizontal: 4,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '500',
+    marginHorizontal: 4,
+    marginTop: 4,
   },
   tooltipButton: {
     width: '100%',

--- a/loc/en.json
+++ b/loc/en.json
@@ -336,6 +336,8 @@
     "transaction_not_available": "Transaction not available",
     "confirmations_lowercase": "{confirmations} confirmations",
     "expand_note": "Expand Note",
+    "address_label_placeholder": "Label for this address",
+    "address_label_none": "No label",
     "cpfp_create": "Create",
     "cpfp_exp": "We will create another transaction that spends your unconfirmed transaction. The total fee will be higher than the original transaction fee, so it should be mined faster. This is called CPFP—Child Pays for Parent.",
     "cpfp_no_bump": "This transaction is not bumpable.",

--- a/screen/receive/ReceiveCustomAmountSheet.tsx
+++ b/screen/receive/ReceiveCustomAmountSheet.tsx
@@ -13,11 +13,13 @@ import { BitcoinUnit } from '../../models/bitcoinUnits';
 import DeeplinkSchemaMatch from '../../class/deeplink-schema-match';
 import { satoshiToBTC, fiatToBTC } from '../../blue_modules/currency';
 import { ReceiveDetailsStackParamList } from '../../navigation/ReceiveDetailsStackParamList';
+import { useStorage } from '../../hooks/context/useStorage';
 
 const ReceiveCustomAmountSheet = () => {
   const navigation = useNavigation<NativeStackNavigationProp<ReceiveDetailsStackParamList, 'ReceiveCustomAmount'>>();
   const route = useRoute<RouteProp<ReceiveDetailsStackParamList, 'ReceiveCustomAmount'>>();
   const { colors } = useTheme();
+  const { addressMetadata, saveToDisk } = useStorage();
 
   const { address, currentLabel = '', currentAmount = '', currentUnit = BitcoinUnit.BTC, preferredUnit = BitcoinUnit.BTC } = route.params;
 
@@ -91,6 +93,10 @@ const ReceiveCustomAmountSheet = () => {
 
   const handleSave = useCallback(() => {
     const resolvedLabel = latestLabel.current ?? label;
+    const trimmed = resolvedLabel.trim();
+    if (trimmed) addressMetadata[address] = { label: trimmed };
+    else delete addressMetadata[address];
+    saveToDisk();
     const encoded = computeBip21(amount, unit, resolvedLabel);
     navigation.popTo(
       'ReceiveDetails',
@@ -103,11 +109,13 @@ const ReceiveCustomAmountSheet = () => {
       },
       { merge: true },
     );
-  }, [amount, unit, label, computeBip21, navigation]);
+  }, [amount, unit, label, computeBip21, navigation, address, addressMetadata, saveToDisk]);
 
   const handleReset = useCallback(() => {
     const fallbackUnit = preferredUnit || BitcoinUnit.BTC;
     const encoded = DeeplinkSchemaMatch.bip21encode(address);
+    delete addressMetadata[address];
+    saveToDisk();
     navigation.popTo(
       'ReceiveDetails',
       {
@@ -119,7 +127,7 @@ const ReceiveCustomAmountSheet = () => {
       },
       { merge: true },
     );
-  }, [address, navigation, preferredUnit]);
+  }, [address, navigation, preferredUnit, addressMetadata, saveToDisk]);
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['bottom', 'left', 'right']}>

--- a/screen/receive/ReceiveDetails.tsx
+++ b/screen/receive/ReceiveDetails.tsx
@@ -183,7 +183,7 @@ type RouteProps = RouteProp<ReceiveDetailsStackParamList, 'ReceiveDetails'>;
 const ReceiveDetails = () => {
   const route = useRoute<RouteProps>();
   const { walletID, address } = route.params;
-  const { wallets, saveToDisk, sleep, fetchAndSaveWalletTransactions } = useStorage();
+  const { wallets, saveToDisk, sleep, fetchAndSaveWalletTransactions, addressMetadata } = useStorage();
   const { isElectrumDisabled } = useSettings();
   const { colors, closeImage } = useTheme();
   const isDarkTheme = useColorScheme() === 'dark';
@@ -346,6 +346,15 @@ const ReceiveDetails = () => {
       setAddressBIP21Encoded(address);
     }
   }, [address, isCustom, setAddressBIP21Encoded]);
+
+  useEffect(() => {
+    if (!address || isCustom) return;
+    const storedLabel = addressMetadata?.[address]?.label;
+    if (!storedLabel) return;
+    setCustomLabel(storedLabel);
+    setIsCustom(true);
+    setBip21encoded(DeeplinkSchemaMatch.bip21encode(address, { label: storedLabel }));
+  }, [address, isCustom, addressMetadata]);
 
   const toolTipActions = useMemo(() => {
     const action = { ...CommonToolTipActions.PaymentsCode };

--- a/screen/transactions/TransactionStatus.tsx
+++ b/screen/transactions/TransactionStatus.tsx
@@ -148,7 +148,7 @@ const TransactionStatus: React.FC = () => {
     isLoading: !initialTx,
   });
   const { isCPFPPossible, isRBFBumpFeePossible, isRBFCancelPossible, tx, isLoading, eta, intervalMs, wallet, loadingError } = state;
-  const { wallets, txMetadata, counterpartyMetadata, fetchAndSaveWalletTransactions, saveToDisk } = useStorage();
+  const { wallets, txMetadata, counterpartyMetadata, addressMetadata, fetchAndSaveWalletTransactions, saveToDisk } = useStorage();
   const subscribedWallet = useWalletSubscribe(walletID);
   const { navigate, goBack, setOptions } = useExtendedNavigation<NavigationProps>();
   const { colors } = useTheme();
@@ -688,6 +688,25 @@ const TransactionStatus: React.FC = () => {
     }
   }, [tx?.hash, txMetadata, saveToDisk]);
 
+  const handleAddressLabelPress = useCallback(
+    async (address: string) => {
+      const currentLabel = addressMetadata?.[address]?.label ?? '';
+      try {
+        const newLabel = await prompt(loc.transactions.address_label_placeholder, '', {
+          type: 'plain-text',
+          defaultValue: currentLabel,
+        });
+        if (newLabel === undefined) return;
+        addressMetadata[address] = { label: newLabel.trim() };
+        await saveToDisk();
+        triggerHapticFeedback(HapticFeedbackTypes.NotificationSuccess);
+      } catch (_) {
+        // user cancelled
+      }
+    },
+    [addressMetadata, saveToDisk],
+  );
+
   const handleOpenBlockExplorer = useCallback(() => {
     if (!tx?.hash || !selectedBlockExplorer) return;
     const url = `${selectedBlockExplorer.url}/tx/${tx.hash}`;
@@ -763,14 +782,18 @@ const TransactionStatus: React.FC = () => {
   const renderSection = (array: any[]) => {
     const fromArray = [];
 
-    for (const [index, address] of array.entries()) {
+    for (const address of array) {
       const isWeOwnAddress = weOwnAddress(address);
       const addressStyle = isWeOwnAddress ? [styles.weOwnAddress, stylesHook.rowValue] : [stylesHook.rowValue];
+      const label = addressMetadata?.[address]?.label;
 
       fromArray.push(
         <View key={address} style={styles.addressRow}>
           <CopyTextToClipboard text={address} style={StyleSheet.flatten(addressStyle)} />
-          {index !== array.length - 1 && <BlueText style={addressStyle}>,</BlueText>}
+          <TouchableOpacity onPress={() => handleAddressLabelPress(address)} style={styles.addressLabelButton}>
+            <Text style={[styles.addressLabelText, stylesHook.rowValue]}>{label || loc.transactions.address_label_none}</Text>
+            <Icon name="pencil" type="font-awesome" size={12} color={colors.alternativeTextColor} />
+          </TouchableOpacity>
         </View>,
       );
     }
@@ -1562,9 +1585,22 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   addressRow: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    marginBottom: 8,
+  },
+  addressLabelButton: {
     flexDirection: 'row',
     alignItems: 'center',
-    flexWrap: 'wrap',
+    gap: 6,
+    marginTop: 4,
+    paddingVertical: 4,
+    paddingHorizontal: 6,
+    borderRadius: 4,
+  },
+  addressLabelText: {
+    fontSize: 13,
+    fontWeight: '500',
   },
   detailValue: {
     fontSize: 15,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Extends encrypted on-disk storage schema; migration is backward-compatible but any bug in load/save could affect wallet data persistence.
> 
> **Overview**
> Adds **persistent address labels** keyed by Bitcoin address, stored alongside existing tx and counterparty metadata in the encrypted app bucket (with `?? {}` on load for older saves).
> 
> Labels can be set or cleared from the **receive custom amount** sheet and are written through `saveToDisk`. **Receive** pre-fills the description and BIP21 URI when a stored label exists. The **address list** shows the label under each address.
> 
> On **transaction details**, inputs/outputs in the advanced section show each address with a tappable label row (prompt to edit, persisted like other metadata). New copy in `en.json` for the label placeholder and empty state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fe72f1497096a1bc10545a7d910276a7b3b2330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->