### PR TITLE
FIX: include recovering funds in Arkade balance & guard sends against them

### DIFF
--- a/class/wallets/lightning-ark-wallet.ts
+++ b/class/wallets/lightning-ark-wallet.ts
@@ -630,11 +630,10 @@ export class LightningArkWallet extends LightningCustodianWallet {
     //      unspent in getCoins) AND the freshly-minted preconfirmed VTXO, so
     //      `balance.total` transiently double-counts the refill. Subtracting
     //      `boarding.total` removes the boarding leg, so each sat counts once.
-    // NOTE: `pendingRecovery` (funds under a now-deprecated server signer past
-    // its cutoff, awaiting the SDK's automatic migration) MUST be included — it
-    // is still the user's money and is what `total` counts. Summing only
-    // `available + recoverable` here dropped it, so after a signer-rotation
-    // cutoff an imported wallet whose funds are all deprecated-signer VTXOs
+    // The included `pendingRecovery` leg (funds under a now-deprecated server
+    // signer awaiting the SDK's automatic migration) is what makes this differ
+    // from a bare `available + recoverable`: that sum dropped it, so after a
+    // signer-rotation cutoff a wallet holding only deprecated-signer VTXOs
     // showed a balance of 0.
     this.balance = balance.total - balance.boarding.total;
   }
@@ -695,8 +694,7 @@ export class LightningArkWallet extends LightningCustodianWallet {
    * pendingRecovery. Adds a concrete ETA when the SDK advertises one: each
    * deprecated-signer report carries `nextSweepEta` (ms epoch = the soonest
    * batch expiry, i.e. when the server sweeps those VTXOs and they become
-   * spendable). We surface the earliest across signers; if none is advertised
-   * (or it is already in the past), we fall back to open-ended wording.
+   * spendable).
    */
   private async _recoveringFundsMessage(pendingRecovery: number, spendable: number): Promise<string> {
     let whenClause = ' They will become available once recovery completes.';

--- a/class/wallets/lightning-ark-wallet.ts
+++ b/class/wallets/lightning-ark-wallet.ts
@@ -662,6 +662,22 @@ export class LightningArkWallet extends LightningCustodianWallet {
     assert(invoiceDetails.amountSats > this._limitMin, `Minimum you can send is ${this._limitMin} sat`);
     assert(invoiceDetails.amountSats < this._limitMax, `Maximum you can is ${this._limitMax} sat`);
 
+    // Recovering-funds guard. The displayed balance includes `pendingRecovery`
+    // (deprecated-signer funds past their rotation cutoff), but the SDK's send
+    // coin-selection excludes them until the Ark server sweeps them. Without
+    // this, sending against a balance that is mostly pendingRecovery fails with
+    // a bare "insufficient funds" that contradicts the on-screen amount. Detect
+    // that case and surface an honest message instead.
+    const balance = await this._wallet.getBalance();
+    const spendable = balance.available + balance.recoverable;
+    const estFee = this.getSubmarineFeeEstimate(invoiceDetails.amountSats) ?? 0;
+    if (balance.pendingRecovery > 0 && invoiceDetails.amountSats + estFee > spendable) {
+      throw new Error(
+        `${balance.pendingRecovery} sats are still recovering after a network upgrade and are not spendable yet. ` +
+          `They will become available once recovery completes. Spendable now: ${spendable} sats.`,
+      );
+    }
+
     const paymentResult = await this._arkadeSwaps.sendLightningPayment({ invoice });
 
     this.last_paid_invoice_result = {

--- a/class/wallets/lightning-ark-wallet.ts
+++ b/class/wallets/lightning-ark-wallet.ts
@@ -262,9 +262,9 @@ export class LightningArkWallet extends LightningCustodianWallet {
         if (this._wallet) {
           this._transactionsHistory = await this._wallet.getTransactionHistory();
           const balance = await this._wallet.getBalance();
-          // Keep this in sync with fetchBalance(): offchain spendable + recoverable,
-          // boarding excluded (see fetchBalance for the double-count rationale).
-          this.balance = balance.available + balance.recoverable;
+          // Keep this in sync with fetchBalance(): SDK `total` minus boarding
+          // (all offchain funds incl. pendingRecovery; see fetchBalance).
+          this.balance = balance.total - balance.boarding.total;
         }
         this._lastBalanceFetch = +new Date();
         this._lastTxFetch = +new Date();
@@ -617,8 +617,9 @@ export class LightningArkWallet extends LightningCustodianWallet {
 
     const balance = await this._wallet.getBalance();
     this._lastBalanceFetch = +new Date();
-    // Headline balance = spendable offchain + recoverable, i.e. SDK `total`
-    // minus `boarding.total`. A refill stays OUT of the balance until the SDK
+    // Headline balance = SDK `total` minus `boarding.total`, i.e. every offchain
+    // sat the wallet owns (settled + preconfirmed + recoverable + pendingRecovery)
+    // with boarding excluded. A refill stays OUT of the balance until the SDK
     // settles its boarding UTXO into a VTXO — the same moment its history row
     // flips from "Pending" to a confirmed "Refill". Two reasons boarding is
     // excluded here:
@@ -626,10 +627,15 @@ export class LightningArkWallet extends LightningCustodianWallet {
     //      is usable; it is surfaced as a "Pending" row instead (getTransactions).
     //   2. While settling, the SDK briefly reports BOTH the boarding UTXO (still
     //      unspent in getCoins) AND the freshly-minted preconfirmed VTXO, so
-    //      `balance.total` transiently double-counts the refill. Counting only
-    //      offchain+recoverable means each sat is counted once, at settlement.
-    // Mirrors the reference wallets (trixie's headline is `available`).
-    this.balance = balance.available + balance.recoverable;
+    //      `balance.total` transiently double-counts the refill. Subtracting
+    //      `boarding.total` removes the boarding leg, so each sat counts once.
+    // NOTE: `pendingRecovery` (funds under a now-deprecated server signer past
+    // its cutoff, awaiting the SDK's automatic migration) MUST be included — it
+    // is still the user's money and is what `total` counts. Summing only
+    // `available + recoverable` here dropped it, so after a signer-rotation
+    // cutoff an imported wallet whose funds are all deprecated-signer VTXOs
+    // showed a balance of 0.
+    this.balance = balance.total - balance.boarding.total;
   }
 
   async payInvoice(invoice: string, freeAmount: number = 0) {

--- a/class/wallets/lightning-ark-wallet.ts
+++ b/class/wallets/lightning-ark-wallet.ts
@@ -30,6 +30,7 @@ import ecc from '../../blue_modules/noble_ecc.ts';
 import { Measure } from '../measure.ts';
 import { deleteArkadeRealm, getArkadeRealm } from '../../blue_modules/arkade-adapters/realm/realmInstance';
 import { registerArkPaymentPush } from '../../blue_modules/notifications';
+import { transactionTimeToReadable } from '../../loc';
 const { bech32m } = require('bech32');
 
 const bip32 = BIP32Factory(ecc);
@@ -672,10 +673,7 @@ export class LightningArkWallet extends LightningCustodianWallet {
     const spendable = balance.available + balance.recoverable;
     const estFee = this.getSubmarineFeeEstimate(invoiceDetails.amountSats) ?? 0;
     if (balance.pendingRecovery > 0 && invoiceDetails.amountSats + estFee > spendable) {
-      throw new Error(
-        `${balance.pendingRecovery} sats are still recovering after a network upgrade and are not spendable yet. ` +
-          `They will become available once recovery completes. Spendable now: ${spendable} sats.`,
-      );
+      throw new Error(await this._recoveringFundsMessage(balance.pendingRecovery, spendable));
     }
 
     const paymentResult = await this._arkadeSwaps.sendLightningPayment({ invoice });
@@ -690,6 +688,39 @@ export class LightningArkWallet extends LightningCustodianWallet {
     console.log('Amount:', paymentResult.amount);
     console.log('Preimage:', paymentResult.preimage);
     console.log('Transaction ID:', paymentResult.txid);
+  }
+
+  /**
+   * Human-readable "your funds are recovering" error for a send blocked by
+   * pendingRecovery. Adds a concrete ETA when the SDK advertises one: each
+   * deprecated-signer report carries `nextSweepEta` (ms epoch = the soonest
+   * batch expiry, i.e. when the server sweeps those VTXOs and they become
+   * spendable). We surface the earliest across signers; if none is advertised
+   * (or it is already in the past), we fall back to open-ended wording.
+   */
+  private async _recoveringFundsMessage(pendingRecovery: number, spendable: number): Promise<string> {
+    let whenClause = ' They will become available once recovery completes.';
+    try {
+      if (this._wallet) {
+        const manager = await this._wallet.getVtxoManager();
+        const reports = await manager.getDeprecatedSignerStatus();
+        let soonest: number | undefined;
+        for (const r of reports) {
+          if (typeof r.nextSweepEta !== 'number') continue;
+          soonest = soonest === undefined ? r.nextSweepEta : Math.min(soonest, r.nextSweepEta);
+        }
+        if (soonest !== undefined && soonest > Date.now()) {
+          whenClause = ` They should become available ${transactionTimeToReadable(soonest)}.`;
+        }
+      }
+    } catch {
+      // ETA is best-effort; keep the open-ended wording on any failure.
+    }
+    return (
+      `${pendingRecovery} sats are still recovering after a network upgrade and are not spendable yet.` +
+      whenClause +
+      ` Spendable now: ${spendable} sats.`
+    );
   }
 
   /**

--- a/tests/unit/lightning-ark-wallet.test.ts
+++ b/tests/unit/lightning-ark-wallet.test.ts
@@ -1089,7 +1089,11 @@ describe('LightningArkWallet — addInvoice + payInvoice (mocked SDK runtime)', 
   // directly. We exercise the wallet's wiring — fee math, BOLT11 vs Ark
   // address routing, parameter forwarding — not the SDK's network behavior.
   let w: LightningArkWallet;
-  const fakeWallet: { sendBitcoin: jest.Mock } = { sendBitcoin: jest.fn() };
+  const fakeWallet: { sendBitcoin: jest.Mock; getBalance: jest.Mock; getVtxoManager: jest.Mock } = {
+    sendBitcoin: jest.fn(),
+    getBalance: jest.fn(),
+    getVtxoManager: jest.fn(),
+  };
   const fakeArkadeSwaps: {
     createLightningInvoice: jest.Mock;
     sendLightningPayment: jest.Mock;
@@ -1098,10 +1102,32 @@ describe('LightningArkWallet — addInvoice + payInvoice (mocked SDK runtime)', 
     sendLightningPayment: jest.fn(),
   };
 
+  // A WalletBalance with everything spendable and nothing recovering, so the
+  // payInvoice recovering-funds guard is a no-op by default.
+  const balanceWith = (over: Partial<Record<'available' | 'recoverable' | 'pendingRecovery', number>> = {}) => {
+    const available = over.available ?? 1_000_000;
+    const recoverable = over.recoverable ?? 0;
+    const pendingRecovery = over.pendingRecovery ?? 0;
+    return {
+      boarding: { confirmed: 0, unconfirmed: 0, total: 0 },
+      settled: available,
+      preconfirmed: 0,
+      available,
+      recoverable,
+      pendingRecovery,
+      total: available + recoverable + pendingRecovery,
+      assets: [],
+    };
+  };
+
   beforeEach(() => {
     w = new LightningArkWallet();
     w.setSecret('arkade://' + TEST_MNEMONIC);
     fakeWallet.sendBitcoin.mockReset().mockResolvedValue(undefined);
+    fakeWallet.getBalance.mockReset().mockResolvedValue(balanceWith());
+    fakeWallet.getVtxoManager.mockReset().mockResolvedValue({
+      getDeprecatedSignerStatus: jest.fn().mockResolvedValue([]),
+    });
     fakeArkadeSwaps.createLightningInvoice.mockReset();
     fakeArkadeSwaps.sendLightningPayment.mockReset();
     // Wire the wallet up as if init() had already completed.
@@ -1173,6 +1199,28 @@ describe('LightningArkWallet — addInvoice + payInvoice (mocked SDK runtime)', 
       payment_hash: expectedPaymentHash,
       payment_request: invoice,
     });
+  });
+
+  it('payInvoice blocks with a recovering-funds message when the balance is mostly pendingRecovery', async () => {
+    const invoice =
+      'lnbc100u1p50528cpp5rhy4fgs0ff23asecxtxt9zvc3apn0p8h7fxsj0d5k7j3x92zwhlqdq5w3jhxapqd9h8vmmfvdjscqrp80xqyf8ucsp5vcsrzye432n9wh0zwuv5z8y5n9zvkwpctr685e80utzc2yueccms9qxpqysgqd87swq3hput9k6llp0wxg098hc7ge3e5nrtnvak6zreywzaf4k9s8d3u4hrmt3m22kf0jt7ruqj0caknk5ykzdenjdphz50t7xrstnqqn6aw0m';
+    // 10_000 sat invoice, but nothing spendable and 44_665 stuck in recovery.
+    fakeWallet.getBalance.mockResolvedValue(balanceWith({ available: 0, recoverable: 0, pendingRecovery: 44_665 }));
+
+    await assert.rejects(() => w.payInvoice(invoice), /44665 sats are still recovering.*Spendable now: 0 sats/s);
+    assert.strictEqual(fakeArkadeSwaps.sendLightningPayment.mock.calls.length, 0, 'must not attempt the swap for unspendable funds');
+  });
+
+  it('payInvoice recovering-funds message includes the sweep ETA when advertised', async () => {
+    const invoice =
+      'lnbc100u1p50528cpp5rhy4fgs0ff23asecxtxt9zvc3apn0p8h7fxsj0d5k7j3x92zwhlqdq5w3jhxapqd9h8vmmfvdjscqrp80xqyf8ucsp5vcsrzye432n9wh0zwuv5z8y5n9zvkwpctr685e80utzc2yueccms9qxpqysgqd87swq3hput9k6llp0wxg098hc7ge3e5nrtnvak6zreywzaf4k9s8d3u4hrmt3m22kf0jt7ruqj0caknk5ykzdenjdphz50t7xrstnqqn6aw0m';
+    fakeWallet.getBalance.mockResolvedValue(balanceWith({ available: 0, recoverable: 0, pendingRecovery: 44_665 }));
+    const etaMs = Date.now() + 2 * 24 * 60 * 60 * 1000; // ~2 days out
+    fakeWallet.getVtxoManager.mockResolvedValue({
+      getDeprecatedSignerStatus: jest.fn().mockResolvedValue([{ status: 'expired', awaitingSweepValue: 44_665, nextSweepEta: etaMs }]),
+    });
+
+    await assert.rejects(() => w.payInvoice(invoice), /should become available in/s);
   });
 
   it('payInvoice routes a valid Ark address through Wallet.sendBitcoin', async () => {


### PR DESCRIPTION
## FIX: include recovering funds in Arkade balance & guard sends against them

### Problem

After a signer-rotation cutoff, an imported Arkade wallet holding only deprecated-signer funds (`pendingRecovery`) showed a **balance of 0** — the headline was `available + recoverable`, which omits that leg. But those funds also can't be spent until the server sweeps them, so simply displaying them would let a send fail with a bare `insufficient funds` that contradicts the on-screen amount.

### Changes

- **Balance** = `total − boarding.total` (includes `pendingRecovery`), consistent across `fetchBalance()` and the swap-event refresh.
- **Send guard:** when a Lightning send exceeds the truly-spendable balance and `pendingRecovery > 0`, `payInvoice` throws a clear "funds still recovering" message and skips the swap — with a concrete sweep ETA when the SDK advertises one.

### Screenshot

<img width="387" height="291" alt="image" src="https://github.com/user-attachments/assets/3b55472b-3f37-47c9-8f59-ac0e2ff78db9" />


### Testing

Added unit coverage for the guard and ETA rendering; 73 tests passing in `lightning-ark-wallet.test.ts`.
