### PR TITLE
OPS: bump Arkade SDKs (sdk 0.4.35, boltz-swap 0.3.40)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.3.38",
-        "@arkade-os/sdk": "0.4.33",
+        "@arkade-os/boltz-swap": "0.3.40",
+        "@arkade-os/sdk": "0.4.35",
         "@babel/preset-env": "7.29.5",
         "@bugsnag/react-native": "8.9.0",
         "@bugsnag/source-maps": "2.3.3",
@@ -179,12 +179,12 @@
       }
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.3.38",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.3.38.tgz",
-      "integrity": "sha512-BVbyw9Fj+1eQn771t0ZO9uW7E1BgViAPLFddb4pnW9p3rM9fCIdWEs2ZrjPnq70leDdhrUxRy++cJuK7zFThuA==",
+      "version": "0.3.40",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.3.40.tgz",
+      "integrity": "sha512-Q1myKKXC5c44wzAD6eb4lrq3rro0qwyJqNqf0powjfbhSTzHfk5Do6DfZYrciueEK4agilynLNurWCYsoE8yEw==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.4.33",
+        "@arkade-os/sdk": "0.4.35",
         "@noble/curves": "2.0.1",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",
@@ -218,9 +218,9 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.4.33",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.4.33.tgz",
-      "integrity": "sha512-EvfmDhSyAiZ7DW89o5D1N4woDEFMfZLHXi/zh9C1xKlPHB2PCezEkHpVe51lNF0Vx3rgkf6bx54QXoGOvg1p9A==",
+      "version": "0.4.35",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.4.35.tgz",
+      "integrity": "sha512-gMARWDEgy5YL15vE4hBoUf4IGBi94tDRymtVwIehL+2MQylFm6cO1Qt50/aA6dwle5Ae+XMfF99Wf6k/Gc257A==",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors-scure": "3.1.7",

--- a/package.json
+++ b/package.json
@@ -93,8 +93,8 @@
     "unit": "jest -b tests/unit/*"
   },
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.3.38",
-    "@arkade-os/sdk": "0.4.33",
+    "@arkade-os/boltz-swap": "0.3.40",
+    "@arkade-os/sdk": "0.4.35",
     "@babel/preset-env": "7.29.5",
     "@bugsnag/react-native": "8.9.0",
     "@bugsnag/source-maps": "2.3.3",


### PR DESCRIPTION
## Summary

Bumps the two Arkade SDK dependencies to their latest patch releases:

| Package | From | To |
| --- | --- | --- |
| `@arkade-os/sdk` | 0.4.33 | 0.4.35 |
| `@arkade-os/boltz-swap` | 0.3.38 | 0.3.40 |

Both are bumped together intentionally: `@arkade-os/boltz-swap@0.3.40` declares an exact dependency on `@arkade-os/sdk@0.4.35`, so they are lockstep-versioned. Bumping both keeps a single deduplicated SDK in the dependency tree. Exact version pinning (no `^`/`~`) is preserved to match the existing convention for these packages.

## Test plan

- [x] `tsc` typecheck passes (exit 0) against the new versions — confirms no API-surface breakage in BlueWallet's usage
- [x] `patch-package` applies cleanly (no Arkade patches affected)
- [x] Arkade-related unit tests pass: `arkade-background`, `arkade-notifications`, `lightning-ark-wallet`, `lightning-ark-derivation` — 116/116
- [x] Full CI suite (lint + unit + integration)
