### PR TITLE
FIX: reserve floating-button space in wallet tx list on both platforms

### DIFF
--- a/components/FloatButtons.tsx
+++ b/components/FloatButtons.tsx
@@ -54,10 +54,13 @@ const useFloatButtonAnimation = (initialHeight: number) => {
 
 const getScaledButtonHeight = (fontScale: number): number => Math.round(LAYOUT.BUTTON_HEIGHT * fontScale);
 
-/** Scroll padding so list content clears float buttons (excludes safe-area inset). Default 70 at fontScale 1. */
+/** Gap between list content and the top of the float buttons. */
 const FLOAT_BUTTON_LIST_CLEARANCE = 18;
 
-export const getFloatingButtonReservedHeight = (fontScale = 1): number => getScaledButtonHeight(fontScale) + FLOAT_BUTTON_LIST_CLEARANCE;
+const getFloatButtonBottomOffset = (bottomInset: number): number => (bottomInset ? bottomInset + 10 : 30);
+
+export const getFloatingButtonReservedHeight = (fontScale = 1, bottomInset = 0): number =>
+  getScaledButtonHeight(fontScale) + FLOAT_BUTTON_LIST_CLEARANCE + getFloatButtonBottomOffset(bottomInset) - bottomInset;
 
 const useFloatButtonLayout = (width: number, sizeClass: SizeClass, fontScale: number) => {
   const lastVerticalDecision = useRef(false);
@@ -473,7 +476,7 @@ export const FContainer = forwardRef<View, FContainerProps>((props, ref) => {
 
   const bottomInsets = useMemo(
     () => ({
-      bottom: insets.bottom ? insets.bottom + 10 : 30,
+      bottom: getFloatButtonBottomOffset(insets.bottom),
     }),
     [insets.bottom],
   );

--- a/screen/wallets/WalletTransactions.tsx
+++ b/screen/wallets/WalletTransactions.tsx
@@ -30,7 +30,7 @@ import { LightningCustodianWallet } from '../../class/wallets/lightning-custodia
 import { MultisigHDWallet } from '../../class/wallets/multisig-hd-wallet';
 import { WatchOnlyWallet } from '../../class/wallets/watch-only-wallet';
 import presentAlert, { AlertType } from '../../components/Alert';
-import { FButton, FContainer, FloatButtonsBottomFade } from '../../components/FloatButtons';
+import { FButton, FContainer, FloatButtonsBottomFade, getFloatingButtonReservedHeight } from '../../components/FloatButtons';
 import { useTheme } from '../../components/themes';
 import { TransactionListItem } from '../../components/TransactionListItem';
 import { TX_ROW_BASE_HEIGHT } from '../../components/ListItem';
@@ -191,6 +191,7 @@ const WalletTransactions: React.FC<WalletTransactionsProps> = ({ route }: { rout
   const { colors, dark } = useTheme();
   const { isElectrumDisabled } = useSettings();
   const insets = useSafeAreaInsets();
+  const { fontScale } = useWindowDimensions();
   const navBarHeight = Platform.select({ ios: 44, android: 56, default: 44 }) ?? 44;
   const headerOverlayHeight = insets.top + navBarHeight;
   const walletActionButtonsRef = useRef<View>(null);
@@ -218,6 +219,9 @@ const WalletTransactions: React.FC<WalletTransactionsProps> = ({ route }: { rout
     },
     backgroundContainer: {
       backgroundColor: colors.background,
+    },
+    contentBottomInset: {
+      paddingBottom: insets.bottom + getFloatingButtonReservedHeight(fontScale, insets.bottom),
     },
     activityIndicatorStyle: {
       backgroundColor: colors.background,
@@ -438,7 +442,6 @@ const WalletTransactions: React.FC<WalletTransactionsProps> = ({ route }: { rout
     [name, navigate, navigation, onWalletSelect, walletID, wallets],
   );
 
-  const { fontScale } = useWindowDimensions();
   const txRowHeight = Math.round(TX_ROW_BASE_HEIGHT * fontScale);
 
   const getItemLayout = useCallback(
@@ -839,9 +842,8 @@ const WalletTransactions: React.FC<WalletTransactionsProps> = ({ route }: { rout
         renderItem={renderItem}
         initialNumToRender={10}
         removeClippedSubviews={false}
-        contentContainerStyle={[styles.contentContainer, stylesHook.backgroundContainer]}
+        contentContainerStyle={[styles.contentContainer, stylesHook.backgroundContainer, stylesHook.contentBottomInset]}
         contentInsetAdjustmentBehavior="never"
-        contentInset={{ top: 0, left: 0, bottom: 90, right: 0 }}
         maxToRenderPerBatch={10}
         onScroll={handleScroll}
         windowSize={15}

--- a/screen/wallets/WalletsList.tsx
+++ b/screen/wallets/WalletsList.tsx
@@ -29,6 +29,7 @@ import TotalWalletsBalance from '../../components/TotalWalletsBalance';
 import { useSettings } from '../../hooks/context/useSettings';
 import useMenuElements from '../../hooks/useMenuElements';
 import SafeAreaSectionList from '../../components/SafeAreaSectionList';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { scanQrHelper } from '../../helpers/scan-qr';
 import { isIOS26OrHigher } from '../../components/platform';
 
@@ -115,10 +116,11 @@ const WalletsList: React.FC = () => {
   const { wallets, getTransactions, refreshAllWalletTransactions } = useStorage();
   const { isTotalBalanceEnabled, isElectrumDisabled } = useSettings();
   const { width, fontScale } = useWindowDimensions();
+  const insets = useSafeAreaInsets();
   const carouselHeight = getWalletCarouselHeight(fontScale);
   const transactionItemHeight = Math.round(TX_ROW_BASE_HEIGHT * fontScale);
   const sectionHeaderHeight = Math.round(SECTION_HEADER_BASE_HEIGHT * fontScale);
-  const floatingButtonHeight = getFloatingButtonReservedHeight(fontScale);
+  const floatingButtonHeight = getFloatingButtonReservedHeight(fontScale, insets.bottom);
   const { colors, scanImage } = useTheme();
   const navigation = useExtendedNavigation<NavigationProps>();
   const isFocused = useIsFocused();


### PR DESCRIPTION
contentInset is iOS-only, so on Android the last transaction row was hidden behind the Receive/Send buttons.

I replaced hardcoded bottom inset with contentContainerStyle paddingBottom computed from getFloatingButtonReservedHeight(fontScale) + safe-area bottom inset.

| After | Before |
|--------|--------|
|  https://github.com/user-attachments/assets/e920bedf-520d-4f53-9003-05b009fa7ba5 | https://github.com/user-attachments/assets/6c9a6dc3-db1c-4518-8bfe-917fe55fcd95 |
