### PR TITLE
OPS: upload Android/iOS RN sourcemaps via BugSnag CLI

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -66,8 +66,8 @@ jobs:
           yes | sdkmanager --licenses
           sdkmanager "platforms;android-36" "platform-tools" "build-tools;36.0.0" "ndk;27.1.12297006"
 
-      - name: Install node_modules (include dev deps for patch-package)
-        run: npm ci --yes
+      - name: Install Node Modules
+        run: npm ci --omit=dev --yes
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,6 @@ GEM
       abbrev
       git
       xml-simple
-    fastlane-plugin-bugsnag_sourcemaps_upload (0.2.0)
     fastlane-sirp (1.1.0)
     ffi (1.17.3)
     fourflusher (2.3.1)
@@ -347,7 +346,6 @@ DEPENDENCIES
   fastlane (~> 2.237.0)
   fastlane-plugin-browserstack
   fastlane-plugin-bugsnag
-  fastlane-plugin-bugsnag_sourcemaps_upload
   jwt
   logger
   mutex_m
@@ -412,7 +410,6 @@ CHECKSUMS
   fastlane (2.237.0) sha256=bb1e867bc070fb328741b5e6e7606d5ba596941a9ecca0478f60ef22d1009db9
   fastlane-plugin-browserstack (0.3.4) sha256=a4f3e4a552e2390a4733570857512571535912100ffada177d5374413f2c1333
   fastlane-plugin-bugsnag (3.0.0) sha256=8ddac4b79cb4b5d00432cccd5789a9e1a1119c29f7773a27d01b1d8a2363915d
-  fastlane-plugin-bugsnag_sourcemaps_upload (0.2.0) sha256=a05afaefa81a7bf56c36386dddeb0931db31ead6886e3eae24f9683bda1a064d
   fastlane-sirp (1.1.0) sha256=10bc94f9682efd8e1badfb31452a76dd8981f1f3a33717c765fde6d75b54d847
   ffi (1.17.3) sha256=0e9f39f7bb3934f77ad6feab49662be77e87eedcdeb2a3f5c0234c2938563d4c
   fourflusher (2.3.1) sha256=1b3de61c7c791b6a4e64f31e3719eb25203d151746bb519a0292bff1065ccaa9

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -91,6 +91,18 @@ module AndroidHelpers
     Actions.sh("cd android && ./gradlew assembleRelease --no-daemon --stacktrace --console=plain | tee #{log_path}") do |status|
       UI.user_error!("Gradle assembleRelease failed") unless status.success?
     end
+    # RN 0.71+ cannot use bugsnag-android-gradle-plugin's uploadReactNativeMappings
+    # (bundle task renamed). Official upload path is BugSnag CLI:
+    # https://docs.bugsnag.com/platforms/react-native/react-native/showing-full-stacktraces/
+    upload_bugsnag_react_native_android!
+  end
+
+  def upload_bugsnag_react_native_android!
+    UI.message("Uploading React Native Android source maps to BugSnag...")
+    Actions.sh("npm run bugsnag:upload-rn-android") do |status|
+      UI.user_error!("BugSnag React Native Android source map upload failed") unless status.success?
+    end
+    UI.success("React Native Android source maps uploaded to BugSnag")
   end
 
   def resolve_apk_paths(version_name:, build_number:, branch_name:)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,6 +25,7 @@ def app_store_state_readable(state)
 end
 
 require 'securerandom'
+require 'shellwords'
 
 default_platform(:android)
 PROJECT_ROOT = File.expand_path("..", __dir__)
@@ -980,31 +981,35 @@ platform :ios do
 end
 
 desc "Upload iOS source maps to Bugsnag"
+# Official BugSnag CLI path for RN iOS (replaces @bugsnag/source-maps Xcode script
+# and fastlane-plugin-bugsnag_sourcemaps_upload):
+# https://docs.bugsnag.com/platforms/react-native/react-native/showing-full-stacktraces/
 lane :upload_bugsnag_sourcemaps do
-  bugsnag_api_key = ENV['BUGSNAG_API_KEY']
-  bugsnag_release_stage = ENV['BUGSNAG_RELEASE_STAGE'] || "production"
-  version = ENV['PROJECT_VERSION']
-  build_number = ENV['NEW_BUILD_NUMBER']
+  Dir.chdir(project_root) do
+    source_map = File.join("ios", "build", "sourcemaps", "main.jsbundle.map")
+    UI.user_error!("iOS source map not found at #{source_map}. Ensure SOURCEMAP_FILE is set in ios/.xcode.env and the app was built.") unless File.exist?(source_map)
 
-  UI.user_error!("BUGSNAG_API_KEY environment variable is missing") if bugsnag_api_key.nil?
-  UI.user_error!("PROJECT_VERSION environment variable is missing") if version.nil?
-  UI.user_error!("NEW_BUILD_NUMBER environment variable is missing") if build_number.nil?
+    cmd = [
+      "npm", "run", "bugsnag:upload-rn-ios", "--",
+      "--scheme=BlueWallet",
+      "--xcode-project=ios/BlueWallet.xcodeproj",
+      "--source-map=#{source_map}",
+    ]
 
-  ios_sourcemap = "./ios/build/Build/Products/Release-iphonesimulator/main.jsbundle.map"
+    archive_path = lane_context[SharedValues::XCODEBUILD_ARCHIVE] rescue nil
+    if archive_path.nil? || archive_path.to_s.empty?
+      archive_path = Dir.glob(File.join(Dir.home, "Library/Developer/Xcode/Archives/**/*.xcarchive")).max_by { |path| File.mtime(path) }
+    end
+    cmd << "--xcarchive-path=#{archive_path}" if archive_path && File.exist?(archive_path)
 
-  if File.exist?(ios_sourcemap)
-    UI.message("Uploading iOS source map to Bugsnag...")
-    bugsnag_sourcemaps_upload(
-      api_key: bugsnag_api_key,
-      source_map: ios_sourcemap,
-      minified_file: "./ios/main.jsbundle",
-      code_bundle_id: "#{version}-#{build_number}",
-      release_stage: bugsnag_release_stage,
-      app_version: version
-    )
-    UI.success("iOS source map uploaded successfully.")
-  else
-    UI.error("iOS source map not found at #{ios_sourcemap}")
+    # Optional overrides; CLI also reads Info.plist / project defaults
+    cmd << "--api-key=#{ENV['BUGSNAG_API_KEY']}" if ENV['BUGSNAG_API_KEY'] && !ENV['BUGSNAG_API_KEY'].empty?
+    cmd << "--version-name=#{ENV['PROJECT_VERSION']}" if ENV['PROJECT_VERSION'] && !ENV['PROJECT_VERSION'].empty?
+    cmd << "--bundle-version=#{ENV['NEW_BUILD_NUMBER']}" if ENV['NEW_BUILD_NUMBER'] && !ENV['NEW_BUILD_NUMBER'].empty?
+
+    UI.message("Uploading React Native iOS source maps to BugSnag...")
+    sh(cmd.shelljoin)
+    UI.success("React Native iOS source maps uploaded to BugSnag")
   end
 end
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,5 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-browserstack'
-gem 'fastlane-plugin-bugsnag_sourcemaps_upload'
 gem "fastlane-plugin-bugsnag"

--- a/ios/.xcode.env
+++ b/ios/.xcode.env
@@ -1,1 +1,10 @@
+# This `.xcode.env` file is shared among all developers working on this app.
+# Sourced by React Native's with-environment.sh during Xcode builds.
+# See https://reactnative.dev/docs/environment-setup#optional-configuring-your-environment
+
 export NODE_BINARY=$(command -v node)
+
+# Official BugSnag / React Native source map location:
+# https://docs.bugsnag.com/platforms/react-native/react-native/showing-full-stacktraces/
+export SOURCEMAP_FILE=$(pwd)/build/sourcemaps/main.jsbundle.map
+mkdir -p "$(dirname "$SOURCEMAP_FILE")"

--- a/ios/BlueWallet.xcodeproj/project.pbxproj
+++ b/ios/BlueWallet.xcodeproj/project.pbxproj
@@ -789,7 +789,6 @@
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				B40D4E2D225841C300428FCC /* Embed Watch Content */,
 				3271B0B6236E2E0700DA766F /* Embed Foundation Extensions */,
-				A8D9893AE3CD454A9094B651 /* Upload source maps to Bugsnag */,
 				4B36CFF6FE55027DCA5CB6E1 /* Upload Bugsnag dSYM */,
 				BFE56A9A22A21E360BF7A1EC /* [CP] Embed Pods Frameworks */,
 				D0E81659D2FBFDD27024CF05 /* [CP] Copy Pods Resources */,
@@ -1006,7 +1005,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export EXTRA_PACKAGER_ARGS=\"--sourcemap-output $TMPDIR/$(md5 -qs \"$CONFIGURATION_BUILD_DIR\")-main.jsbundle.map\"\nexport NODE_BINARY=$(which node)\n../node_modules/react-native/scripts/react-native-xcode.sh\n\n";
+			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"\\\"$WITH_ENVIRONMENT\\\" \\\"$REACT_NATIVE_XCODE\\\"\"\n";
 		};
 		3B467A525D105B531AB91B81 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1050,24 +1049,6 @@
 			shellPath = "/usr/bin/env ruby";
 			shellScript = "api_key = nil # Insert your key here to use it directly from this script\n\n# Attempt to get the API key from an environment variable\nunless api_key\n  api_key = ENV[\"BUGSNAG_API_KEY\"]\n\n  # If not present, attempt to lookup the value from the Info.plist\n  unless api_key\n    info_plist_path = \"#{ENV[\"BUILT_PRODUCTS_DIR\"]}/#{ENV[\"INFOPLIST_PATH\"]}\"\n    plist_buddy_response = `/usr/libexec/PlistBuddy -c \"print :bugsnag:apiKey\" \"#{info_plist_path}\"`\n    plist_buddy_response = `/usr/libexec/PlistBuddy -c \"print :BugsnagAPIKey\" \"#{info_plist_path}\"` if !$?.success?\n    api_key = plist_buddy_response if $?.success?\n  end\nend\n\nfail(\"No Bugsnag API key detected - add your key to your Info.plist, BUGSNAG_API_KEY environment variable or this Run Script phase\") unless api_key\n\nfork do\n  Process.setsid\n  STDIN.reopen(\"/dev/null\")\n  STDOUT.reopen(\"/dev/null\", \"a\")\n  STDERR.reopen(\"/dev/null\", \"a\")\n\n  require 'shellwords'\n\n  Dir[\"#{ENV[\"DWARF_DSYM_FOLDER_PATH\"]}/*/Contents/Resources/DWARF/*\"].each do |dsym|\n    curl_command = \"curl --http1.1 -F dsym=@#{Shellwords.escape(dsym)} -F projectRoot=#{Shellwords.escape(ENV[\"PROJECT_DIR\"])} \"\n    curl_command += \"-F apiKey=#{Shellwords.escape(api_key)} \"\n    curl_command += \"https://upload.bugsnag.com/\"\n    system(curl_command)\n  end\nend\n\n";
 			showEnvVarsInLog = 0;
-		};
-		A8D9893AE3CD454A9094B651 /* Upload source maps to Bugsnag */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Upload source maps to Bugsnag";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "SOURCE_MAP=\"$TMPDIR/$(md5 -qs \"$CONFIGURATION_BUILD_DIR\")-main.jsbundle.map\" ../node_modules/@bugsnag/react-native/bugsnag-react-native-xcode.sh\n\n";
 		};
 		BFE56A9A22A21E360BF7A1EC /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@arkade-os/boltz-swap": "0.3.48",
         "@arkade-os/sdk": "0.4.43",
+        "@bugsnag/cli": "3.10.3",
         "@bugsnag/react-native": "8.9.0",
         "@keystonehq/bc-ur-registry": "0.8.0",
         "@ngraveio/bc-ur": "1.1.13",
@@ -114,7 +115,6 @@
       "devDependencies": {
         "@babel/core": "^7.26.0",
         "@babel/runtime": "^7.26.0",
-        "@bugsnag/cli": "3.10.3",
         "@jest/reporters": "^27.5.1",
         "@react-native/eslint-config": "^0.86.0",
         "@react-native/jest-preset": "0.86.0",
@@ -1507,7 +1507,6 @@
       "version": "3.10.3",
       "resolved": "https://registry.npmjs.org/@bugsnag/cli/-/cli-3.10.3.tgz",
       "integrity": "sha512-b3+UOEvY+77jM2CT38m+/yzzYSuxlo73q4wWUKfRvFbDUO+cy5rfSoEoITXgUtbmjWBDS8NnjTmINHxzrOWBvQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -17739,7 +17738,6 @@
       "version": "6.27.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
       "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@arkade-os/boltz-swap": "0.3.48",
         "@arkade-os/sdk": "0.4.43",
         "@bugsnag/react-native": "8.9.0",
-        "@bugsnag/source-maps": "2.3.3",
         "@keystonehq/bc-ur-registry": "0.8.0",
         "@ngraveio/bc-ur": "1.1.13",
         "@noble/ciphers": "1.3.0",
@@ -1669,22 +1668,6 @@
     "node_modules/@bugsnag/safe-json-stringify": {
       "version": "6.1.0",
       "license": "MIT"
-    },
-    "node_modules/@bugsnag/source-maps": {
-      "version": "2.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "command-line-args": "^5.1.1",
-        "command-line-usage": "^6.1.0",
-        "concat-stream": "^2.0.0",
-        "consola": "^2.15.0",
-        "form-data": "^3.0.0",
-        "glob": "^7.1.6",
-        "read-pkg-up": "^7.0.1"
-      },
-      "bin": {
-        "bugsnag-source-maps": "bin/cli"
-      }
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
@@ -4573,10 +4556,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/normalize-package-data": {
-      "version": "2.4.4",
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -5106,13 +5085,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/array-back": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "dev": true,
@@ -5304,10 +5276,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "license": "MIT"
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
       "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
@@ -6727,118 +6695,11 @@
       "version": "1.1.3",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/command-exists": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
       "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
       "license": "MIT"
-    },
-    "node_modules/command-line-args": {
-      "version": "5.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^3.1.0",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/command-line-usage": {
-      "version": "6.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.2",
-        "chalk": "^2.4.2",
-        "table-layout": "^1.0.2",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/array-back": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/chalk": {
-      "version": "2.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/color-convert": {
-      "version": "1.9.3",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/color-name": {
-      "version": "1.1.3",
-      "license": "MIT"
-    },
-    "node_modules/command-line-usage/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/has-flag": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/supports-color": {
-      "version": "5.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/typical": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/commander": {
       "version": "9.5.0",
@@ -6894,20 +6755,8 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/concat-stream": {
-      "version": "2.0.0",
-      "engines": [
-        "node >= 6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2",
-        "typedarray": "^0.0.6"
-      }
     },
     "node_modules/connect": {
       "version": "3.7.0",
@@ -6937,10 +6786,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/consola": {
-      "version": "2.15.3",
       "license": "MIT"
     },
     "node_modules/content-type": {
@@ -7417,13 +7262,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -8139,6 +7977,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -9450,16 +9289,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/find-replace": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "license": "MIT",
@@ -9530,20 +9359,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fresh": {
@@ -9729,6 +9544,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -9758,6 +9574,7 @@
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9766,6 +9583,7 @@
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -9943,10 +9761,6 @@
     "node_modules/hoist-non-react-statics/node_modules/react-is": {
       "version": "16.13.1",
       "license": "MIT"
-    },
-    "node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "license": "ISC"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -12927,10 +12741,6 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "license": "MIT"
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "license": "MIT"
@@ -14222,23 +14032,6 @@
         "url": "https://github.com/sponsors/antelle"
       }
     },
-    "node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.2",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "dev": true,
@@ -14774,6 +14567,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15972,92 +15766,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/read-pkg": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/locate-path": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-locate": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "license": "MIT",
@@ -16106,13 +15814,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/reduce-flatten": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -17060,30 +16761,6 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-exceptions": {
-      "version": "2.5.0",
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-license-ids": {
-      "version": "3.0.21",
-      "license": "CC0-1.0"
-    },
     "node_modules/split-on-first": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
@@ -17462,33 +17139,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
-      }
-    },
-    "node_modules/table-layout": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.1",
-        "deep-extend": "~0.6.0",
-        "typical": "^5.2.0",
-        "wordwrapjs": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/table-layout/node_modules/array-back": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/table-layout/node_modules/typical": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/tar-fs": {
@@ -18037,10 +17687,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "license": "MIT"
-    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "dev": true,
@@ -18063,13 +17709,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/typical": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/uint8array-tools": {
@@ -18313,14 +17952,6 @@
         }
       }
     },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
     "node_modules/varuint-bitcoin": {
       "version": "1.1.2",
       "license": "MIT",
@@ -18506,24 +18137,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wordwrapjs": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "reduce-flatten": "^2.0.0",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/wordwrapjs/node_modules/typical": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,7 @@
       "devDependencies": {
         "@babel/core": "^7.26.0",
         "@babel/runtime": "^7.26.0",
+        "@bugsnag/cli": "3.10.3",
         "@jest/reporters": "^27.5.1",
         "@react-native/eslint-config": "^0.86.0",
         "@react-native/jest-preset": "0.86.0",
@@ -1501,6 +1502,24 @@
       "license": "MIT",
       "dependencies": {
         "bip68": "^1.0.4"
+      }
+    },
+    "node_modules/@bugsnag/cli": {
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cli/-/cli-3.10.3.tgz",
+      "integrity": "sha512-b3+UOEvY+77jM2CT38m+/yzzYSuxlo73q4wWUKfRvFbDUO+cy5rfSoEoITXgUtbmjWBDS8NnjTmINHxzrOWBvQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "undici": "^6.23.0",
+        "yaml": "^2.7.0"
+      },
+      "bin": {
+        "bugsnag-cli": "bin/bugsnag-cli"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@bugsnag/core": {
@@ -18075,6 +18094,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@babel/core": "^7.26.0",
     "@babel/runtime": "^7.26.0",
+    "@bugsnag/cli": "3.10.3",
     "@jest/reporters": "^27.5.1",
     "@react-native/eslint-config": "^0.86.0",
     "@react-native/jest-preset": "0.86.0",
@@ -88,7 +89,8 @@
     "lint": " npm run tslint && node scripts/find-unused-loc.js && node scripts/find-english-leftovers.js && node scripts/validate-fastlane-metadata.js && eslint --ext .js,.ts,.tsx '*.@(js|ts|tsx)' screen 'blue_modules/*.@(js|ts|tsx)' class models loc tests components navigation typings",
     "lint:fix": "npm run lint -- --fix",
     "lint:quickfix": "git status --porcelain | grep -v '\\.json' | grep -E '\\.js|\\.ts' --color=never |  awk '{print $2}' | xargs eslint --fix; exit 0",
-    "unit": "jest -b tests/unit/*"
+    "unit": "jest -b tests/unit/*",
+    "bugsnag:upload-rn-android": "bugsnag-cli upload react-native-android"
   },
   "dependencies": {
     "@arkade-os/boltz-swap": "0.3.48",

--- a/package.json
+++ b/package.json
@@ -90,13 +90,13 @@
     "lint:fix": "npm run lint -- --fix",
     "lint:quickfix": "git status --porcelain | grep -v '\\.json' | grep -E '\\.js|\\.ts' --color=never |  awk '{print $2}' | xargs eslint --fix; exit 0",
     "unit": "jest -b tests/unit/*",
-    "bugsnag:upload-rn-android": "bugsnag-cli upload react-native-android"
+    "bugsnag:upload-rn-android": "bugsnag-cli upload react-native-android",
+    "bugsnag:upload-rn-ios": "bugsnag-cli upload react-native-ios"
   },
   "dependencies": {
     "@arkade-os/boltz-swap": "0.3.48",
     "@arkade-os/sdk": "0.4.43",
     "@bugsnag/react-native": "8.9.0",
-    "@bugsnag/source-maps": "2.3.3",
     "@keystonehq/bc-ur-registry": "0.8.0",
     "@ngraveio/bc-ur": "1.1.13",
     "@noble/ciphers": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "@babel/core": "^7.26.0",
     "@babel/runtime": "^7.26.0",
-    "@bugsnag/cli": "3.10.3",
     "@jest/reporters": "^27.5.1",
     "@react-native/eslint-config": "^0.86.0",
     "@react-native/jest-preset": "0.86.0",
@@ -96,6 +95,7 @@
   "dependencies": {
     "@arkade-os/boltz-swap": "0.3.48",
     "@arkade-os/sdk": "0.4.43",
+    "@bugsnag/cli": "3.10.3",
     "@bugsnag/react-native": "8.9.0",
     "@keystonehq/bc-ur-registry": "0.8.0",
     "@ngraveio/bc-ur": "1.1.13",


### PR DESCRIPTION
## Summary
- Android and iOS JS sourcemaps now upload via the [official BugSnag CLI path for React Native](https://docs.bugsnag.com/platforms/react-native/react-native/showing-full-stacktraces/).
- Android: `bugsnag-cli upload react-native-android` after `assembleRelease` (Gradle plugin `uploadReactNativeMappings` is broken on RN 0.71+).
- iOS: set `SOURCEMAP_FILE` in `ios/.xcode.env`, use the stock RN `with-environment.sh` bundle phase, upload with `bugsnag-cli upload react-native-ios` from Fastlane after archive.
- Removes legacy iOS Xcode “Upload source maps to Bugsnag” phase (needed `@bugsnag/source-maps`), drops that npm package, and removes unused `fastlane-plugin-bugsnag_sourcemaps_upload`.
- Keeps BugSnag Android Gradle plugin for NDK/build metadata, and iOS dSYM upload phases unchanged.

## Test plan
- [x] Android: `bugsnag-cli upload react-native-android --dry-run --variant=release` finds the release map
- [ ] CI `BuildReleaseApk`: log shows RN Android sourcemap upload success
- [ ] CI iOS release: archive succeeds without `bugsnag-source-maps: No such file`, then Fastlane `upload_bugsnag_sourcemaps` runs CLI successfully
- [ ] Confirm JS errors symbolicate on Android and iOS in the BugSnag dashboard