### PR TITLE
FIX: recover stranded swap funds

### DIFF
--- a/class/wallets/lightning-ark-wallet.ts
+++ b/class/wallets/lightning-ark-wallet.ts
@@ -230,6 +230,22 @@ export class LightningArkWallet extends LightningCustodianWallet {
         // waiting for the next user-driven fetchBalance tick.
         this._subscribeToSwapEvents(arkadeSwaps);
 
+        // SwapManager only auto-refunds a failed submarine swap while it is
+        // actually alive and watching it (WebSocket/poll). On a backgrounded
+        // or killed app — the common case for a Lightning send that fails a
+        // few seconds after being fired off — nothing is watching, so the
+        // locked VHTLC funds never come back on their own; only the
+        // per-swap "Refund" button (lndViewInvoice.tsx) or the "Restore swap
+        // activity" button (WalletDetails.tsx) would catch it, and both
+        // require the user to know to go look (#8804: "the failed invoices
+        // balance never came back"). Sweep once per fresh init using the
+        // SDK's own reconciliation API so a fresh app launch self-heals
+        // without the user's help. Not awaited: this is a best-effort
+        // background reconciliation, not a gate on wallet startup.
+        this._recoverStrandedSubmarineFunds(arkadeSwaps).catch((e: any) => {
+          console.log('[ARK] stranded-funds recovery failed:', e?.message ?? e);
+        });
+
         return { wallet, arkadeSwaps };
       })();
 
@@ -276,6 +292,24 @@ export class LightningArkWallet extends LightningCustodianWallet {
     swapManager.onSwapCompleted(refresh).catch(() => {});
     swapManager.onSwapFailed(refresh).catch(() => {});
     swapManager.onActionExecuted(refresh).catch(() => {});
+  }
+
+  // One-shot reconciliation for submarine swaps whose failure SwapManager
+  // never got to observe live (app backgrounded/killed mid-swap). Scan is
+  // side-effect free and cheap (one batched spendable + one batched
+  // recoverable indexer query); only swaps already past their refund CLTV
+  // (`status === 'recoverable'`) are swept, matching what the manual
+  // "Refund" button would do for each one individually.
+  private async _recoverStrandedSubmarineFunds(arkadeSwaps: ArkadeSwaps) {
+    const candidates = await arkadeSwaps.scanRecoverableSubmarineSwaps();
+    const swaps = candidates.filter(c => c.status === 'recoverable').map(c => c.swap);
+    if (swaps.length === 0) return;
+
+    await arkadeSwaps.recoverAllSubmarineFunds(swaps);
+    if (this._arkadeSwaps === arkadeSwaps) {
+      await this.fetchBalance();
+      await this.fetchTransactions();
+    }
   }
 
   private async _fetchLightningFeesAndLimits() {

--- a/tests/unit/lightning-ark-wallet.test.ts
+++ b/tests/unit/lightning-ark-wallet.test.ts
@@ -1454,3 +1454,85 @@ describe('LightningArkWallet — per-swap claim/refund + restore', () => {
     assert.strictEqual(fakeArkadeSwaps.restoreSwaps.mock.calls.length, 2);
   });
 });
+
+describe('LightningArkWallet — _recoverStrandedSubmarineFunds (#8804)', () => {
+  // SwapManager only auto-refunds a failed submarine swap while it is alive
+  // and watching it. A payment that fails while the app is backgrounded or
+  // killed is never seen live, so the locked VHTLC sats never come back on
+  // their own — the only recovery paths were the manual per-swap "Refund"
+  // button and the manual "Restore swap activity" button, both easy to miss.
+  // This sweeps scanRecoverableSubmarineSwaps()/recoverAllSubmarineFunds()
+  // once per fresh init so a plain app relaunch self-heals.
+  let w: LightningArkWallet;
+  const fakeArkadeSwaps: {
+    scanRecoverableSubmarineSwaps: jest.Mock;
+    recoverAllSubmarineFunds: jest.Mock;
+  } = {
+    scanRecoverableSubmarineSwaps: jest.fn(),
+    recoverAllSubmarineFunds: jest.fn(),
+  };
+
+  beforeEach(() => {
+    w = new LightningArkWallet();
+    w.setSecret('arkade://' + TEST_MNEMONIC);
+    fakeArkadeSwaps.scanRecoverableSubmarineSwaps.mockReset().mockResolvedValue([]);
+    fakeArkadeSwaps.recoverAllSubmarineFunds.mockReset().mockResolvedValue([]);
+    (w as any)._arkadeSwaps = fakeArkadeSwaps;
+    jest.spyOn(w, 'fetchBalance').mockResolvedValue();
+    jest.spyOn(w, 'fetchTransactions').mockResolvedValue();
+  });
+
+  it('sweeps swaps whose status is "recoverable" and refreshes balance + transaction/swap history', async () => {
+    const recoverable = { swap: { id: 's1', type: 'submarine' }, status: 'recoverable', vtxoCount: 1, amountSats: 5_000 };
+    fakeArkadeSwaps.scanRecoverableSubmarineSwaps.mockResolvedValue([recoverable]);
+
+    await (w as any)._recoverStrandedSubmarineFunds(fakeArkadeSwaps);
+
+    assert.strictEqual(fakeArkadeSwaps.recoverAllSubmarineFunds.mock.calls.length, 1);
+    assert.deepStrictEqual(fakeArkadeSwaps.recoverAllSubmarineFunds.mock.calls[0][0], [recoverable.swap]);
+    // @ts-expect-error spy
+    assert.strictEqual(w.fetchBalance.mock.calls.length, 1);
+    // @ts-expect-error spy
+    assert.strictEqual(w.fetchTransactions.mock.calls.length, 1);
+  });
+
+  it('leaves pre_cltv / already_spent / invalid_swap candidates alone and skips the refresh', async () => {
+    fakeArkadeSwaps.scanRecoverableSubmarineSwaps.mockResolvedValue([
+      { swap: { id: 's2', type: 'submarine' }, status: 'pre_cltv', vtxoCount: 1, amountSats: 1_000 },
+      { swap: { id: 's3', type: 'submarine' }, status: 'already_spent', vtxoCount: 0, amountSats: 0 },
+      { swap: { id: 's4', type: 'submarine' }, status: 'invalid_swap', vtxoCount: 0, amountSats: 0, error: 'bad script' },
+    ]);
+
+    await (w as any)._recoverStrandedSubmarineFunds(fakeArkadeSwaps);
+
+    assert.strictEqual(fakeArkadeSwaps.recoverAllSubmarineFunds.mock.calls.length, 0);
+    // @ts-expect-error spy
+    assert.strictEqual(w.fetchBalance.mock.calls.length, 0);
+    // @ts-expect-error spy
+    assert.strictEqual(w.fetchTransactions.mock.calls.length, 0);
+  });
+
+  it('does nothing when the scan finds no candidates at all', async () => {
+    await (w as any)._recoverStrandedSubmarineFunds(fakeArkadeSwaps);
+
+    assert.strictEqual(fakeArkadeSwaps.recoverAllSubmarineFunds.mock.calls.length, 0);
+    // @ts-expect-error spy
+    assert.strictEqual(w.fetchBalance.mock.calls.length, 0);
+    // @ts-expect-error spy
+    assert.strictEqual(w.fetchTransactions.mock.calls.length, 0);
+  });
+
+  it("skips the refresh if the wallet has since been re-init'd (stale arkadeSwaps ref)", async () => {
+    const recoverable = { swap: { id: 's5', type: 'submarine' }, status: 'recoverable', vtxoCount: 1, amountSats: 2_000 };
+    fakeArkadeSwaps.scanRecoverableSubmarineSwaps.mockResolvedValue([recoverable]);
+    (w as any)._arkadeSwaps = { different: true }; // simulate onDelete/re-init happening mid-scan
+
+    await (w as any)._recoverStrandedSubmarineFunds(fakeArkadeSwaps);
+
+    assert.strictEqual(fakeArkadeSwaps.recoverAllSubmarineFunds.mock.calls.length, 1, 'the sweep itself still runs');
+    // @ts-expect-error spy
+    assert.strictEqual(w.fetchBalance.mock.calls.length, 0, 'but must not touch a stale instance state');
+    // @ts-expect-error spy
+    assert.strictEqual(w.fetchTransactions.mock.calls.length, 0, 'but must not touch a stale instance state');
+  });
+});


### PR DESCRIPTION
Fixes #8804 — balance not syncing back after a few failed Lightning payments.

Turns out failed sends lock funds in an on-chain contract (VHTLC) until they're refunded, and the SDK only does that refund automatically while the app is open and actively watching the payment. If a send fails while you're backgrounded or the app got killed — pretty common, since it doesn't fail instantly — nothing ever picks it up. The only way back was a manual "restore swap activity" button most people would never know exists.

Fix: on wallet init, scan for any submarine swaps stuck in this state and sweep the funds back automatically, so just reopening the app self-heals instead of requiring the user to notice and dig for a button.