### PR TITLE
OPS: bump detox to 20.51.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "crypto-browserify": "3.12.1",
         "crypto-js": "4.2.0",
         "dayjs": "1.11.20",
-        "detox": "20.51.1",
+        "detox": "^20.51.3",
         "ecpair": "3.0.1",
         "electrum-client": "github:BlueWallet/rn-electrum-client#83420b8",
         "electrum-mnemonic": "2.0.0",
@@ -8001,9 +8001,9 @@
       }
     },
     "node_modules/detox": {
-      "version": "20.51.1",
-      "resolved": "https://registry.npmjs.org/detox/-/detox-20.51.1.tgz",
-      "integrity": "sha512-SKHM445qJDSaCO0vQHZnzfStpU1nQtBgWPjMZh/R+1q/ra9F2WyvtNSQcDTb2SPC/jN4FNWaj9ZUcJTkaLEB/g==",
+      "version": "20.51.3",
+      "resolved": "https://registry.npmjs.org/detox/-/detox-20.51.3.tgz",
+      "integrity": "sha512-wrR1Xr+mojmM+UsycyLalLmednc2ZMHasdzGZgdmqfcVXN5OcSyVzA/JGoTmmz3Q/Xqv4bvT3jg/HdfQwiQMiw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "crypto-browserify": "3.12.1",
         "crypto-js": "4.2.0",
         "dayjs": "1.11.20",
-        "detox": "^20.51.3",
+        "detox": "20.51.3",
         "ecpair": "3.0.1",
         "electrum-client": "github:BlueWallet/rn-electrum-client#83420b8",
         "electrum-mnemonic": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "crypto-browserify": "3.12.1",
     "crypto-js": "4.2.0",
     "dayjs": "1.11.20",
-    "detox": "^20.51.3",
+    "detox": "20.51.3",
     "ecpair": "3.0.1",
     "electrum-client": "github:BlueWallet/rn-electrum-client#83420b8",
     "electrum-mnemonic": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "crypto-browserify": "3.12.1",
     "crypto-js": "4.2.0",
     "dayjs": "1.11.20",
-    "detox": "20.51.1",
+    "detox": "^20.51.3",
     "ecpair": "3.0.1",
     "electrum-client": "github:BlueWallet/rn-electrum-client#83420b8",
     "electrum-mnemonic": "2.0.0",


### PR DESCRIPTION
Bump detox from 20.51.1 to latest 20.51.3.

This updates the end-to-end testing framework to the latest patch version.

Changes:
- Updated package.json and package-lock.json

This should be a non-breaking update as it's a patch version bump.