### PR TITLE
FIX: ark tests Premature close — drop node-fetch, use native fetch

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -182,6 +182,7 @@ jobs:
       - name: Install applesimutils
         run: |
           brew tap wix/brew
+          brew trust wix/brew
           brew install applesimutils
 
       - name: Download simulator app

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,7 +146,6 @@
         "eslint-plugin-react-native": "^4.1.0",
         "jest": "^29.6.3",
         "jest-environment-node": "^29.7.0",
-        "node-fetch": "^2.6.7",
         "patch-package": "^8.0.0",
         "prettier": "^3.2.5",
         "react-test-renderer": "19.2.3",
@@ -14929,25 +14928,6 @@
       "version": "5.1.0",
       "license": "MIT"
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
       "license": "MIT",
@@ -18461,11 +18441,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/trace-event-lib": {
       "version": "1.4.1",
       "license": "MIT",
@@ -19100,23 +19075,9 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "license": "MIT"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "eslint-plugin-react-native": "^4.1.0",
     "jest": "^29.6.3",
     "jest-environment-node": "^29.7.0",
-    "node-fetch": "^2.6.7",
     "patch-package": "^8.0.0",
     "prettier": "^3.2.5",
     "react-test-renderer": "19.2.3",

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -37,7 +37,9 @@ console.debug = console.log = (...args) => {
 
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
-global.fetch = require('node-fetch');
+if (typeof globalThis.fetch !== 'function') {
+  throw new Error('Native fetch missing; Node >= 22.11 is required (see package.json engines)');
+}
 
 jest.mock('@react-native-clipboard/clipboard', () => mockClipboard);
 


### PR DESCRIPTION
**Bug:** ark integration tests die `FetchError: ... Premature close` on `https://arkade.computer/v1/info`.

**Cause:** `tests/setup.js` shim `global.fetch = node-fetch`. node-fetch v2 no brotli decode. arkade.computer behind Cloudflare → send `content-encoding: br`. node-fetch pipe body thru Gunzip → brotli body not gzip → stream break → "Premature close". Not network flake (curl 200 OK).

**Fix:** drop node-fetch shim. use Node native fetch (undici) — decode br/gzip + h2 like curl. production already native (`util/fetch.ts`). engines Node >= 22.11 always has it. node-fetch devDep removed.

**Check:** unit 463 pass. ark `can generate` pass, probe 200 OK.