### PR TITLE
TST: follow-up cleanup audit for #8585

### DIFF
--- a/tests/e2e/setup.js
+++ b/tests/e2e/setup.js
@@ -9,7 +9,7 @@
 //
 // Tell Detox to ignore that endpoint. The blacklist is process-scoped on
 // iOS, so we re-apply it after every launchApp.
-const URL_BLACKLIST = ['.*arkade\\.computer/v1/indexer/script/subscription.*', '.*groundcontrol-bluewallet\\.herokuapp\\.com.*'];
+const URL_BLACKLIST = ['.*arkade\\.computer/v1/indexer/script/subscription.*'];
 
 beforeAll(async () => {
   if (typeof device === 'undefined' || !device?.launchApp) return;


### PR DESCRIPTION
Follow-up to #8585.

- Drop the GroundControl entry from the Detox e2e URL blacklist. It pointed at `groundcontrol-bluewallet.herokuapp.com`, which stopped being the production host in 2a3de6f47 — so e2e runs have long passed with GroundControl requests not blacklisted at all. They are short REST calls that never block Detox idle synchronization, so the entry is unnecessary rather than merely outdated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)