### PR TITLE
Request incognito keyboard for sensitive Android inputs

### DIFF
--- a/android/app/src/main/java/io/bluewallet/bluewallet/SettingsModule.kt
+++ b/android/app/src/main/java/io/bluewallet/bluewallet/SettingsModule.kt
@@ -3,6 +3,9 @@ package io.bluewallet.bluewallet
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import android.widget.TextView
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.Promise
@@ -206,6 +209,43 @@ class SettingsModule(reactContext: ReactApplicationContext) : NativeSettingsModu
         } catch (e: Exception) {
             Log.e(TAG, "Error opening settings", e)
             promise.reject("ERROR", e.message)
+        }
+    }
+
+    /**
+     * Request best-effort Android keyboard privacy for the focused editor.
+     *
+     * Keyboards that honor IME_FLAG_NO_PERSONALIZED_LEARNING should avoid
+     * storing this input for suggestions, analytics, or user dictionaries.
+     */
+    @ReactMethod
+    override fun requestKeyboardIncognitoMode(promise: Promise) {
+        val activity = currentActivity
+        if (activity == null) {
+            promise.resolve(false)
+            return
+        }
+
+        activity.runOnUiThread {
+            try {
+                val focusedView = activity.currentFocus
+                if (focusedView !is TextView) {
+                    promise.resolve(false)
+                    return@runOnUiThread
+                }
+
+                focusedView.imeOptions =
+                    focusedView.imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
+
+                val inputMethodManager =
+                    activity.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+                inputMethodManager?.restartInput(focusedView)
+
+                promise.resolve(true)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error requesting keyboard incognito mode", e)
+                promise.reject("ERROR", e.message)
+            }
         }
     }
 }

--- a/blue_modules/SettingsModule.ts
+++ b/blue_modules/SettingsModule.ts
@@ -44,6 +44,12 @@ interface SettingsModuleInterface {
    * This opens the app's settings screen
    */
   openSettings(): Promise<boolean>;
+
+  /**
+   * Ask Android keyboards not to persist personalized learning for the
+   * currently focused input.
+   */
+  requestKeyboardIncognitoMode(): Promise<boolean>;
 }
 
 // Only available on Android

--- a/blue_modules/requestKeyboardIncognitoMode.ts
+++ b/blue_modules/requestKeyboardIncognitoMode.ts
@@ -1,0 +1,15 @@
+import { Platform } from 'react-native';
+
+import SettingsModule from './SettingsModule';
+
+const requestKeyboardIncognitoMode = async (): Promise<boolean> => {
+  if (Platform.OS !== 'android') return false;
+
+  try {
+    return (await SettingsModule?.requestKeyboardIncognitoMode()) ?? false;
+  } catch {
+    return false;
+  }
+};
+
+export default requestKeyboardIncognitoMode;

--- a/codegen/NativeSettingsModule.ts
+++ b/codegen/NativeSettingsModule.ts
@@ -10,6 +10,7 @@ export interface Spec extends TurboModule {
   setDoNotTrack(enabled: boolean): Promise<boolean>;
   getDoNotTrack(): Promise<boolean>;
   openSettings(): Promise<boolean>;
+  requestKeyboardIncognitoMode(): Promise<boolean>;
 }
 
 const nativeModule = TurboModuleRegistry.get<Spec>('SettingsModule');

--- a/components/BlueFormMultiInput.tsx
+++ b/components/BlueFormMultiInput.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Platform, StyleSheet, TextInput, TextInputProps } from 'react-native';
+import { Platform, StyleSheet, TextInputProps } from 'react-native';
 
+import IncognitoKeyboardTextInput from './IncognitoKeyboardTextInput';
 import { useTheme } from './themes';
 
 const BlueFormMultiInput: React.FC<TextInputProps> = props => {
@@ -8,7 +9,7 @@ const BlueFormMultiInput: React.FC<TextInputProps> = props => {
   const { style, editable, ...restProps } = props;
 
   return (
-    <TextInput
+    <IncognitoKeyboardTextInput
       multiline
       underlineColorAndroid="transparent"
       numberOfLines={4}

--- a/components/IncognitoKeyboardTextInput.tsx
+++ b/components/IncognitoKeyboardTextInput.tsx
@@ -1,0 +1,55 @@
+import React, { forwardRef, useCallback } from 'react';
+import { TextInput, TextInputProps } from 'react-native';
+
+import requestKeyboardIncognitoMode from '../blue_modules/requestKeyboardIncognitoMode';
+
+export type IncognitoKeyboardTextInputProps = TextInputProps & {
+  incognitoKeyboard?: boolean;
+};
+
+const IncognitoKeyboardTextInput = forwardRef<
+  TextInput,
+  IncognitoKeyboardTextInputProps
+>(
+  (
+    {
+      autoCapitalize,
+      autoCorrect,
+      importantForAutofill,
+      incognitoKeyboard = true,
+      onFocus,
+      spellCheck,
+      ...props
+    },
+    ref,
+  ) => {
+    const handleFocus = useCallback<NonNullable<TextInputProps['onFocus']>>(
+      event => {
+        if (incognitoKeyboard) {
+          requestKeyboardIncognitoMode();
+        }
+
+        onFocus?.(event);
+      },
+      [incognitoKeyboard, onFocus],
+    );
+
+    return (
+      <TextInput
+        ref={ref}
+        autoCapitalize={incognitoKeyboard ? (autoCapitalize ?? 'none') : autoCapitalize}
+        autoCorrect={incognitoKeyboard ? (autoCorrect ?? false) : autoCorrect}
+        importantForAutofill={
+          incognitoKeyboard ? (importantForAutofill ?? 'no') : importantForAutofill
+        }
+        onFocus={handleFocus}
+        spellCheck={incognitoKeyboard ? (spellCheck ?? false) : spellCheck}
+        {...props}
+      />
+    );
+  },
+);
+
+IncognitoKeyboardTextInput.displayName = 'IncognitoKeyboardTextInput';
+
+export default IncognitoKeyboardTextInput;

--- a/components/PasswordInput.tsx
+++ b/components/PasswordInput.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import { Animated, Easing, StyleSheet, TextInput, View } from 'react-native';
+import IncognitoKeyboardTextInput from './IncognitoKeyboardTextInput';
 import { useTheme } from './themes';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../blue_modules/hapticFeedback';
 import loc from '../loc';
@@ -136,7 +137,7 @@ export const PasswordInput = forwardRef<PasswordInputHandle, PasswordInputProps>
           },
         ]}
       >
-        <TextInput
+        <IncognitoKeyboardTextInput
           ref={inputRef}
           testID="PasswordInput"
           style={[styles.input, stylesHook.input]}

--- a/helpers/prompt.ts
+++ b/helpers/prompt.ts
@@ -1,5 +1,6 @@
 import { Platform } from 'react-native';
 import prompt from 'react-native-prompt-android';
+import requestKeyboardIncognitoMode from '../blue_modules/requestKeyboardIncognitoMode';
 import loc from '../loc';
 
 type PromptHelperOptions = {
@@ -8,6 +9,32 @@ type PromptHelperOptions = {
   destructive?: boolean; // applies only to the cancelable (two-button) layout
   continueButtonText?: string;
   defaultValue?: string;
+};
+
+const requestSecurePromptKeyboardPrivacy = (): (() => void) => {
+  if (Platform.OS !== 'android') return () => {};
+
+  const retryDelayMs = 100;
+  const maxDurationMs = 1500;
+  const startedAt = Date.now();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let stopped = false;
+
+  const attempt = () => {
+    if (stopped) return;
+
+    requestKeyboardIncognitoMode().then(applied => {
+      if (stopped || applied || Date.now() - startedAt >= maxDurationMs) return;
+      timeout = setTimeout(attempt, retryDelayMs);
+    });
+  };
+
+  timeout = setTimeout(attempt, retryDelayMs);
+
+  return () => {
+    stopped = true;
+    if (timeout) clearTimeout(timeout);
+  };
 };
 
 export default (title: string, text: string, options: PromptHelperOptions = {}): Promise<string> => {
@@ -22,11 +49,13 @@ export default (title: string, text: string, options: PromptHelperOptions = {}):
   }
 
   return new Promise((resolve, reject) => {
+    let stopKeyboardPrivacyRetry: (() => void) | undefined;
     const buttons: Array<PromptButton> = cancelable
       ? [
           {
             text: loc._.cancel,
             onPress: () => {
+              stopKeyboardPrivacyRetry?.();
               reject(Error('Cancel Pressed'));
             },
             style: 'cancel',
@@ -34,6 +63,7 @@ export default (title: string, text: string, options: PromptHelperOptions = {}):
           {
             text: continueButtonText,
             onPress: password => {
+              stopKeyboardPrivacyRetry?.();
               console.log('OK Pressed');
               resolve(password);
             },
@@ -44,6 +74,7 @@ export default (title: string, text: string, options: PromptHelperOptions = {}):
           {
             text: continueButtonText,
             onPress: password => {
+              stopKeyboardPrivacyRetry?.();
               console.log('OK Pressed');
               resolve(password);
             },
@@ -57,5 +88,9 @@ export default (title: string, text: string, options: PromptHelperOptions = {}):
       keyboardType,
       ...(defaultValue !== undefined && { defaultValue }),
     });
+
+    if (type === 'secure-text') {
+      stopKeyboardPrivacyRetry = requestSecurePromptKeyboardPrivacy();
+    }
   });
 };

--- a/screen/PromptPasswordConfirmationSheet.tsx
+++ b/screen/PromptPasswordConfirmationSheet.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RouteProp, StackActions, useNavigation, useRoute } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { Animated, Easing, Keyboard, StyleSheet, Text, TextInput, View, TextStyle, ViewStyle } from 'react-native';
+import { Animated, Easing, Keyboard, StyleSheet, Text, View, TextStyle, ViewStyle } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { SecondButton } from '../components/SecondButton';
@@ -12,6 +12,7 @@ import { DetailViewStackParamList } from '../navigation/DetailViewStackParamList
 import { MODAL_TYPES } from './PromptPasswordConfirmationSheet.types';
 import { useStorage } from '../hooks/context/useStorage';
 import presentAlert from '../components/Alert';
+import IncognitoKeyboardTextInput from '../components/IncognitoKeyboardTextInput';
 
 type DynamicStyles = {
   modalContent: ViewStyle;
@@ -222,7 +223,7 @@ const PromptPasswordConfirmationSheet = () => {
               </Text>
               <View style={styles.inputContainer}>
                 <Animated.View style={{ transform: [{ translateX: shakeAnimation }] }}>
-                  <TextInput
+                  <IncognitoKeyboardTextInput
                     testID="PasswordInput"
                     secureTextEntry
                     placeholder="Password"
@@ -239,7 +240,7 @@ const PromptPasswordConfirmationSheet = () => {
                 </Animated.View>
                 {(modalType === MODAL_TYPES.CREATE_PASSWORD || modalType === MODAL_TYPES.CREATE_FAKE_STORAGE) && (
                   <Animated.View style={{ transform: [{ translateX: shakeAnimation }] }}>
-                    <TextInput
+                    <IncognitoKeyboardTextInput
                       testID="ConfirmPasswordInput"
                       secureTextEntry
                       placeholder="Confirm Password"

--- a/screen/wallets/ImportSpeed.tsx
+++ b/screen/wallets/ImportSpeed.tsx
@@ -4,6 +4,7 @@ import { ActivityIndicator, StyleSheet, TextInput, View } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import BlueFormLabel from '../../components/BlueFormLabel';
 import BlueFormMultiInput from '../../components/BlueFormMultiInput';
+import IncognitoKeyboardTextInput from '../../components/IncognitoKeyboardTextInput';
 import { HDSegwitBech32Wallet } from '../../class/wallets/hd-segwit-bech32-wallet';
 import { WatchOnlyWallet } from '../../class/wallets/watch-only-wallet';
 import presentAlert from '../../components/Alert';
@@ -94,7 +95,7 @@ const ImportSpeed = () => {
       <BlueFormLabel>Wallet type</BlueFormLabel>
       <TextInput testID="SpeedWalletTypeInput" value={walletType} style={styles.pathInput} onChangeText={setWalletType} />
       <BlueFormLabel>Passphrase</BlueFormLabel>
-      <TextInput testID="SpeedPassphraseInput" value={passphrase} style={styles.pathInput} onChangeText={setPassphrase} />
+      <IncognitoKeyboardTextInput testID="SpeedPassphraseInput" value={passphrase} style={styles.pathInput} onChangeText={setPassphrase} />
       <BlueSpacing20 />
       <View style={styles.center}>
         {loading ? <ActivityIndicator /> : <Button testID="SpeedDoImport" title="Import" onPress={importMnemonic} />}


### PR DESCRIPTION
## Summary
- Request Android `IME_FLAG_NO_PERSONALIZED_LEARNING` for focused sensitive text inputs.
- Add a reusable `IncognitoKeyboardTextInput` wrapper with privacy-oriented defaults (`autoCorrect=false`, `spellCheck=false`, `importantForAutofill="no"`).
- Apply the wrapper to mnemonic/seed multi-inputs, password inputs, secure prompt dialogs, storage password confirmation, and the import-speed passphrase field.
- Retry the secure Android prompt request briefly because `react-native-prompt-android` focuses its internal input asynchronously.

Fixes #2235.

## Notes
This is a fresh implementation because the two earlier attempts are no longer merge-ready: #8554 is closed/dirty, while #8539 has been open since May. This version keeps the native surface small and covers the sensitive input paths I found in the current tree.

## Validation
- `git diff --check`
- Attempted `npm run tslint`, but this clone has no local `node_modules`; TypeScript failed on missing repo dependencies/types before it could provide a useful signal for this patch.

Bounty payout address: `bc1qjf2t6dc75c6t2948essyrqec0a08l8zl28fcfh`
