### PR TITLE
OPS: remove unused @bugsnag/source-maps dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@arkade-os/sdk": "0.4.43",
         "@babel/preset-env": "7.29.7",
         "@bugsnag/react-native": "8.9.0",
-        "@bugsnag/source-maps": "2.3.3",
         "@keystonehq/bc-ur-registry": "0.8.0",
         "@ngraveio/bc-ur": "1.1.13",
         "@noble/ciphers": "1.3.0",
@@ -2395,22 +2394,6 @@
     "node_modules/@bugsnag/safe-json-stringify": {
       "version": "6.1.0",
       "license": "MIT"
-    },
-    "node_modules/@bugsnag/source-maps": {
-      "version": "2.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "command-line-args": "^5.1.1",
-        "command-line-usage": "^6.1.0",
-        "concat-stream": "^2.0.0",
-        "consola": "^2.15.0",
-        "form-data": "^3.0.0",
-        "glob": "^7.1.6",
-        "read-pkg-up": "^7.0.1"
-      },
-      "bin": {
-        "bugsnag-source-maps": "bin/cli"
-      }
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
@@ -5568,10 +5551,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/normalize-package-data": {
-      "version": "2.4.4",
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -6097,13 +6076,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/array-back": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "dev": true,
@@ -6303,10 +6275,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "license": "MIT"
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
       "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
@@ -7726,118 +7694,11 @@
       "version": "1.1.3",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/command-exists": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
       "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
       "license": "MIT"
-    },
-    "node_modules/command-line-args": {
-      "version": "5.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^3.1.0",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/command-line-usage": {
-      "version": "6.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.2",
-        "chalk": "^2.4.2",
-        "table-layout": "^1.0.2",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/array-back": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/chalk": {
-      "version": "2.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/color-convert": {
-      "version": "1.9.3",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/color-name": {
-      "version": "1.1.3",
-      "license": "MIT"
-    },
-    "node_modules/command-line-usage/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/has-flag": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/supports-color": {
-      "version": "5.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/typical": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/commander": {
       "version": "9.5.0",
@@ -7893,20 +7754,8 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/concat-stream": {
-      "version": "2.0.0",
-      "engines": [
-        "node >= 6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2",
-        "typedarray": "^0.0.6"
-      }
     },
     "node_modules/connect": {
       "version": "3.7.0",
@@ -7936,10 +7785,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/consola": {
-      "version": "2.15.3",
       "license": "MIT"
     },
     "node_modules/content-type": {
@@ -8416,13 +8261,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -9149,6 +8987,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10459,16 +10298,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/find-replace": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "license": "MIT",
@@ -10539,20 +10368,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fresh": {
@@ -10738,6 +10553,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -10767,6 +10583,7 @@
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -10775,6 +10592,7 @@
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -10971,10 +10789,6 @@
     "node_modules/hoist-non-react-statics/node_modules/react-is": {
       "version": "16.13.1",
       "license": "MIT"
-    },
-    "node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "license": "ISC"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -13955,10 +13769,6 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "license": "MIT"
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "license": "MIT"
@@ -15225,23 +15035,6 @@
         "url": "https://github.com/sponsors/antelle"
       }
     },
-    "node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.2",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "dev": true,
@@ -15777,6 +15570,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16983,92 +16777,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/read-pkg": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/locate-path": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-locate": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "license": "MIT",
@@ -17117,13 +16825,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/reduce-flatten": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -18071,30 +17772,6 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-exceptions": {
-      "version": "2.5.0",
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-license-ids": {
-      "version": "3.0.21",
-      "license": "CC0-1.0"
-    },
     "node_modules/split-on-first": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
@@ -18473,33 +18150,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
-      }
-    },
-    "node_modules/table-layout": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.1",
-        "deep-extend": "~0.6.0",
-        "typical": "^5.2.0",
-        "wordwrapjs": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/table-layout/node_modules/array-back": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/table-layout/node_modules/typical": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/tar-fs": {
@@ -19046,10 +18696,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "license": "MIT"
-    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "dev": true,
@@ -19072,13 +18718,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/typical": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/uint8array-tools": {
@@ -19312,14 +18951,6 @@
         }
       }
     },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
     "node_modules/varuint-bitcoin": {
       "version": "1.1.2",
       "license": "MIT",
@@ -19505,24 +19136,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wordwrapjs": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "reduce-flatten": "^2.0.0",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/wordwrapjs/node_modules/typical": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "@arkade-os/sdk": "0.4.43",
     "@babel/preset-env": "7.29.7",
     "@bugsnag/react-native": "8.9.0",
-    "@bugsnag/source-maps": "2.3.3",
     "@keystonehq/bc-ur-registry": "0.8.0",
     "@ngraveio/bc-ur": "1.1.13",
     "@noble/ciphers": "1.3.0",


### PR DESCRIPTION
## Summary
- Removes `@bugsnag/source-maps` from production dependencies — it is never referenced in app code, scripts, CI, or Fastlane.
- Sourcemap / dSYM upload already goes through `fastlane-plugin-bugsnag_sourcemaps_upload`, the Xcode script from `@bugsnag/react-native`, and the Android Bugsnag Gradle plugin.
- Drops ~49 packages from the install tree and reduces npm install attack surface.

## Test plan
- [ ] Confirm `package.json` / `package-lock.json` no longer list `@bugsnag/source-maps`
- [ ] Confirm existing Bugsnag upload paths still work: Fastlane `upload_bugsnag_sourcemaps`, iOS Xcode Bugsnag script, Android Gradle plugin
- [ ] Smoke: `npm ci` succeeds on a clean checkout


Made with [Cursor](https://cursor.com)