### PR TITLE
FIX: Prevent excessive setTokenConfiguration calls 

### DIFF
--- a/blue_modules/notifications.ts
+++ b/blue_modules/notifications.ts
@@ -24,6 +24,7 @@ const handledNotificationKeys = new Set<string>();
 let pendingRegistrationPromise: Promise<boolean> | null = null;
 let pendingRegistrationResolve: ((value: boolean) => void) | null = null;
 let pendingRegistrationTimeout: ReturnType<typeof setTimeout> | undefined;
+let lastPostedToken: TPushToken | null = null;
 
 type TPushToken = {
   token: string;
@@ -546,7 +547,13 @@ const configureNotifications = async (onProcessNotifications?: () => void): Prom
             console.log('configureNotifications: Token received:', token);
           }
           await _setPushToken(token);
-          await postTokenConfig().catch(error => console.error('Failed to post token configuration:', error));
+          // Only post token configuration if token has changed (fixes issue #2255)
+          // This prevents excessive calls to GroundControl's setTokenConfiguration endpoint
+          const tokenChanged = !lastPostedToken || lastPostedToken.token !== token.token;
+          if (tokenChanged) {
+            lastPostedToken = token;
+            await postTokenConfig().catch(error => console.error('Failed to post token configuration:', error));
+          }
           settlePendingRegistration(true);
         }),
         Notifications.events().registerRemoteNotificationsRegistrationFailed(error => {


### PR DESCRIPTION
issue #2255

- Add token change detection to track last posted push token
- Only post setTokenConfiguration when token actually changes
- Skip redundant POST requests for same token on app refresh/backgrounding
- Reduces unnecessary load on GroundControl server"
