### PR TITLE
FIX: RBF Speedup and Cancel button  not working for HD Bech32 Wallet

### DIFF
--- a/screen/transactions/TransactionStatus.tsx
+++ b/screen/transactions/TransactionStatus.tsx
@@ -766,6 +766,11 @@ const TransactionStatus: React.FC = () => {
         ],
         { cancelable: false },
       );
+    } else {
+      navigate(route, {
+        txid: transaction.hash,
+        wallet: w,
+      });
     }
   };
 


### PR DESCRIPTION
Fixes RBF `Speedup` and `Cancel` buttons not working when clicked for HD Bech32 Wallet

The buttons were also not working for HD Bech32 Watchonly wallet if the `Use with hardware wallet option` was already checked

This was due to missing else branch in the change introduced by https://github.com/BlueWallet/BlueWallet/pull/8641