### PR TITLE
fix: key on tx list

### DIFF
--- a/screen/wallets/WalletsList.tsx
+++ b/screen/wallets/WalletsList.tsx
@@ -471,7 +471,9 @@ const WalletsList: React.FC = () => {
 
   const sectionListKeyExtractor = useCallback((item: any, index: any) => {
     if (typeof item === 'string') return item;
-    return item?.hash || item?.txid || `${item}${index}`;
+    const txKey = item?.hash || item?.txid;
+    if (txKey && item?.walletID) return `${txKey}_${item.walletID}`;
+    return txKey || `${item}${index}`;
   }, []);
 
   const refreshProps = isDesktop || isElectrumDisabled ? {} : { refreshing: isLoading, onRefresh };


### PR DESCRIPTION
The warning was annoying. 

The getTransactions() in WalletsList.tsx aggregates transactions from all wallets. When the same transaction appears in multiple wallets (e.g., both sender and receiver are in the app), the sectionListKeyExtractor uses item.hash as the key, producing duplicates.