### PR TITLE
FIX: stray tool artifacts in ak/fil_PH vocabularies

### DIFF
--- a/loc/vocabulary/ak.md
+++ b/loc/vocabulary/ak.md
@@ -96,5 +96,3 @@ Note: Akan (Twi/Fante) is a Niger-Congo Kwa language written in the Latin script
 | Memo | nkaeɛ | noun · "note / reminder" (no upstream wallet citation). |
 | Description | nkyerɛkyerɛmu | noun · "explanation / description" (no upstream wallet citation). |
 | Label | din | noun · "name / label" · ⚠️ must be a noun, not "to label" (no upstream wallet citation). |
-</invoke>
-

--- a/loc/vocabulary/fil_PH.md
+++ b/loc/vocabulary/fil_PH.md
@@ -96,5 +96,3 @@ Note: Filipino/Tagalog (Latin script, LTR). Bitcoin Core ships a Filipino/Tagalo
 | Memo | memo / tala | noun · borrowing / native "note". |
 | Description | paglalarawan | noun · native Filipino. |
 | Label | label / tatak | noun · borrowing / native "mark". |
-</invoke>
-


### PR DESCRIPTION
Removes leftover `</invoke>` generation artifacts from `loc/vocabulary/ak.md` and `loc/vocabulary/fil_PH.md` (line 99 in both, merged earlier). Content unchanged otherwise.