### PR TITLE
FIX: keep signed transaction hex screen scrollable

### DIFF
--- a/screen/send/psbtWithHardwareWallet.tsx
+++ b/screen/send/psbtWithHardwareWallet.tsx
@@ -198,7 +198,7 @@ const PsbtWithHardwareWallet = () => {
       <View style={[styles.rootPadding, stylesHook.rootPadding]}>
         <BlueCard style={[styles.hexWrap, stylesHook.hexWrap]}>
           <BlueText style={[styles.hexLabel, stylesHook.hexLabel]}>{loc.send.create_this_is_hex}</BlueText>
-          <TextInput style={[styles.hexInput, stylesHook.hexInput]} multiline editable value={txHex} />
+          <TextInput style={[styles.hexInput, stylesHook.hexInput]} multiline editable={false} value={txHex} />
 
           <TouchableOpacity accessibilityRole="button" style={styles.hexTouch} onPress={copyHexToClipboard}>
             <Text style={[styles.hexText, stylesHook.hexText]}>{loc.send.create_copy}</Text>
@@ -342,13 +342,17 @@ const styles = StyleSheet.create({
   hexWrap: {
     alignItems: 'center',
     flex: 1,
+    width: '100%',
   },
   hexLabel: {
     fontWeight: '500',
   },
   hexInput: {
+    alignSelf: 'stretch',
     borderRadius: 4,
     marginTop: 20,
+    maxHeight: 220,
+    minHeight: 120,
     fontWeight: '500',
     fontSize: 14,
     paddingHorizontal: 16,


### PR DESCRIPTION
## What

Fixes the signed transaction HEX screen so long signed transaction hex values do not prevent the user from scrolling to the copy/broadcast actions.

Fixes #8699

## Why

With a very long signed transaction hex, the editable multiline `TextInput` can dominate the screen and trap touch/scroll behavior on mobile. This makes the action buttons below the HEX difficult or impossible to reach.

## How

- Makes the HEX field read-only with `editable={false}`.
- Gives the HEX container a stable full width.
- Constrains the HEX field height with a minimum and maximum height.
- Keeps the surrounding screen scrollable without adding dependencies.

## Screenshots / Evidence

Reproduced locally with a long signed transaction HEX on:

- iOS, iPhone 17 Pro Max running iOS 26.5.1.
- Android, Xiaomi Mi 9T.

I avoided attaching the original screenshot directly because it contains a signed raw transaction; a redacted screenshot can be provided if needed.

## Testing

- Built and installed the app locally on an iPhone 17 Pro Max running iOS 26.5.1.
- Verified the screen no longer relies on an oversized editable HEX field for layout.
