### PR TITLE
FIX: slow down animated QR frame rate 2x

### DIFF
--- a/components/DynamicQRCode.tsx
+++ b/components/DynamicQRCode.tsx
@@ -113,7 +113,7 @@ export class DynamicQRCode extends Component<DynamicQRCodeProps, DynamicQRCodeSt
   startAutoMove = () => {
     if (!this.state.intervalHandler)
       this.setState(() => ({
-        intervalHandler: setInterval(this.moveToNextFragment, 500),
+        intervalHandler: setInterval(this.moveToNextFragment, 1000),
       }));
   };
 


### PR DESCRIPTION
Double the DynamicQRCode interval from 500ms to 1000ms so fragment animation is easier for hardware wallets to scan.