### PR TITLE
ADD: setting to redact push notification content

### DIFF
--- a/blue_modules/notifications.ts
+++ b/blue_modules/notifications.ts
@@ -460,6 +460,35 @@ export const setLevels = async (levelAll: boolean) => {
   }
 };
 
+/**
+ * Posts to groundcontrol whether push notification text/data
+ *  for this device should be redacted
+ *
+ * @param redacted {Boolean}
+ * @returns {Promise<void>}
+ */
+export const setRedactNotifications = async (redacted: boolean) => {
+  const pushToken = await getPushToken();
+  if (!pushToken?.token || !pushToken?.os) {
+    throw new Error('No push token available');
+  }
+
+  const response = await fetch(`${baseURI}/setTokenConfiguration`, {
+    method: 'POST',
+    headers: _getHeaders(),
+    body: JSON.stringify({ redacted, token: pushToken.token, os: pushToken.os }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to set redact configuration: ' + response.statusText);
+  }
+};
+
+export const isNotificationsRedacted = async (): Promise<boolean> => {
+  const levels = await getLevels();
+  return !!levels?.redacted;
+};
+
 export const addNotification = async (notification: TPayload) => {
   let notifications = [];
   try {

--- a/loc/en.json
+++ b/loc/en.json
@@ -329,6 +329,8 @@
   "notifications": {
     "would_you_like_to_receive_notifications": "Would you like to receive notifications when you get incoming payments?",
     "notifications_subtitle": "Incoming payments and transaction confirmations",
+    "redact_notifications": "Hide payment details",
+    "redact_notifications_subtitle": "Notifications won't show amounts or transaction info on your lock screen.",
     "no_and_dont_ask": "No, and do not ask me again.",
     "permission_denied_message": "You have denied permission to send you notifications. If you would like to receive notifications, please enable them in your device settings."
   },

--- a/screen/settings/NotificationSettings.tsx
+++ b/screen/settings/NotificationSettings.tsx
@@ -10,6 +10,8 @@ import {
   checkPermissions,
   checkNotificationPermissionStatus,
   enqueueTestPushNotification,
+  setRedactNotifications,
+  isNotificationsRedacted,
   NOTIFICATIONS_NO_AND_DONT_ASK_FLAG,
 } from '../../blue_modules/notifications';
 import presentAlert from '../../components/Alert';
@@ -38,6 +40,7 @@ interface SettingItem extends SettingsListItemProps {
 const NotificationSettings: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [isNotificationsEnabledState, setNotificationsEnabledState] = useState<boolean | undefined>(undefined);
+  const [isRedactedState, setRedactedState] = useState(false);
 
   const [tokenInfo, setTokenInfo] = useState('<empty>');
   const [tapCount, setTapCount] = useState(0);
@@ -107,6 +110,17 @@ const NotificationSettings: React.FC = () => {
     [showNotificationPermissionAlert, setNotificationsEnabledState],
   );
 
+  const onRedactSwitch = useCallback(async (value: boolean) => {
+    setRedactedState(value);
+    try {
+      await setRedactNotifications(value);
+    } catch (error) {
+      console.error(error);
+      presentAlert({ message: (error as Error).message });
+      setRedactedState(!value); // revert on failure
+    }
+  }, []);
+
   const updateNotificationStatus = async () => {
     try {
       const currentStatus = await checkNotificationPermissionStatus();
@@ -133,6 +147,7 @@ const NotificationSettings: React.FC = () => {
           setNotificationsEnabledState(false);
         } else {
           await updateNotificationStatus();
+          setRedactedState(await isNotificationsRedacted());
         }
 
         setTokenInfo(
@@ -235,6 +250,22 @@ const NotificationSettings: React.FC = () => {
         Component: View,
         section: 1,
       },
+      ...(isNotificationsEnabledState
+        ? [
+            {
+              id: 'redactNotifications',
+              title: loc.notifications.redact_notifications,
+              subtitle: loc.notifications.redact_notifications_subtitle,
+              switch: {
+                value: isRedactedState,
+                onValueChange: onRedactSwitch,
+                disabled: isLoading,
+              },
+              Component: View,
+              section: 1,
+            },
+          ]
+        : []),
       {
         id: 'notificationsExplanation',
         title: '',
@@ -271,6 +302,8 @@ const NotificationSettings: React.FC = () => {
   }, [
     isNotificationsEnabledState,
     onNotificationsSwitch,
+    isRedactedState,
+    onRedactSwitch,
     isLoading,
     renderDeveloperSettings,
     renderPushNotificationsExplanation,


### PR DESCRIPTION
Adds a "Redact notification content" toggle to Notification Settings. When enabled, GroundControl sends generic push text with no transaction data, so payment details never appear on the lock screen or in the notification payload.

depends on https://github.com/BlueWallet/GroundControl/pull/329 
closes https://github.com/BlueWallet/BlueWallet/issues/8499

<img width="300" alt="Screenshot_1782376142" src="https://github.com/user-attachments/assets/498f96ba-23e2-486d-9985-cd6b35f5d0ba" />
