### PR TITLE
FIX: startup crash

### DIFF
--- a/android/app/src/main/java/io/bluewallet/bluewallet/MainApplication.kt
+++ b/android/app/src/main/java/io/bluewallet/bluewallet/MainApplication.kt
@@ -14,6 +14,8 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
+import com.facebook.drawee.backends.pipeline.Fresco
+import com.facebook.react.modules.fresco.FrescoModule
 import com.facebook.react.modules.i18nmanager.I18nUtil
 import io.bluewallet.bluewallet.components.segmentedcontrol.SegmentedControlPackage
 
@@ -97,6 +99,13 @@ class MainApplication : Application(), ReactApplication {
         
         val sharedI18nUtilInstance = I18nUtil.getInstance()
         sharedI18nUtilInstance.allowRTL(applicationContext, true)
+
+        // Initialize Fresco before RN mounts views. FrescoModule init can lag behind the first
+        // frame (e.g. UnlockWith logo) when OkHttp/SSL warms up network security config.
+        if (!FrescoModule.hasBeenInitialized()) {
+            Fresco.initialize(this)
+        }
+
         loadReactNative(this)
 
         initializeDeviceUID()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, targeted startup ordering change in MainApplication with a guard to avoid double initialization; no auth or data-handling impact.
> 
> **Overview**
> Fixes an Android **startup crash** by initializing **Fresco** in `MainApplication.onCreate()` **before** `loadReactNative()`, when `FrescoModule` has not already initialized it.
> 
> The change addresses a race where the first frame (e.g. UnlockWith logo) can render before Fresco is ready, especially when OkHttp/SSL and network security config warm up slowly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c8cfd3690ff354b1d80a7912779ab3a1c9f6326. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->