### PR TITLE
OPS: swap GroundControl production URL to groundcontrol.bluewallet.io

### DIFF
--- a/blue_modules/constants.ts
+++ b/blue_modules/constants.ts
@@ -2,4 +2,4 @@
  * Let's keep config vars, constants and definitions here
  */
 
-export const groundControlUri: string = 'https://groundcontrol-bluewallet.herokuapp.com';
+export const groundControlUri: string = 'https://groundcontrol.bluewallet.io/';

--- a/tests/integration/notifications.test.js
+++ b/tests/integration/notifications.test.js
@@ -7,7 +7,7 @@ describe('notifications', () => {
   // yeah, lets rely less on external services...
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('can check groundcontrol server uri validity', async () => {
-    assert.ok(await isGroundControlUriValid('https://groundcontrol-bluewallet.herokuapp.com'));
+    assert.ok(await isGroundControlUriValid('https://groundcontrol.bluewallet.io/'));
     assert.ok(!(await isGroundControlUriValid('https://www.google.com')));
     await new Promise(resolve => setTimeout(resolve, 2000));
   });


### PR DESCRIPTION
Replaces the old Heroku GroundControl URL (groundcontrol-bluewallet.herokuapp.com) with the new production domain https://groundcontrol.bluewallet.io/. Updated in constants.ts and the integration test.