### PR TITLE
Retyui remove dead code

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  presets: ['module:@react-native/babel-preset'],
+  presets: [['module:@react-native/babel-preset', { enableBabelRuntime: '^7.26.0' }]],
   plugins: ['react-native-worklets/plugin'],
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  // Pin the @babel/runtime version so Metro resolves a single copy instead of
+  // bundling duplicate helpers, which bloats the bundle.
+  // See https://github.com/babel/babel/issues/18050
   presets: [['module:@react-native/babel-preset', { enableBabelRuntime: '^7.26.0' }]],
   plugins: ['react-native-worklets/plugin'],
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single build-tool config change with no app, auth, or wallet logic touched; main risk is a Metro/Babel transform regression if the runtime version is incompatible.
> 
> **Overview**
> Configures `@react-native/babel-preset` to use the project’s **`@babel/runtime`** via **`enableBabelRuntime: '^7.26.0'`**, instead of the default string preset entry with no options.
> 
> This pins the runtime helper version to match the app’s existing Babel 7.26 dev dependencies and can avoid duplicate or mismatched runtime behavior during Metro transforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12d2ef2a6c04ead979dab23d630e537ee754f6af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->