### PR TITLE
TST: stabilize Detox QR and menu flows

### DIFF
--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -11,7 +11,10 @@ import {
   hashIt,
   helperCreateWallet,
   helperDeleteWallet,
+  restoreSynchronizationAfterScan,
+  restoreSynchronizationIfScannerClosed,
   scanText,
+  scanUrFragments,
   scrollUpOnHomeScreen,
   setCustomFeeRate,
   sleep,
@@ -608,6 +611,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
 
     await scanText('pipe goose bottom run seed curious thought kangaroo example family coral success');
     // scan auto-imports the seed via onBarScanned and navigates back to Step2
+    await restoreSynchronizationAfterScan();
 
     // key2 - xpub:
     await waitForId('VaultCosignerImport2');
@@ -617,6 +621,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await scanText(
       'ur:crypto-account/oeadcypdlouebgaolytaadmetaaddloxaxhdclaxfdyksnwkuypkfevlfzfroyiyecoeosbakbpdcldawzhtcarkwsndcphphsbsdsayaahdcxfgjyckryosmwtdptlbflonbkimlsmovolslbytonayisprvoieftgeflzcrtvesbamtaaddyotadlocsdyykaeykaeykaoykaocypdlouebgaxaaaycyttatrnolimvetsst',
     );
+    await restoreSynchronizationAfterScan();
 
     // scan auto-imports the xpub via onBarScanned and navigates back to Step2
     await waitForId('CreateButton');
@@ -670,15 +675,18 @@ describe('BlueWallet UI Tests - no wallets', () => {
 
     await waitFor(element(by.id('UrProgressBar'))).toBeNotVisible();
 
-    for (const ur of urs) {
-      await scanText(ur);
-      await waitFor(element(by.id('UrProgressBar'))).toBeVisible();
-    }
+    try {
+      await scanUrFragments(urs);
 
-    await waitForText('OK', 3 * 61000); // waiting for wallet import
-    await element(by.text('OK')).tap();
+      await waitForText('OK', 3 * 61000); // waiting for wallet import
+      await element(by.text('OK')).tap();
+    } finally {
+      if (!(await restoreSynchronizationIfScannerClosed())) {
+        console.warn('[detox] leaving sync disabled after multisig import: scanner still open');
+      }
+    }
     await scrollUpOnHomeScreen();
-    // ok, wallet imported
+    // ok, wallet imported — left the UR / QR import UI
 
     // lets go inside wallet
     const expectedWalletLabel = 'Multisig Vault';
@@ -720,33 +728,58 @@ describe('BlueWallet UI Tests - no wallets', () => {
       'UR:CRYPTO-PSBT/416-4/LPCFADNBAACFAXPLCYZTVYVOPKHDWPONBWDWPACLGTAEIDWLWZBAZODNCSMSEHZELBIYDLMWCSHDIADKNYWNZSSGPKVEFLMKLRKNCELEDAMYEMBYKIJKFNDEDMIAHPLBRDPMLTROWMFNWSLTROCMIOYKWPFZDSLGLGDKWSOYPFAHMODAMYENSAIOSEGAZEEHTSLBKGOEDMWZUTRFNYJEKIPEEMIYJSOTUEZERORFPSGRPABSSKLOGOONAECAGRSFBDLRWFEMLNSALRCWZOWNLPHNPTNSLPJTKBMTEYNSISTAFTEHSEGDOTENSNMHKNFGCLFXOXMYPLCELTKOMTNEGRTOJYGURHKGPMTAFHHKWPKIOTJPGWVSKNSKSSFTOYPTKKSGSRFGIORHMDDAFHNYKTHPCPOTKEGELANNLEWEGMJEKPIYGYSFECJNCWFNRYVLTBTBWPHTKBISTLRLDEMWADCWMNKTTARKDRJSZCJPLRCNFSHGNEGAMTYLVLGOWS',
     ];
 
-    for (const ur of ursSignedByPassport) {
-      await scanText(ur);
-      await waitFor(element(by.id('UrProgressBar'))).toBeVisible();
+    // Keep sync disabled across animated QR cosign screens — re-enabling here
+    // waits on pending layer animations and can hang the suite.
+    try {
+      // ItemSigned can update on the underlying screen before ScanQRCode pops;
+      // scanUrFragments waits for the scanner to dismiss before returning.
+      await scanUrFragments(ursSignedByPassport);
+      await waitFor(element(by.id('ItemSigned')))
+        .toBeVisible()
+        .withTimeout(30_000);
+      await waitForId('ProvideSignature');
+      await element(by.id('ProvideSignature')).tap();
+      // Wait for the cosign QR screen to mount before scrolling — with sync off
+      // after UR scans, whileElement(...).scroll can race the navigation.
+      await waitFor(element(by.id('PsbtMultisigQRCodeScrollView')))
+        .toBeVisible()
+        .withTimeout(30_000);
+      await waitFor(element(by.id('CosignedScanOrImportFile')))
+        .toBeVisible()
+        .whileElement(by.id('PsbtMultisigQRCodeScrollView'))
+        .scroll(500, 'down'); // in case emu screen is small and it doesnt fit
+      await tapAndTapAgainIfElementIsNotVisible('CosignedScanOrImportFile', 'ScanQrBackdoorButton');
+
+      const urSignedByPassportAndKeystone = [
+        'UR:CRYPTO-PSBT/105-2/LPCSINAOCFAXOLCYSBLUFDHSHKADTEHKAXOTJOJKIDJYZMADAEKIAOAEAEAEADSGMHIEQDIAFLKPVABAJEHLLNVLRKKPCPDAHYNSOTTSOYBTIMMUCYAASSMDAMDAMKAEAEAEAEAEZMZMZMZMAOGDSRAEAEAEAEAEAECMAEBBKBOTLPWFGMRNINIMPFYNWLGEBAVTVLSWTYPAGEGUWFVLAEAEAEAEAEAECPAECXHEJTWTTTWEPDFMMDSNYKDPRYZMRLBARSPAAYLETDCLGDJKIHBNTYFXCHNNWTRHFEAEAEAEAEAEADAEWDAOAEAEAEAEADADSTENIYASISYLVDVLGWCXRPBWVYVSDALOTLCESKTTFEJTWDTBPTECMOMNLNDABSDTADAEAEAEAEADAEAELAAOGDPTADAEAEAEAEAECPAECXCLSWSSWSCPVTGTESFWSBCTCSETNSPYNLBKJLZTUEMWSOMSNNTYGSLSFPNEPKVOIOONMOAOAEAEAEAEAECMAEBBMNAMRTRKDYGUHDURWSVOLGDRRLESMEDLOLGWLYNTAOFLDYFYAOCXDYYTJOMYYAUELEDYKIYLADUROYFNURDRGLFTCYKEKEFEIAOYGSTNCPIDGYZOEEDAAOCXHGCAENYKHNJLGOHEJOGMRLBNTDWYGWJOPFPYFMKKTISROXGMIMGYURAYCXLEUOZSADCLAOJPBGWSASPTIATTPMLECMPRIHSTMDJYLOYKTKRTHHTLSTFZKPOYWKBKROASBGBAVDAEAEAEAEADADDNGDPTADAEAEAEAEAECPAECXCLSWSSWSCPVTGTESFWSBCTCSETNSPYNLBKJLZTUEMWSOMSNNTYGSLSFPNEPKVOIOCPAOAXFTRPWPCPGYBKEHRTTTFDCTNTRHKGFGCXSAHSRHWDMDTONBRLROWMSFCPBTHNTIAAFLDYFYAOCXISRERKHDRDGAPMATEHJLFL',
+        'UR:CRYPTO-PSBT/158-2/LPCSNNAOCFAXOLCYSBLUFDHSHKADTEZECFFTHDETNBADMOCLINLNOSOXZEYKGDPYTPKTRETNURTIZOPDAOCXIAAOWETTJKMDUOSBONAASWNLMERLZSGLCYCTGAKBDAFHGHWKMTRSNLAAYKFWWPRSADADAHFLGMCLAXBAPLDADMGDFLRHLOHGUYHESWEOSKMDMTJLDRTKSSRDFGDWSNTNCHZEVSJTJKDNCNCLAXFTRPWPCPGYBKEHRTTTFDCTNTRHKGFGCXSAHSRHWDMDTONBRLROWMSFCPBTHNTIAAGMPLCPAMAXBAPLDADMGDFLRHLOHGUYHESWEOSKMDMTJLDRTKSSRDFGDWSNTNCHZEVSJTJKDNCNCECMLGTBAXDYAEAELAAEAEAELAAEAEAELAAOAEAELAAEAEAEAEAXAEAEAECPAMAXFTRPWPCPGYBKEHRTTTFDCTNTRHKGFGCXSAHSRHWDMDTONBRLROWMSFCPBTHNTIAACETEKBPMLODYAEAELAAEAEAELAAEAEAELAAOAEAELAAEAEAEAEAXAEAEAEAEAEADADFLGMCLAXCSMYGWCMSGFWBTIENEOTRHHDFTVTLYTASNUYWZAMFSNLZSYLHGDKDWAYKBFYZTECCLAXFXPSGMTABNWEIAJTHSCLAOSERKVLJKADWEBKTBBTRKJPTPYKMKLTMSRYRKDYPLLKGMPLCPAOAXCSMYGWCMSGFWBTIENEOTRHHDFTVTLYTASNUYWZAMFSNLZSYLHGDKDWAYKBFYZTECCETEKBPMLODYAEAELAAEAEAELAAEAEAELAAOAEAELAADAEAEAEAEAEAEAECPAOAXFXPSGMTABNWEIAJTHSCLAOSERKVLJKADWEBKTBBTRKJPTPYKMKLTMSRYRKDYPLLKCECMLGTBAXDYAEAELAAEAEAELAAEAEAELAAOAEAELAADAEAEAEAEAEAEAEAENNHKLKUO',
+      ];
+
+      await scanUrFragments(urSignedByPassportAndKeystone);
+      await waitFor(element(by.id('ExportSignedPsbt')))
+        .toBeVisible()
+        .withTimeout(30_000);
+
+      await element(by.id('PsbtMultisigConfirmButton')).tap();
+    } finally {
+      if (device.getPlatform() === 'ios') {
+        let psbtQrHidden;
+        try {
+          await waitFor(element(by.id('PsbtMultisigQRCodeScrollView')))
+            .not.toBeVisible()
+            .withTimeout(2_000);
+          psbtQrHidden = true;
+        } catch {
+          psbtQrHidden = false;
+        }
+
+        if (!psbtQrHidden) {
+          console.warn('[detox] leaving sync disabled after UR cosign: animated PSBT QR still open');
+        } else if (!(await restoreSynchronizationIfScannerClosed())) {
+          console.warn('[detox] leaving sync disabled after UR cosign because the scanner is still open');
+        }
+      }
     }
-
-    await waitFor(element(by.id('ItemSigned'))).toBeVisible(); // one green checkmark visible
-
-    await element(by.id('ProvideSignature')).tap();
-    await waitFor(element(by.id('CosignedScanOrImportFile')))
-      .toBeVisible()
-      .whileElement(by.id('PsbtMultisigQRCodeScrollView'))
-      .scroll(500, 'down'); // in case emu screen is small and it doesnt fit
-    await tapAndTapAgainIfElementIsNotVisible('CosignedScanOrImportFile', 'ScanQrBackdoorButton');
-
-    const urSignedByPassportAndKeystone = [
-      'UR:CRYPTO-PSBT/105-2/LPCSINAOCFAXOLCYSBLUFDHSHKADTEHKAXOTJOJKIDJYZMADAEKIAOAEAEAEADSGMHIEQDIAFLKPVABAJEHLLNVLRKKPCPDAHYNSOTTSOYBTIMMUCYAASSMDAMDAMKAEAEAEAEAEZMZMZMZMAOGDSRAEAEAEAEAEAECMAEBBKBOTLPWFGMRNINIMPFYNWLGEBAVTVLSWTYPAGEGUWFVLAEAEAEAEAEAECPAECXHEJTWTTTWEPDFMMDSNYKDPRYZMRLBARSPAAYLETDCLGDJKIHBNTYFXCHNNWTRHFEAEAEAEAEAEADAEWDAOAEAEAEAEADADSTENIYASISYLVDVLGWCXRPBWVYVSDALOTLCESKTTFEJTWDTBPTECMOMNLNDABSDTADAEAEAEAEADAEAELAAOGDPTADAEAEAEAEAECPAECXCLSWSSWSCPVTGTESFWSBCTCSETNSPYNLBKJLZTUEMWSOMSNNTYGSLSFPNEPKVOIOONMOAOAEAEAEAEAECMAEBBMNAMRTRKDYGUHDURWSVOLGDRRLESMEDLOLGWLYNTAOFLDYFYAOCXDYYTJOMYYAUELEDYKIYLADUROYFNURDRGLFTCYKEKEFEIAOYGSTNCPIDGYZOEEDAAOCXHGCAENYKHNJLGOHEJOGMRLBNTDWYGWJOPFPYFMKKTISROXGMIMGYURAYCXLEUOZSADCLAOJPBGWSASPTIATTPMLECMPRIHSTMDJYLOYKTKRTHHTLSTFZKPOYWKBKROASBGBAVDAEAEAEAEADADDNGDPTADAEAEAEAEAECPAECXCLSWSSWSCPVTGTESFWSBCTCSETNSPYNLBKJLZTUEMWSOMSNNTYGSLSFPNEPKVOIOCPAOAXFTRPWPCPGYBKEHRTTTFDCTNTRHKGFGCXSAHSRHWDMDTONBRLROWMSFCPBTHNTIAAFLDYFYAOCXISRERKHDRDGAPMATEHJLFL',
-      'UR:CRYPTO-PSBT/158-2/LPCSNNAOCFAXOLCYSBLUFDHSHKADTEZECFFTHDETNBADMOCLINLNOSOXZEYKGDPYTPKTRETNURTIZOPDAOCXIAAOWETTJKMDUOSBONAASWNLMERLZSGLCYCTGAKBDAFHGHWKMTRSNLAAYKFWWPRSADADAHFLGMCLAXBAPLDADMGDFLRHLOHGUYHESWEOSKMDMTJLDRTKSSRDFGDWSNTNCHZEVSJTJKDNCNCLAXFTRPWPCPGYBKEHRTTTFDCTNTRHKGFGCXSAHSRHWDMDTONBRLROWMSFCPBTHNTIAAGMPLCPAMAXBAPLDADMGDFLRHLOHGUYHESWEOSKMDMTJLDRTKSSRDFGDWSNTNCHZEVSJTJKDNCNCECMLGTBAXDYAEAELAAEAEAELAAEAEAELAAOAEAELAAEAEAEAEAXAEAEAECPAMAXFTRPWPCPGYBKEHRTTTFDCTNTRHKGFGCXSAHSRHWDMDTONBRLROWMSFCPBTHNTIAACETEKBPMLODYAEAELAAEAEAELAAEAEAELAAOAEAELAAEAEAEAEAXAEAEAEAEAEADADFLGMCLAXCSMYGWCMSGFWBTIENEOTRHHDFTVTLYTASNUYWZAMFSNLZSYLHGDKDWAYKBFYZTECCLAXFXPSGMTABNWEIAJTHSCLAOSERKVLJKADWEBKTBBTRKJPTPYKMKLTMSRYRKDYPLLKGMPLCPAOAXCSMYGWCMSGFWBTIENEOTRHHDFTVTLYTASNUYWZAMFSNLZSYLHGDKDWAYKBFYZTECCETEKBPMLODYAEAELAAEAEAELAAEAEAELAAOAEAELAADAEAEAEAEAEAEAECPAOAXFXPSGMTABNWEIAJTHSCLAOSERKVLJKADWEBKTBBTRKJPTPYKMKLTMSRYRKDYPLLKCECMLGTBAXDYAEAELAAEAEAELAAEAEAELAAOAEAELAADAEAEAEAEAEAEAEAENNHKLKUO',
-    ];
-
-    for (const ur of urSignedByPassportAndKeystone) {
-      await scanText(ur);
-      await waitFor(element(by.id('UrProgressBar'))).toBeVisible();
-    }
-
-    await waitFor(element(by.id('ExportSignedPsbt'))).toBeVisible();
-
-    await element(by.id('PsbtMultisigConfirmButton')).tap();
 
     // created. verifying:
     await waitForId('TransactionValue');
@@ -847,6 +880,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await helperCreateWallet();
     await tapAndTapAgainIfElementIsNotVisible('HomeScreenScanButton', 'ScanQrBackdoorButton');
     await scanText('bitcoin:bc1qzrtn3xwlunlrm0n0uu23lr00gmdx4lnlavdy75');
+    await restoreSynchronizationAfterScan();
     await waitForId('AddressInput');
     await expect(element(by.id('AddressInput'))).toHaveText('bc1qzrtn3xwlunlrm0n0uu23lr00gmdx4lnlavdy75');
 
@@ -864,6 +898,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await element(by.id('ImportWallet')).tap();
     await element(by.id('ScanImport')).tap();
     await scanText('lndhub://a3b4c9109408a043d1ea:ec5a888596b2c45729d1@https://kek.lol');
+    await restoreSynchronizationAfterScan();
     await waitForText('OK', 30_000); // waiting for wallet import
     await element(by.text('OK')).tap();
 
@@ -873,6 +908,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await scanText(
       'lightning:lnbc1p090vrqpp5yxpd5wjtln4r874a9grkpr772cs0uyn7ayva3ypleyut7z0a4rgsdpu235hqurfdcsx7an9wf6x7undv4h8ggpgw35hqurfdchx6eff9p6nzvfc8q5scqzpgxqyz5vqcy30v2txquuh06h6946pal4dlm4hyujqv8ec3cunetf46gfydpxswedv4sr2rlg8dwpcg3fq9gah3j42373w366e6yau37t30amp5zqqftd004',
     );
+    await restoreSynchronizationAfterScan();
     await waitForId('AddressInput');
     await expect(element(by.id('AddressInput'))).toHaveText(
       'lnbc1p090vrqpp5yxpd5wjtln4r874a9grkpr772cs0uyn7ayva3ypleyut7z0a4rgsdpu235hqurfdcsx7an9wf6x7undv4h8ggpgw35hqurfdchx6eff9p6nzvfc8q5scqzpgxqyz5vqcy30v2txquuh06h6946pal4dlm4hyujqv8ec3cunetf46gfydpxswedv4sr2rlg8dwpcg3fq9gah3j42373w366e6yau37t30amp5zqqftd004',
@@ -890,6 +926,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await scanText(
       'bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001&lightning=lnbc1u1pwry044pp53xlmkghmzjzm3cljl6729cwwqz5hhnhevwfajpkln850n7clft4sdqlgfy4qv33ypmj7sj0f32rzvfqw3jhxaqcqzysxq97zvuq5zy8ge6q70prnvgwtade0g2k5h2r76ws7j2926xdjj2pjaq6q3r4awsxtm6k5prqcul73p3atveljkn6wxdkrcy69t6k5edhtc6q7lgpe4m5k4',
     );
+    await restoreSynchronizationAfterScan();
 
     await waitForId('SelectWalletsList');
     await element(by.text('Imported Lightning')).tap();
@@ -911,6 +948,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await scanText(
       'bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001&lightning=lnbc1u1pwry044pp53xlmkghmzjzm3cljl6729cwwqz5hhnhevwfajpkln850n7clft4sdqlgfy4qv33ypmj7sj0f32rzvfqw3jhxaqcqzysxq97zvuq5zy8ge6q70prnvgwtade0g2k5h2r76ws7j2926xdjj2pjaq6q3r4awsxtm6k5prqcul73p3atveljkn6wxdkrcy69t6k5edhtc6q7lgpe4m5k4',
     );
+    await restoreSynchronizationAfterScan();
 
     await waitForId('SelectWalletsList');
     await element(by.text('cr34t3d')).tap();
@@ -923,6 +961,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await waitForId('WalletsList');
     await tapAndTapAgainIfElementIsNotVisible('HomeScreenScanButton', 'ScanQrBackdoorButton');
     await scanText('https://azte.co/redeem?code=1111222233334444');
+    await restoreSynchronizationAfterScan();
     await waitForId('AztecoCode');
     await expect(element(by.id('AztecoCode'))).toBeVisible();
 
@@ -982,6 +1021,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await waitForId('ScanOrOpenFile');
     await element(by.id('ScanOrOpenFile')).tap();
     await scanText('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about');
+    await restoreSynchronizationAfterScan();
 
     // create vault
     await waitForId('CreateButton');
@@ -1156,6 +1196,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await waitForId('ScanOrOpenFile');
     await element(by.id('ScanOrOpenFile')).tap();
     await scanText('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about');
+    await restoreSynchronizationAfterScan();
 
     // key 2 - import seed
     await waitForId('VaultCosignerImport2');
@@ -1163,6 +1204,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await waitForId('ScanOrOpenFile');
     await element(by.id('ScanOrOpenFile')).tap();
     await scanText('zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong');
+    await restoreSynchronizationAfterScan();
 
     // create vault
     await waitForId('CreateButton');

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -11,7 +11,6 @@ import {
   hashIt,
   helperCreateWallet,
   helperDeleteWallet,
-  restoreSynchronizationAfterScan,
   restoreSynchronizationIfScannerClosed,
   scanText,
   scanUrFragments,
@@ -611,7 +610,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
 
     await scanText('pipe goose bottom run seed curious thought kangaroo example family coral success');
     // scan auto-imports the seed via onBarScanned and navigates back to Step2
-    await restoreSynchronizationAfterScan();
 
     // key2 - xpub:
     await waitForId('VaultCosignerImport2');
@@ -621,7 +619,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await scanText(
       'ur:crypto-account/oeadcypdlouebgaolytaadmetaaddloxaxhdclaxfdyksnwkuypkfevlfzfroyiyecoeosbakbpdcldawzhtcarkwsndcphphsbsdsayaahdcxfgjyckryosmwtdptlbflonbkimlsmovolslbytonayisprvoieftgeflzcrtvesbamtaaddyotadlocsdyykaeykaeykaoykaocypdlouebgaxaaaycyttatrnolimvetsst',
     );
-    await restoreSynchronizationAfterScan();
 
     // scan auto-imports the xpub via onBarScanned and navigates back to Step2
     await waitForId('CreateButton');
@@ -880,7 +877,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await helperCreateWallet();
     await tapAndTapAgainIfElementIsNotVisible('HomeScreenScanButton', 'ScanQrBackdoorButton');
     await scanText('bitcoin:bc1qzrtn3xwlunlrm0n0uu23lr00gmdx4lnlavdy75');
-    await restoreSynchronizationAfterScan();
     await waitForId('AddressInput');
     await expect(element(by.id('AddressInput'))).toHaveText('bc1qzrtn3xwlunlrm0n0uu23lr00gmdx4lnlavdy75');
 
@@ -898,7 +894,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await element(by.id('ImportWallet')).tap();
     await element(by.id('ScanImport')).tap();
     await scanText('lndhub://a3b4c9109408a043d1ea:ec5a888596b2c45729d1@https://kek.lol');
-    await restoreSynchronizationAfterScan();
     await waitForText('OK', 30_000); // waiting for wallet import
     await element(by.text('OK')).tap();
 
@@ -908,7 +903,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await scanText(
       'lightning:lnbc1p090vrqpp5yxpd5wjtln4r874a9grkpr772cs0uyn7ayva3ypleyut7z0a4rgsdpu235hqurfdcsx7an9wf6x7undv4h8ggpgw35hqurfdchx6eff9p6nzvfc8q5scqzpgxqyz5vqcy30v2txquuh06h6946pal4dlm4hyujqv8ec3cunetf46gfydpxswedv4sr2rlg8dwpcg3fq9gah3j42373w366e6yau37t30amp5zqqftd004',
     );
-    await restoreSynchronizationAfterScan();
     await waitForId('AddressInput');
     await expect(element(by.id('AddressInput'))).toHaveText(
       'lnbc1p090vrqpp5yxpd5wjtln4r874a9grkpr772cs0uyn7ayva3ypleyut7z0a4rgsdpu235hqurfdcsx7an9wf6x7undv4h8ggpgw35hqurfdchx6eff9p6nzvfc8q5scqzpgxqyz5vqcy30v2txquuh06h6946pal4dlm4hyujqv8ec3cunetf46gfydpxswedv4sr2rlg8dwpcg3fq9gah3j42373w366e6yau37t30amp5zqqftd004',
@@ -926,7 +920,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await scanText(
       'bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001&lightning=lnbc1u1pwry044pp53xlmkghmzjzm3cljl6729cwwqz5hhnhevwfajpkln850n7clft4sdqlgfy4qv33ypmj7sj0f32rzvfqw3jhxaqcqzysxq97zvuq5zy8ge6q70prnvgwtade0g2k5h2r76ws7j2926xdjj2pjaq6q3r4awsxtm6k5prqcul73p3atveljkn6wxdkrcy69t6k5edhtc6q7lgpe4m5k4',
     );
-    await restoreSynchronizationAfterScan();
 
     await waitForId('SelectWalletsList');
     await element(by.text('Imported Lightning')).tap();
@@ -948,7 +941,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await scanText(
       'bitcoin:1DamianM2k8WfNEeJmyqSe2YW1upB7UATx?amount=0.000001&lightning=lnbc1u1pwry044pp53xlmkghmzjzm3cljl6729cwwqz5hhnhevwfajpkln850n7clft4sdqlgfy4qv33ypmj7sj0f32rzvfqw3jhxaqcqzysxq97zvuq5zy8ge6q70prnvgwtade0g2k5h2r76ws7j2926xdjj2pjaq6q3r4awsxtm6k5prqcul73p3atveljkn6wxdkrcy69t6k5edhtc6q7lgpe4m5k4',
     );
-    await restoreSynchronizationAfterScan();
 
     await waitForId('SelectWalletsList');
     await element(by.text('cr34t3d')).tap();
@@ -961,7 +953,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await waitForId('WalletsList');
     await tapAndTapAgainIfElementIsNotVisible('HomeScreenScanButton', 'ScanQrBackdoorButton');
     await scanText('https://azte.co/redeem?code=1111222233334444');
-    await restoreSynchronizationAfterScan();
     await waitForId('AztecoCode');
     await expect(element(by.id('AztecoCode'))).toBeVisible();
 
@@ -1021,7 +1012,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await waitForId('ScanOrOpenFile');
     await element(by.id('ScanOrOpenFile')).tap();
     await scanText('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about');
-    await restoreSynchronizationAfterScan();
 
     // create vault
     await waitForId('CreateButton');
@@ -1196,7 +1186,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await waitForId('ScanOrOpenFile');
     await element(by.id('ScanOrOpenFile')).tap();
     await scanText('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about');
-    await restoreSynchronizationAfterScan();
 
     // key 2 - import seed
     await waitForId('VaultCosignerImport2');
@@ -1204,7 +1193,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await waitForId('ScanOrOpenFile');
     await element(by.id('ScanOrOpenFile')).tap();
     await scanText('zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong');
-    await restoreSynchronizationAfterScan();
 
     // create vault
     await waitForId('CreateButton');

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -11,10 +11,10 @@ import {
   hashIt,
   helperCreateWallet,
   helperDeleteWallet,
-  restoreSynchronizationIfScannerClosed,
+  restoreSynchronizationIfAnimatedQrClosed,
   scanText,
-  scanUrFragments,
   scrollUpOnHomeScreen,
+  waitForQrScannerClosed,
   setCustomFeeRate,
   sleep,
   tapAndTapAgainIfElementIsNotVisible,
@@ -673,13 +673,21 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await waitFor(element(by.id('UrProgressBar'))).toBeNotVisible();
 
     try {
-      await scanUrFragments(urs);
+      for (let i = 0; i < urs.length; i++) {
+        await scanText(urs[i], { restoreSynchronization: false });
+        if (i < urs.length - 1) {
+          await waitFor(element(by.id('UrProgressBar')))
+            .toBeVisible()
+            .withTimeout(60_000);
+        }
+      }
+      await waitForQrScannerClosed();
 
       await waitForText('OK', 3 * 61000); // waiting for wallet import
       await element(by.text('OK')).tap();
     } finally {
-      if (!(await restoreSynchronizationIfScannerClosed())) {
-        console.warn('[detox] leaving sync disabled after multisig import: scanner still open');
+      if (!(await restoreSynchronizationIfAnimatedQrClosed())) {
+        console.warn('[detox] leaving sync disabled after multisig import: animated QR/scanner still open');
       }
     }
     await scrollUpOnHomeScreen();
@@ -728,9 +736,16 @@ describe('BlueWallet UI Tests - no wallets', () => {
     // Keep sync disabled across animated QR cosign screens — re-enabling here
     // waits on pending layer animations and can hang the suite.
     try {
-      // ItemSigned can update on the underlying screen before ScanQRCode pops;
-      // scanUrFragments waits for the scanner to dismiss before returning.
-      await scanUrFragments(ursSignedByPassport);
+      for (let i = 0; i < ursSignedByPassport.length; i++) {
+        await scanText(ursSignedByPassport[i], { restoreSynchronization: false });
+        if (i < ursSignedByPassport.length - 1) {
+          await waitFor(element(by.id('UrProgressBar')))
+            .toBeVisible()
+            .withTimeout(60_000);
+        }
+      }
+      // ItemSigned can update before ScanQRCode pops; wait for dismiss first.
+      await waitForQrScannerClosed();
       await waitFor(element(by.id('ItemSigned')))
         .toBeVisible()
         .withTimeout(30_000);
@@ -752,29 +767,23 @@ describe('BlueWallet UI Tests - no wallets', () => {
         'UR:CRYPTO-PSBT/158-2/LPCSNNAOCFAXOLCYSBLUFDHSHKADTEZECFFTHDETNBADMOCLINLNOSOXZEYKGDPYTPKTRETNURTIZOPDAOCXIAAOWETTJKMDUOSBONAASWNLMERLZSGLCYCTGAKBDAFHGHWKMTRSNLAAYKFWWPRSADADAHFLGMCLAXBAPLDADMGDFLRHLOHGUYHESWEOSKMDMTJLDRTKSSRDFGDWSNTNCHZEVSJTJKDNCNCLAXFTRPWPCPGYBKEHRTTTFDCTNTRHKGFGCXSAHSRHWDMDTONBRLROWMSFCPBTHNTIAAGMPLCPAMAXBAPLDADMGDFLRHLOHGUYHESWEOSKMDMTJLDRTKSSRDFGDWSNTNCHZEVSJTJKDNCNCECMLGTBAXDYAEAELAAEAEAELAAEAEAELAAOAEAELAAEAEAEAEAXAEAEAECPAMAXFTRPWPCPGYBKEHRTTTFDCTNTRHKGFGCXSAHSRHWDMDTONBRLROWMSFCPBTHNTIAACETEKBPMLODYAEAELAAEAEAELAAEAEAELAAOAEAELAAEAEAEAEAXAEAEAEAEAEADADFLGMCLAXCSMYGWCMSGFWBTIENEOTRHHDFTVTLYTASNUYWZAMFSNLZSYLHGDKDWAYKBFYZTECCLAXFXPSGMTABNWEIAJTHSCLAOSERKVLJKADWEBKTBBTRKJPTPYKMKLTMSRYRKDYPLLKGMPLCPAOAXCSMYGWCMSGFWBTIENEOTRHHDFTVTLYTASNUYWZAMFSNLZSYLHGDKDWAYKBFYZTECCETEKBPMLODYAEAELAAEAEAELAAEAEAELAAOAEAELAADAEAEAEAEAEAEAECPAOAXFXPSGMTABNWEIAJTHSCLAOSERKVLJKADWEBKTBBTRKJPTPYKMKLTMSRYRKDYPLLKCECMLGTBAXDYAEAELAAEAEAELAAEAEAELAAOAEAELAADAEAEAEAEAEAEAEAENNHKLKUO',
       ];
 
-      await scanUrFragments(urSignedByPassportAndKeystone);
+      for (let i = 0; i < urSignedByPassportAndKeystone.length; i++) {
+        await scanText(urSignedByPassportAndKeystone[i], { restoreSynchronization: false });
+        if (i < urSignedByPassportAndKeystone.length - 1) {
+          await waitFor(element(by.id('UrProgressBar')))
+            .toBeVisible()
+            .withTimeout(60_000);
+        }
+      }
+      await waitForQrScannerClosed();
       await waitFor(element(by.id('ExportSignedPsbt')))
         .toBeVisible()
         .withTimeout(30_000);
 
       await element(by.id('PsbtMultisigConfirmButton')).tap();
     } finally {
-      if (device.getPlatform() === 'ios') {
-        let psbtQrHidden;
-        try {
-          await waitFor(element(by.id('PsbtMultisigQRCodeScrollView')))
-            .not.toBeVisible()
-            .withTimeout(2_000);
-          psbtQrHidden = true;
-        } catch {
-          psbtQrHidden = false;
-        }
-
-        if (!psbtQrHidden) {
-          console.warn('[detox] leaving sync disabled after UR cosign: animated PSBT QR still open');
-        } else if (!(await restoreSynchronizationIfScannerClosed())) {
-          console.warn('[detox] leaving sync disabled after UR cosign because the scanner is still open');
-        }
+      if (!(await restoreSynchronizationIfAnimatedQrClosed())) {
+        console.warn('[detox] leaving sync disabled after UR cosign: animated QR/scanner still open');
       }
     }
 

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -13,8 +13,8 @@ import {
   helperDeleteWallet,
   restoreSynchronizationIfAnimatedQrClosed,
   scanText,
+  scanUrParts,
   scrollUpOnHomeScreen,
-  waitForQrScannerClosed,
   setCustomFeeRate,
   sleep,
   tapAndTapAgainIfElementIsNotVisible,
@@ -673,15 +673,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await waitFor(element(by.id('UrProgressBar'))).toBeNotVisible();
 
     try {
-      for (let i = 0; i < urs.length; i++) {
-        await scanText(urs[i], { restoreSynchronization: false });
-        if (i < urs.length - 1) {
-          await waitFor(element(by.id('UrProgressBar')))
-            .toBeVisible()
-            .withTimeout(60_000);
-        }
-      }
-      await waitForQrScannerClosed();
+      await scanUrParts(urs);
 
       await waitForText('OK', 3 * 61000); // waiting for wallet import
       await element(by.text('OK')).tap();
@@ -736,16 +728,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
     // Keep sync disabled across animated QR cosign screens — re-enabling here
     // waits on pending layer animations and can hang the suite.
     try {
-      for (let i = 0; i < ursSignedByPassport.length; i++) {
-        await scanText(ursSignedByPassport[i], { restoreSynchronization: false });
-        if (i < ursSignedByPassport.length - 1) {
-          await waitFor(element(by.id('UrProgressBar')))
-            .toBeVisible()
-            .withTimeout(60_000);
-        }
-      }
-      // ItemSigned can update before ScanQRCode pops; wait for dismiss first.
-      await waitForQrScannerClosed();
+      await scanUrParts(ursSignedByPassport);
       await waitFor(element(by.id('ItemSigned')))
         .toBeVisible()
         .withTimeout(30_000);
@@ -767,15 +750,7 @@ describe('BlueWallet UI Tests - no wallets', () => {
         'UR:CRYPTO-PSBT/158-2/LPCSNNAOCFAXOLCYSBLUFDHSHKADTEZECFFTHDETNBADMOCLINLNOSOXZEYKGDPYTPKTRETNURTIZOPDAOCXIAAOWETTJKMDUOSBONAASWNLMERLZSGLCYCTGAKBDAFHGHWKMTRSNLAAYKFWWPRSADADAHFLGMCLAXBAPLDADMGDFLRHLOHGUYHESWEOSKMDMTJLDRTKSSRDFGDWSNTNCHZEVSJTJKDNCNCLAXFTRPWPCPGYBKEHRTTTFDCTNTRHKGFGCXSAHSRHWDMDTONBRLROWMSFCPBTHNTIAAGMPLCPAMAXBAPLDADMGDFLRHLOHGUYHESWEOSKMDMTJLDRTKSSRDFGDWSNTNCHZEVSJTJKDNCNCECMLGTBAXDYAEAELAAEAEAELAAEAEAELAAOAEAELAAEAEAEAEAXAEAEAECPAMAXFTRPWPCPGYBKEHRTTTFDCTNTRHKGFGCXSAHSRHWDMDTONBRLROWMSFCPBTHNTIAACETEKBPMLODYAEAELAAEAEAELAAEAEAELAAOAEAELAAEAEAEAEAXAEAEAEAEAEADADFLGMCLAXCSMYGWCMSGFWBTIENEOTRHHDFTVTLYTASNUYWZAMFSNLZSYLHGDKDWAYKBFYZTECCLAXFXPSGMTABNWEIAJTHSCLAOSERKVLJKADWEBKTBBTRKJPTPYKMKLTMSRYRKDYPLLKGMPLCPAOAXCSMYGWCMSGFWBTIENEOTRHHDFTVTLYTASNUYWZAMFSNLZSYLHGDKDWAYKBFYZTECCETEKBPMLODYAEAELAAEAEAELAAEAEAELAAOAEAELAADAEAEAEAEAEAEAECPAOAXFXPSGMTABNWEIAJTHSCLAOSERKVLJKADWEBKTBBTRKJPTPYKMKLTMSRYRKDYPLLKCECMLGTBAXDYAEAELAAEAEAELAAEAEAELAAOAEAELAADAEAEAEAEAEAEAEAENNHKLKUO',
       ];
 
-      for (let i = 0; i < urSignedByPassportAndKeystone.length; i++) {
-        await scanText(urSignedByPassportAndKeystone[i], { restoreSynchronization: false });
-        if (i < urSignedByPassportAndKeystone.length - 1) {
-          await waitFor(element(by.id('UrProgressBar')))
-            .toBeVisible()
-            .withTimeout(60_000);
-        }
-      }
-      await waitForQrScannerClosed();
+      await scanUrParts(urSignedByPassportAndKeystone);
       await waitFor(element(by.id('ExportSignedPsbt')))
         .toBeVisible()
         .withTimeout(30_000);

--- a/tests/e2e/bluewallet2.spec.js
+++ b/tests/e2e/bluewallet2.spec.js
@@ -9,12 +9,14 @@ import {
   goBack,
   hashIt,
   helperImportWallet,
+  restoreSynchronizationAfterScan,
   scanText,
   scrollUpOnHomeScreen,
   setCustomFeeRate,
   sleep,
   tapAndTapAgainIfElementIsNotVisible,
   tapAndTapAgainIfTextIsNotVisible,
+  tapHeaderMenuItem,
   tapIfTextPresent,
   typeTextIntoAlertInput,
   waitForId,
@@ -117,6 +119,7 @@ describe('BlueWallet UI Tests - import BIP84 wallet', () => {
     await element(by.id('BlueAddressInputScanQrButton')).tap();
 
     await scanText('bitcoin:bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7?amount=0.00015&pj=https://btc.donate.kukks.org/BTC/pj');
+    await restoreSynchronizationAfterScan();
 
     await element(by.id('CreateTransactionButton')).tap();
     // created. verifying:
@@ -138,6 +141,7 @@ describe('BlueWallet UI Tests - import BIP84 wallet', () => {
     await element(by.id('BlueAddressInputScanQrButton')).tap();
 
     await scanText('bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
+    await restoreSynchronizationAfterScan();
 
     await element(by.id('CreateTransactionButton')).tap();
     // created. verifying:
@@ -352,13 +356,13 @@ describe('BlueWallet UI Tests - import BIP84 wallet', () => {
     await waitForId('SendButton');
     await element(by.id('SendButton')).tap();
 
-    await element(by.id('HeaderMenuButton')).tap();
-    await element(by.text('Sign a transaction')).tap();
+    await tapHeaderMenuItem('Sign a transaction', { restoreSynchronization: false });
 
     // 1 input, 2 outputs. wallet can fully sign this tx
     const psbt =
       'cHNidP8BAFICAAAAAXYa7FEQBAQ2X0B48aHHKKgzkVuHfQ2yCOi3v9RR0IqlAQAAAAAAAACAAegDAAAAAAAAFgAUSnH40G+jiJfreeRb36cs641KFm8AAAAAAAEBH5YVAAAAAAAAFgAUTKHjDm4OJQSbvy9uzyLYi5i5XIoiBgMQcGrP5TIMrdvb73yB4WnZvkPzKr1EzJXJYBHWmlPJZRgAAAAAVAAAgAAAAIAAAACAAQAAAD4AAAAAAA==';
     await scanText(psbt);
+    await restoreSynchronizationAfterScan();
 
     // this is fully-signed tx, "this is tx hex" help text should appear
     await waitForId('DynamicCode');
@@ -512,16 +516,13 @@ describe('BlueWallet UI Tests - import BIP84 wallet', () => {
     await waitForId('SendButton');
 
     await tapAndTapAgainIfElementIsNotVisible('SendButton', 'HeaderMenuButton');
-    await element(by.id('HeaderMenuButton')).tap();
-    await element(by.text('Insert Contact')).tap();
+    await tapHeaderMenuItem('Insert Contact');
     await tapAndTapAgainIfElementIsNotVisible('ContactListItem0', 'BitcoinAmountInput');
     await element(by.id('BitcoinAmountInput')).replaceText('0.0001');
     await waitForKeyboardToClose();
 
-    await element(by.id('HeaderMenuButton')).tap();
-    await element(by.text('Add Recipient')).tap();
-    await element(by.id('HeaderMenuButton')).tap();
-    await element(by.text('Insert Contact')).tap();
+    await tapHeaderMenuItem('Add Recipient');
+    await tapHeaderMenuItem('Insert Contact');
     await element(by.id('ContactListItem1')).tap();
     await element(by.id('BitcoinAmountInput')).atIndex(1).replaceText('0.0002');
     await waitForKeyboardToClose();
@@ -685,8 +686,7 @@ describe('BlueWallet UI Tests - import BIP84 wallet', () => {
     await element(by.text('Imported HD SegWit (BIP84 Bech32 Native)')).tap();
     await waitForId('SendButton');
     await element(by.id('SendButton')).tap();
-    await element(by.id('HeaderMenuButton')).tap();
-    await element(by.text('Coin Control')).tap();
+    await tapHeaderMenuItem('Coin Control');
     await waitFor(element(by.id('Loading'))) // wait for outputs to be loaded
       .not.toExist()
       .withTimeout(300 * 1000);

--- a/tests/e2e/bluewallet2.spec.js
+++ b/tests/e2e/bluewallet2.spec.js
@@ -9,7 +9,6 @@ import {
   goBack,
   hashIt,
   helperImportWallet,
-  restoreSynchronizationAfterScan,
   scanText,
   scrollUpOnHomeScreen,
   setCustomFeeRate,
@@ -119,7 +118,6 @@ describe('BlueWallet UI Tests - import BIP84 wallet', () => {
     await element(by.id('BlueAddressInputScanQrButton')).tap();
 
     await scanText('bitcoin:bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7?amount=0.00015&pj=https://btc.donate.kukks.org/BTC/pj');
-    await restoreSynchronizationAfterScan();
 
     await element(by.id('CreateTransactionButton')).tap();
     // created. verifying:
@@ -141,7 +139,6 @@ describe('BlueWallet UI Tests - import BIP84 wallet', () => {
     await element(by.id('BlueAddressInputScanQrButton')).tap();
 
     await scanText('bc1qnapskphjnwzw2w3dk4anpxntunc77v6qrua0f7');
-    await restoreSynchronizationAfterScan();
 
     await element(by.id('CreateTransactionButton')).tap();
     // created. verifying:
@@ -362,7 +359,6 @@ describe('BlueWallet UI Tests - import BIP84 wallet', () => {
     const psbt =
       'cHNidP8BAFICAAAAAXYa7FEQBAQ2X0B48aHHKKgzkVuHfQ2yCOi3v9RR0IqlAQAAAAAAAACAAegDAAAAAAAAFgAUSnH40G+jiJfreeRb36cs641KFm8AAAAAAAEBH5YVAAAAAAAAFgAUTKHjDm4OJQSbvy9uzyLYi5i5XIoiBgMQcGrP5TIMrdvb73yB4WnZvkPzKr1EzJXJYBHWmlPJZRgAAAAAVAAAgAAAAIAAAACAAQAAAD4AAAAAAA==';
     await scanText(psbt);
-    await restoreSynchronizationAfterScan();
 
     // this is fully-signed tx, "this is tx hex" help text should appear
     await waitForId('DynamicCode');

--- a/tests/e2e/bluewallet3.spec.js
+++ b/tests/e2e/bluewallet3.spec.js
@@ -1,11 +1,14 @@
 import {
+  dismissAlertByText,
   goBack,
   hashIt,
   helperDeleteWallet,
   helperImportWallet,
+  restoreSynchronizationAfterScan,
   scanText,
   scrollUpOnHomeScreen,
   sleep,
+  tapHeaderMenuItem,
   waitForId,
   waitForKeyboardToClose,
 } from './helperz';
@@ -72,10 +75,11 @@ describe('BlueWallet UI Tests - import Watch-only wallet (zpub)', () => {
     await expect(element(by.label('bitcoin:BC1QGRHR5XC5774MAPH97D73YDRJLQQMG2V6JJLR29?amount=1&label=Test'))).toBeVisible();
     await goBack();
     await element(by.id('SendButton')).tap();
-    await element(by.text('OK')).tap();
+    // Offline-signing prompt; liquid-glass OK often fails plain toBeVisible taps.
+    await dismissAlertByText('OK', 15_000);
+    await waitForId('HeaderMenuButton');
 
-    await element(by.id('HeaderMenuButton')).tap();
-    await element(by.text('Import Transaction (QR)')).tap(); // opens camera
+    await tapHeaderMenuItem('Import Transaction (QR)', { restoreSynchronization: false }); // opens camera
 
     // produced by real Keystone device using MNEMONICS_KEYSTONE
     const unsignedPsbt =
@@ -84,6 +88,7 @@ describe('BlueWallet UI Tests - import Watch-only wallet (zpub)', () => {
       'UR:CRYPTO-PSBT/HDWTJOJKIDJYZMADAEGOAOAEAEAEADLFIAYKFPTOTIHSMNDLJTLFTYPAHTFHZESOAODIBNADFDCPFZZEKSSTTOJYKPRLJOAEAEAEAEAEZMZMZMZMADNBDSAEAEAEAEAEAECFKOPTBBCFBGNTGUVAEHNDPECFUYNBHKRNPMCMJNYTBKROYKLOPSAEAEAEAEAEADADCTBEDIAEAEAEAEAEAECMAEBBFTZSECYTJZTEKGOEKECAVOGHMTVWGYIAMHCSKOSWADAYJEAOFLDYFYAOCXGEUTDNBDTNMKTOQDLASKMTTSCLCSHPOLGDBEHDBBZMNERLRFSFIDLTMHTLMTLYWKAOCXFRBWHGOSGYRLYKTSSSSSIEWDZOVOSTFNISKTBYCLLRLRHSHFCMSGTTVDRHURNSOLADCLAXENRDWMCPOTZMHKGMFPNTHLMNDMCETOHLOXTANDAMEOTSURLFHHPLTSDPCSJTWSGAAEAEDLFPLTSW';
 
     await scanText(unsignedPsbt);
+    await restoreSynchronizationAfterScan();
 
     // now lets test scanning back QR with UR PSBT. this should lead straight to broadcast dialog
 
@@ -100,6 +105,7 @@ describe('BlueWallet UI Tests - import Watch-only wallet (zpub)', () => {
     await element(by.id('PsbtTxScanButton')).tap(); // opening camera
 
     await scanText(signedPsbt);
+    await restoreSynchronizationAfterScan();
     await expect(element(by.id('ScanQrBackdoorButton'))).toBeNotVisible();
     await waitForId('PsbtWithHardwareWalletBroadcastTransactionButton');
 

--- a/tests/e2e/bluewallet3.spec.js
+++ b/tests/e2e/bluewallet3.spec.js
@@ -4,7 +4,6 @@ import {
   hashIt,
   helperDeleteWallet,
   helperImportWallet,
-  restoreSynchronizationAfterScan,
   scanText,
   scrollUpOnHomeScreen,
   sleep,
@@ -88,7 +87,6 @@ describe('BlueWallet UI Tests - import Watch-only wallet (zpub)', () => {
       'UR:CRYPTO-PSBT/HDWTJOJKIDJYZMADAEGOAOAEAEAEADLFIAYKFPTOTIHSMNDLJTLFTYPAHTFHZESOAODIBNADFDCPFZZEKSSTTOJYKPRLJOAEAEAEAEAEZMZMZMZMADNBDSAEAEAEAEAEAECFKOPTBBCFBGNTGUVAEHNDPECFUYNBHKRNPMCMJNYTBKROYKLOPSAEAEAEAEAEADADCTBEDIAEAEAEAEAEAECMAEBBFTZSECYTJZTEKGOEKECAVOGHMTVWGYIAMHCSKOSWADAYJEAOFLDYFYAOCXGEUTDNBDTNMKTOQDLASKMTTSCLCSHPOLGDBEHDBBZMNERLRFSFIDLTMHTLMTLYWKAOCXFRBWHGOSGYRLYKTSSSSSIEWDZOVOSTFNISKTBYCLLRLRHSHFCMSGTTVDRHURNSOLADCLAXENRDWMCPOTZMHKGMFPNTHLMNDMCETOHLOXTANDAMEOTSURLFHHPLTSDPCSJTWSGAAEAEDLFPLTSW';
 
     await scanText(unsignedPsbt);
-    await restoreSynchronizationAfterScan();
 
     // now lets test scanning back QR with UR PSBT. this should lead straight to broadcast dialog
 
@@ -105,7 +103,6 @@ describe('BlueWallet UI Tests - import Watch-only wallet (zpub)', () => {
     await element(by.id('PsbtTxScanButton')).tap(); // opening camera
 
     await scanText(signedPsbt);
-    await restoreSynchronizationAfterScan();
     await expect(element(by.id('ScanQrBackdoorButton'))).toBeNotVisible();
     await waitForId('PsbtWithHardwareWalletBroadcastTransactionButton');
 

--- a/tests/e2e/helperz.js
+++ b/tests/e2e/helperz.js
@@ -170,6 +170,13 @@ export async function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/** Re-enables Detox synchronization after scanText navigation leaves the scanner. */
+export async function restoreSynchronizationAfterScan() {
+  if (device.getPlatform() === 'ios') {
+    await device.enableSynchronization();
+  }
+}
+
 export function hashIt(s) {
   return Buffer.from(sha256(s)).toString('hex');
 }
@@ -418,13 +425,73 @@ export async function countElements(testId) {
   return count;
 }
 
-export async function scanText(text) {
+async function submitTextToQrScannerBackdoor(text) {
   await waitForId('ScanQrBackdoorButton');
   for (let c = 0; c <= 5; c++) {
     await element(by.id('ScanQrBackdoorButton')).tap();
   }
   await element(by.id('scanQrBackdoorInput')).replaceText(text);
   await element(by.id('scanQrBackdoorOkButton')).tap();
+  await sleep(300);
+}
+
+/**
+ * Feeds text into the QR scanner backdoor.
+ * On iOS, returns with synchronization disabled so callers can leave animated
+ * QR / UR UI before calling restoreSynchronizationAfterScan().
+ */
+export async function scanText(text) {
+  if (device.getPlatform() === 'ios') {
+    await device.disableSynchronization();
+  }
+  await submitTextToQrScannerBackdoor(text);
+}
+
+/**
+ * After submitting text through the QR scanner backdoor, wait until the ScanQRCode UI is gone.
+ * Use not.toBeVisible (not not.toExist): React Navigation keeps the screen
+ * mounted under the stack, so the backdoor testID can still exist after popTo.
+ */
+export async function waitForQrScannerClosed(timeoutMs = 60_000) {
+  await waitFor(element(by.id('ScanQrBackdoorButton')))
+    .not.toBeVisible()
+    .withTimeout(timeoutMs);
+}
+
+export async function restoreSynchronizationIfScannerClosed(timeoutMs = 2_000) {
+  if (device.getPlatform() !== 'ios') {
+    return true;
+  }
+
+  try {
+    await waitForQrScannerClosed(timeoutMs);
+  } catch {
+    return false;
+  }
+
+  await device.enableSynchronization();
+  return true;
+}
+
+/**
+ * Feed multi-part UR fragments via the QR backdoor.
+ * Non-final parts should show UrProgressBar; the final part dismisses the
+ * scanner, so wait for that navigation before returning.
+ */
+export async function scanUrFragments(urs, { progressTimeoutMs = 60_000 } = {}) {
+  if (device.getPlatform() === 'ios') {
+    await device.disableSynchronization();
+  }
+
+  for (let i = 0; i < urs.length; i++) {
+    await submitTextToQrScannerBackdoor(urs[i]);
+    if (i < urs.length - 1) {
+      await waitFor(element(by.id('UrProgressBar')))
+        .toBeVisible()
+        .withTimeout(progressTimeoutMs);
+    }
+  }
+  await waitForQrScannerClosed();
 }
 
 export async function setCustomFeeRate(feeRate) {
@@ -524,12 +591,84 @@ export async function scrollUpOnHomeScreen() {
     return;
   }
   try {
-    await element(by.type('RCTEnhancedScrollView').withDescendant(by.type('RCTEnhancedScrollView'))).swipe('down', 'slow', 0.5);
+    await element(by.type('RCTEnhancedScrollView').withDescendant(by.type('RCTEnhancedScrollView')))
+      .atIndex(0)
+      .swipe('down', 'slow', 0.5);
   } catch (_) {
-    // if no wallets there will be just one scroll
-    await element(by.type('RCTEnhancedScrollView')).swipe('down', 'slow', 0.5);
+    // if no wallets there will be just one scroll (or nested matcher missed); atIndex
+    // avoids "Multiple elements found" when several scroll views are present.
+    await element(by.type('RCTEnhancedScrollView')).atIndex(0).swipe('down', 'slow', 0.5);
   }
   await sleep(1000); // bounce animation
+}
+
+/**
+ * Opens the send-screen header menu and taps a menu item.
+ * On iOS, action-sheet labels often fail Detox's visibility check (liquid glass
+ * / partial opacity), same class of issue as native alerts — disable sync for
+ * the interaction.
+ *
+ * Pass `restoreSynchronization: false` when the item opens the camera / animated QR UI;
+ * re-enabling there can hang on pending layer animations. Callers should then
+ * use `restoreSynchronizationAfterScan()` after leaving that screen.
+ */
+export async function tapHeaderMenuItem(menuItemText, { restoreSynchronization = true } = {}) {
+  const isIOS = device.getPlatform() === 'ios';
+  if (!isIOS) {
+    await element(by.id('HeaderMenuButton')).tap();
+    await element(by.text(menuItemText)).tap();
+    return;
+  }
+
+  let succeeded = false;
+  await device.disableSynchronization();
+  try {
+    await waitFor(element(by.id('HeaderMenuButton')))
+      .toExist()
+      .withTimeout(15_000);
+
+    let lastError;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        await element(by.id('HeaderMenuButton')).tap();
+        // iOS 26 action sheets use magic-morph transforms that fail Detox's
+        // visibility check until the presentation animation settles.
+        await sleep(1500);
+        // Prefer toExist: liquid-glass menu rows often fail toBeVisible.
+        try {
+          await waitFor(element(by.text(menuItemText)).atIndex(0))
+            .toExist()
+            .withTimeout(5_000);
+        } catch {
+          await waitFor(element(by.label(menuItemText)).atIndex(0))
+            .toExist()
+            .withTimeout(5_000);
+        }
+        try {
+          await element(by.text(menuItemText)).atIndex(0).tap();
+        } catch {
+          try {
+            await element(by.label(menuItemText)).atIndex(0).tap();
+          } catch {
+            // Last resort: tap a corner point to bypass 100% visibility threshold.
+            await element(by.text(menuItemText)).atIndex(0).tap({ x: 8, y: 8 });
+          }
+        }
+        succeeded = true;
+        return;
+      } catch (e) {
+        lastError = e;
+        await sleep(500);
+      }
+    }
+    throw lastError;
+  } finally {
+    // Always restore sync on failure so retries aren't poisoned when the caller
+    // passed restoreSynchronization: false (camera / animated-QR path).
+    if (restoreSynchronization || !succeeded) {
+      await device.enableSynchronization();
+    }
+  }
 }
 
 // We really only need this function when running tests locally.

--- a/tests/e2e/helperz.js
+++ b/tests/e2e/helperz.js
@@ -418,39 +418,34 @@ export async function countElements(testId) {
   return count;
 }
 
-async function submitTextToQrScannerBackdoor(text) {
-  await waitForId('ScanQrBackdoorButton');
-  for (let c = 0; c <= 5; c++) {
-    await element(by.id('ScanQrBackdoorButton')).tap();
-  }
-  await element(by.id('scanQrBackdoorInput')).replaceText(text);
-  await element(by.id('scanQrBackdoorOkButton')).tap();
-  await sleep(300);
-}
-
 /**
  * Feeds text into the QR scanner backdoor.
- * On iOS, disables synchronization for the backdoor interaction, then re-enables
- * it before returning. Multipart UR flows that must keep sync disabled across
- * fragments should use scanUrFragments instead.
+ * On iOS, disables synchronization for the interaction. Pass
+ * `restoreSynchronization: false` for multipart UR scans that must keep sync
+ * disabled until the animated scanner/QR UI is gone.
  */
-export async function scanText(text) {
+export async function scanText(text, { restoreSynchronization = true } = {}) {
   if (device.getPlatform() === 'ios') {
     await device.disableSynchronization();
   }
   try {
-    await submitTextToQrScannerBackdoor(text);
+    await waitForId('ScanQrBackdoorButton');
+    for (let c = 0; c <= 5; c++) {
+      await element(by.id('ScanQrBackdoorButton')).tap();
+    }
+    await element(by.id('scanQrBackdoorInput')).replaceText(text);
+    await element(by.id('scanQrBackdoorOkButton')).tap();
+    await sleep(300);
   } finally {
-    if (device.getPlatform() === 'ios') {
+    if (device.getPlatform() === 'ios' && restoreSynchronization) {
       await device.enableSynchronization();
     }
   }
 }
 
 /**
- * After submitting text through the QR scanner backdoor, wait until the ScanQRCode UI is gone.
- * Use not.toBeVisible (not not.toExist): React Navigation keeps the screen
- * mounted under the stack, so the backdoor testID can still exist after popTo.
+ * Wait until ScanQRCode is gone. Use not.toBeVisible (not not.toExist): React
+ * Navigation keeps the screen mounted under the stack after popTo.
  */
 export async function waitForQrScannerClosed(timeoutMs = 60_000) {
   await waitFor(element(by.id('ScanQrBackdoorButton')))
@@ -458,12 +453,16 @@ export async function waitForQrScannerClosed(timeoutMs = 60_000) {
     .withTimeout(timeoutMs);
 }
 
-export async function restoreSynchronizationIfScannerClosed(timeoutMs = 2_000) {
+/** iOS: enable sync only after animated PSBT QR and scanner are hidden. */
+export async function restoreSynchronizationIfAnimatedQrClosed(timeoutMs = 2_000) {
   if (device.getPlatform() !== 'ios') {
     return true;
   }
 
   try {
+    await waitFor(element(by.id('PsbtMultisigQRCodeScrollView')))
+      .not.toBeVisible()
+      .withTimeout(timeoutMs);
     await waitForQrScannerClosed(timeoutMs);
   } catch {
     return false;
@@ -471,27 +470,6 @@ export async function restoreSynchronizationIfScannerClosed(timeoutMs = 2_000) {
 
   await device.enableSynchronization();
   return true;
-}
-
-/**
- * Feed multi-part UR fragments via the QR backdoor.
- * Non-final parts should show UrProgressBar; the final part dismisses the
- * scanner, so wait for that navigation before returning.
- */
-export async function scanUrFragments(urs, { progressTimeoutMs = 60_000 } = {}) {
-  if (device.getPlatform() === 'ios') {
-    await device.disableSynchronization();
-  }
-
-  for (let i = 0; i < urs.length; i++) {
-    await submitTextToQrScannerBackdoor(urs[i]);
-    if (i < urs.length - 1) {
-      await waitFor(element(by.id('UrProgressBar')))
-        .toBeVisible()
-        .withTimeout(progressTimeoutMs);
-    }
-  }
-  await waitForQrScannerClosed();
 }
 
 export async function setCustomFeeRate(feeRate) {
@@ -610,7 +588,7 @@ export async function scrollUpOnHomeScreen() {
  *
  * Pass `restoreSynchronization: false` when the item opens the camera / animated QR UI;
  * re-enabling there can hang on pending layer animations. A following `scanText()`
- * restores synchronization after the backdoor scan.
+ * (default) restores synchronization after the backdoor scan.
  */
 export async function tapHeaderMenuItem(menuItemText, { restoreSynchronization = true } = {}) {
   const isIOS = device.getPlatform() === 'ios';

--- a/tests/e2e/helperz.js
+++ b/tests/e2e/helperz.js
@@ -170,13 +170,6 @@ export async function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-/** Re-enables Detox synchronization after scanText navigation leaves the scanner. */
-export async function restoreSynchronizationAfterScan() {
-  if (device.getPlatform() === 'ios') {
-    await device.enableSynchronization();
-  }
-}
-
 export function hashIt(s) {
   return Buffer.from(sha256(s)).toString('hex');
 }
@@ -437,14 +430,21 @@ async function submitTextToQrScannerBackdoor(text) {
 
 /**
  * Feeds text into the QR scanner backdoor.
- * On iOS, returns with synchronization disabled so callers can leave animated
- * QR / UR UI before calling restoreSynchronizationAfterScan().
+ * On iOS, disables synchronization for the backdoor interaction, then re-enables
+ * it before returning. Multipart UR flows that must keep sync disabled across
+ * fragments should use scanUrFragments instead.
  */
 export async function scanText(text) {
   if (device.getPlatform() === 'ios') {
     await device.disableSynchronization();
   }
-  await submitTextToQrScannerBackdoor(text);
+  try {
+    await submitTextToQrScannerBackdoor(text);
+  } finally {
+    if (device.getPlatform() === 'ios') {
+      await device.enableSynchronization();
+    }
+  }
 }
 
 /**
@@ -609,8 +609,8 @@ export async function scrollUpOnHomeScreen() {
  * the interaction.
  *
  * Pass `restoreSynchronization: false` when the item opens the camera / animated QR UI;
- * re-enabling there can hang on pending layer animations. Callers should then
- * use `restoreSynchronizationAfterScan()` after leaving that screen.
+ * re-enabling there can hang on pending layer animations. A following `scanText()`
+ * restores synchronization after the backdoor scan.
  */
 export async function tapHeaderMenuItem(menuItemText, { restoreSynchronization = true } = {}) {
   const isIOS = device.getPlatform() === 'ios';

--- a/tests/e2e/helperz.js
+++ b/tests/e2e/helperz.js
@@ -443,14 +443,23 @@ export async function scanText(text, { restoreSynchronization = true } = {}) {
   }
 }
 
-/**
- * Wait until ScanQRCode is gone. Use not.toBeVisible (not not.toExist): React
- * Navigation keeps the screen mounted under the stack after popTo.
- */
+/** Wait until ScanQRCode is gone (`not.toBeVisible`: screen stays mounted after popTo). */
 export async function waitForQrScannerClosed(timeoutMs = 60_000) {
   await waitFor(element(by.id('ScanQrBackdoorButton')))
     .not.toBeVisible()
     .withTimeout(timeoutMs);
+}
+
+/** Multipart UR via backdoor; keeps iOS sync off until the scanner dismisses. */
+export async function scanUrParts(urs) {
+  for (const ur of urs.slice(0, -1)) {
+    await scanText(ur, { restoreSynchronization: false });
+    await waitFor(element(by.id('UrProgressBar')))
+      .toBeVisible()
+      .withTimeout(60_000);
+  }
+  await scanText(urs[urs.length - 1], { restoreSynchronization: false });
+  await waitForQrScannerClosed();
 }
 
 /** iOS: enable sync only after animated PSBT QR and scanner are hidden. */


### PR DESCRIPTION
## Summary
- Keep Detox synchronization disabled on iOS while QR/UR scanner and liquid-glass menu animations are active, restoring it only after those views close.
- Share QR backdoor submission for multipart UR scans and wait on deterministic scanner/navigation state.
- Harden the affected multisig, watch-only, cosign, contacts, and coin-control flows while preserving Android's direct synchronized path.

## Why
Detox could wait indefinitely on persistent iOS layer animations. The final implementation does not race synchronization calls, abandon in-flight Detox requests, or swallow restoration errors.

## Test plan
- [x] `npm test` (lint, TypeScript, unit, and integration)
- [x] Focused ESLint and `git diff --check`
- [ ] Android E2E on the exact squashed commit
- [ ] iOS E2E on the exact squashed commit, especially multisig UR/HW signing and watch-only QR import