### PR TITLE
FIX: persist Arkade LNURL payment result

### DIFF
--- a/class/wallets/lightning-ark-wallet.ts
+++ b/class/wallets/lightning-ark-wallet.ts
@@ -657,6 +657,12 @@ export class LightningArkWallet extends LightningCustodianWallet {
 
     const paymentResult = await this._arkadeSwaps.sendLightningPayment({ invoice });
 
+    this.last_paid_invoice_result = {
+      payment_preimage: paymentResult.preimage,
+      payment_hash: invoiceDetails.paymentHash,
+      payment_request: invoice,
+    };
+
     console.log('Payment successful!');
     console.log('Amount:', paymentResult.amount);
     console.log('Preimage:', paymentResult.preimage);

--- a/tests/unit/lightning-ark-wallet.test.ts
+++ b/tests/unit/lightning-ark-wallet.test.ts
@@ -1160,6 +1160,7 @@ describe('LightningArkWallet — addInvoice + payInvoice (mocked SDK runtime)', 
     // Real BOLT11 with amount = 0.0001 BTC (10000 sat) so it passes the limits assertion.
     const invoice =
       'lnbc100u1p50528cpp5rhy4fgs0ff23asecxtxt9zvc3apn0p8h7fxsj0d5k7j3x92zwhlqdq5w3jhxapqd9h8vmmfvdjscqrp80xqyf8ucsp5vcsrzye432n9wh0zwuv5z8y5n9zvkwpctr685e80utzc2yueccms9qxpqysgqd87swq3hput9k6llp0wxg098hc7ge3e5nrtnvak6zreywzaf4k9s8d3u4hrmt3m22kf0jt7ruqj0caknk5ykzdenjdphz50t7xrstnqqn6aw0m';
+    const expectedPaymentHash = w.decodeInvoice(invoice).payment_hash;
     fakeArkadeSwaps.sendLightningPayment.mockResolvedValue({ amount: 10_000, preimage: 'pre', txid: 'tx' });
 
     await w.payInvoice(invoice);
@@ -1167,6 +1168,11 @@ describe('LightningArkWallet — addInvoice + payInvoice (mocked SDK runtime)', 
     assert.strictEqual(fakeArkadeSwaps.sendLightningPayment.mock.calls.length, 1);
     assert.strictEqual(fakeArkadeSwaps.sendLightningPayment.mock.calls[0][0].invoice, invoice);
     assert.strictEqual(fakeWallet.sendBitcoin.mock.calls.length, 0, 'Ark sendBitcoin must not run for BOLT11');
+    assert.deepStrictEqual(w.last_paid_invoice_result, {
+      payment_preimage: 'pre',
+      payment_hash: expectedPaymentHash,
+      payment_request: invoice,
+    });
   });
 
   it('payInvoice routes a valid Ark address through Wallet.sendBitcoin', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Persist Arkade Lightning payment results in the same shape used by custodian wallets.
- Add a unit regression covering `last_paid_invoice_result` after an Arkade BOLT11 payment.

## Testing
- Red: `npx jest tests/unit/lightning-ark-wallet.test.ts --runInBand --runTestsByPath` failed with `last_paid_invoice_result` undefined.
- Green/final: `npx jest tests/unit/lightning-ark-wallet.test.ts --runInBand --runTestsByPath` passed (71 tests).
- `npx eslint class/wallets/lightning-ark-wallet.ts tests/unit/lightning-ark-wallet.test.ts` passed.
- `npm run tslint` passed.

## Review
- Code-review subagent found no issues.
- Residual risk: no end-to-end LNURL UI test; coverage is at the Arkade wallet contract consumed by LNURL-pay.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58d1c8b0-e9b3-462d-8c27-7f71a6efeb97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58d1c8b0-e9b3-462d-8c27-7f71a6efeb97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

