### PR TITLE
FIX: iOS crash when hiding balance via context menu

### DIFF
--- a/components/TotalWalletsBalance.tsx
+++ b/components/TotalWalletsBalance.tsx
@@ -88,26 +88,34 @@ const TotalWalletsBalance: React.FC = React.memo(() => {
     await setTotalBalancePreferredUnitStorage(nextUnit);
   }, [totalBalancePreferredUnit, setTotalBalancePreferredUnitStorage]);
 
-  if (!isTotalBalanceEnabled) return null;
-
+  // We intentionally keep the ToolTipMenu mounted and toggle `display` instead of
+  // returning null when disabled. react-native-context-menu-view is a legacy (Paper)
+  // component driven through the New Architecture interop layer; unmounting the menu
+  // host while the native context menu is still dismissing desyncs Fabric's view
+  // registry and crashes in RCTViewComponentView unmountChildComponentView (NSRangeException).
   return (
-    <ToolTipMenu actions={toolTipActions} onPressMenuItem={onPressMenuItem} shouldOpenOnLongPress style={styles.menuContainer}>
-      <View style={styles.container}>
-        <Text style={styles.label}>{loc.wallets.total_balance}</Text>
-        <TouchableOpacity onPress={handleBalanceOnPress}>
-          <Text style={[styles.balance, { color: colors.foregroundColor }]}>
-            {totalBalanceFormatted}{' '}
-            {totalBalancePreferredUnit !== BitcoinUnit.LOCAL_CURRENCY && (
-              <Text style={[styles.currency, { color: colors.foregroundColor }]}>{totalBalancePreferredUnit}</Text>
-            )}
-          </Text>
-        </TouchableOpacity>
-      </View>
-    </ToolTipMenu>
+    <View style={isTotalBalanceEnabled ? undefined : styles.hidden}>
+      <ToolTipMenu actions={toolTipActions} onPressMenuItem={onPressMenuItem} shouldOpenOnLongPress style={styles.menuContainer}>
+        <View style={styles.container}>
+          <Text style={styles.label}>{loc.wallets.total_balance}</Text>
+          <TouchableOpacity onPress={handleBalanceOnPress}>
+            <Text style={[styles.balance, { color: colors.foregroundColor }]}>
+              {totalBalanceFormatted}{' '}
+              {totalBalancePreferredUnit !== BitcoinUnit.LOCAL_CURRENCY && (
+                <Text style={[styles.currency, { color: colors.foregroundColor }]}>{totalBalancePreferredUnit}</Text>
+              )}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </ToolTipMenu>
+    </View>
   );
 });
 
 const styles = StyleSheet.create({
+  hidden: {
+    display: 'none',
+  },
   menuContainer: {
     alignSelf: 'stretch',
   },

--- a/components/TransactionsNavigationHeader.tsx
+++ b/components/TransactionsNavigationHeader.tsx
@@ -220,23 +220,27 @@ const TransactionsNavigationHeader: React.FC<TransactionsNavigationHeaderProps> 
               onPressMenuItem={onPressMenuItem}
               actions={toolTipWalletBalanceActions}
             >
+              {/* Both views stay mounted; we toggle `display` instead of swapping them.
+                  react-native-context-menu-view is a legacy (Paper) component running under
+                  the New Architecture interop layer, and mounting/unmounting children of the
+                  menu host desyncs Fabric's view registry, crashing in
+                  RCTViewComponentView unmountChildComponentView (NSRangeException). */}
               <View style={styles.walletBalance}>
-                {hideBalance ? (
+                <View style={hideBalance ? undefined : styles.balanceHidden} pointerEvents="none">
                   <BlurredBalanceView />
-                ) : (
-                  <View key={`wallet-balance-textwrap-${wallet.getID?.() ?? ''}-${String(balance)}`}>
-                    <Animated.Text
-                      key={`wallet-balance-text-${wallet.getID?.() ?? ''}-${String(balance)}`} // force recreation on balance change for RTL correctness
-                      testID="WalletBalance"
-                      numberOfLines={1}
-                      minimumFontScale={0.5}
-                      adjustsFontSizeToFit
-                      style={[styles.walletBalanceText, animatedBalanceTextStyle]}
-                    >
-                      {balance}
-                    </Animated.Text>
-                  </View>
-                )}
+                </View>
+                <View style={hideBalance ? styles.balanceHidden : undefined}>
+                  <Animated.Text
+                    key={`wallet-balance-text-${wallet.getID?.() ?? ''}-${String(balance)}`} // force recreation on balance change for RTL correctness
+                    testID="WalletBalance"
+                    numberOfLines={1}
+                    minimumFontScale={0.5}
+                    adjustsFontSizeToFit
+                    style={[styles.walletBalanceText, animatedBalanceTextStyle]}
+                  >
+                    {balance}
+                  </Animated.Text>
+                </View>
               </View>
             </ToolTipMenu>
             <TouchableOpacity style={styles.walletPreferredUnitView} onPress={changeWalletBalanceUnit} disabled={unitSwitching}>
@@ -300,6 +304,9 @@ const styles = StyleSheet.create({
   walletBalance: {
     flexShrink: 1,
     marginRight: 6,
+  },
+  balanceHidden: {
+    display: 'none',
   },
   manageFundsButtonContainer: {
     marginTop: 14,


### PR DESCRIPTION
## Summary

- Fixes a potential iOS New Architecture crash (`NSRangeException` in `RCTViewComponentView unmountChildComponentView`) when rapidly hiding/showing balance via long-press context menu.
- **Wallet transactions header:** defer `hideBalance` toggle until `InteractionManager.runAfterInteractions`, and keep a stable child tree under `ToolTipMenu` instead of swapping `BlurredBalanceView` ↔ balance text during menu dismiss.
- **Total wallets balance:** defer disabling total balance on Hide menu action for the same reason (avoids unmounting `ToolTipMenu` while the native menu is still closing).

## Test plan

- [ ] iOS: open a wallet → long-press header balance → Hide Balance → repeat show/hide quickly (no crash)
- [ ] iOS: wallets list → long-press total balance → Hide → repeat (no crash)
- [ ] Android: same flows (no regression)
- [ ] Balance hide/show still persists after app restart


Made with [Cursor](https://cursor.com)