### PR TITLE
REF: dedup copy-pasted code in wallet classes

### DIFF
--- a/class/wallets/abstract-hd-electrum-wallet.ts
+++ b/class/wallets/abstract-hd-electrum-wallet.ts
@@ -6,14 +6,13 @@ import BIP32Factory, { BIP32Interface } from 'bip32';
 import * as bip39 from 'bip39';
 import * as bitcoin from 'bitcoinjs-lib';
 import { Psbt, Transaction as BTransaction } from 'bitcoinjs-lib';
-import b58 from 'bs58check';
 import { CoinSelectOutput, CoinSelectReturnInput } from 'coinselect';
 import { ECPairFactory, ECPairInterface } from 'ecpair';
 
 import * as BlueElectrum from '../../blue_modules/BlueElectrum';
 import { ElectrumHistory } from '../../blue_modules/BlueElectrum';
 import ecc from '../../blue_modules/noble_ecc';
-import { hexToUint8Array, concatUint8Arrays, uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
+import { hexToUint8Array, uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
 import { randomBytes } from '../rng';
 import { AbstractHDWallet } from './abstract-hd-wallet';
 import { CreateTransactionResult, CreateTransactionTarget, CreateTransactionUtxo, Transaction, Utxo } from './types';
@@ -265,10 +264,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     const xpub = child.toBase58();
 
     // bitcoinjs does not support zpub yet, so we just convert it from xpub
-    let data = b58.decode(xpub);
-    data = data.slice(4);
-    const concatenated = concatUint8Arrays([hexToUint8Array('04b24746'), data]);
-    this._xpub = b58.encode(concatenated);
+    this._xpub = this._xpubToZpub(xpub);
 
     return this._xpub;
   }
@@ -562,95 +558,11 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     });
   }
 
-  async _binarySearchIterationForInternalAddress(index: number) {
-    const gerenateChunkAddresses = (chunkNum: number) => {
-      const ret = [];
-      for (let c = this.gap_limit * chunkNum; c < this.gap_limit * (chunkNum + 1); c++) {
-        ret.push(this._getInternalAddressByIndex(c));
-      }
-      return ret;
-    };
-
-    let lastChunkWithUsedAddressesNum = null;
-    let lastHistoriesWithUsedAddresses = null;
-    for (let c = 0; c < Math.round(index / this.gap_limit); c++) {
-      const histories = await BlueElectrum.multiGetHistoryByAddress(gerenateChunkAddresses(c));
-      if (AbstractHDElectrumWallet._getTransactionsFromHistories(histories).length > 0) {
-        // in this particular chunk we have used addresses
-        lastChunkWithUsedAddressesNum = c;
-        lastHistoriesWithUsedAddresses = histories;
-      } else {
-        // empty chunk. no sense searching more chunks
-        break;
-      }
-    }
-
-    let lastUsedIndex = 0;
-
-    if (lastHistoriesWithUsedAddresses) {
-      // now searching for last used address in batch lastChunkWithUsedAddressesNum
-      for (
-        let c = Number(lastChunkWithUsedAddressesNum) * this.gap_limit;
-        c < Number(lastChunkWithUsedAddressesNum) * this.gap_limit + this.gap_limit;
-        c++
-      ) {
-        const address = this._getInternalAddressByIndex(c);
-        if (lastHistoriesWithUsedAddresses[address] && lastHistoriesWithUsedAddresses[address].length > 0) {
-          lastUsedIndex = Math.max(c, lastUsedIndex) + 1; // point to next, which is supposed to be unused
-        }
-      }
-    }
-
-    return lastUsedIndex;
-  }
-
-  async _binarySearchIterationForExternalAddress(index: number) {
-    const gerenateChunkAddresses = (chunkNum: number) => {
-      const ret = [];
-      for (let c = this.gap_limit * chunkNum; c < this.gap_limit * (chunkNum + 1); c++) {
-        ret.push(this._getExternalAddressByIndex(c));
-      }
-      return ret;
-    };
-
-    let lastChunkWithUsedAddressesNum = null;
-    let lastHistoriesWithUsedAddresses = null;
-    for (let c = 0; c < Math.round(index / this.gap_limit); c++) {
-      const histories = await BlueElectrum.multiGetHistoryByAddress(gerenateChunkAddresses(c));
-      if (AbstractHDElectrumWallet._getTransactionsFromHistories(histories).length > 0) {
-        // in this particular chunk we have used addresses
-        lastChunkWithUsedAddressesNum = c;
-        lastHistoriesWithUsedAddresses = histories;
-      } else {
-        // empty chunk. no sense searching more chunks
-        break;
-      }
-    }
-
-    let lastUsedIndex = 0;
-
-    if (lastHistoriesWithUsedAddresses) {
-      // now searching for last used address in batch lastChunkWithUsedAddressesNum
-      for (
-        let c = Number(lastChunkWithUsedAddressesNum) * this.gap_limit;
-        c < Number(lastChunkWithUsedAddressesNum) * this.gap_limit + this.gap_limit;
-        c++
-      ) {
-        const address = this._getExternalAddressByIndex(c);
-        if (lastHistoriesWithUsedAddresses[address] && lastHistoriesWithUsedAddresses[address].length > 0) {
-          lastUsedIndex = Math.max(c, lastUsedIndex) + 1; // point to next, which is supposed to be unused
-        }
-      }
-    }
-
-    return lastUsedIndex;
-  }
-
-  async _binarySearchIterationForBIP47Address(paymentCode: string, index: number) {
+  async _binarySearchLastUsedIndex(index: number, getAddressByIndex: (c: number) => string): Promise<number> {
     const generateChunkAddresses = (chunkNum: number) => {
       const ret = [];
       for (let c = this.gap_limit * chunkNum; c < this.gap_limit * (chunkNum + 1); c++) {
-        ret.push(this._getBIP47AddressReceive(paymentCode, c));
+        ret.push(getAddressByIndex(c));
       }
       return ret;
     };
@@ -678,7 +590,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
         c < Number(lastChunkWithUsedAddressesNum) * this.gap_limit + this.gap_limit;
         c++
       ) {
-        const address = this._getBIP47AddressReceive(paymentCode, c);
+        const address = getAddressByIndex(c);
         if (lastHistoriesWithUsedAddresses[address] && lastHistoriesWithUsedAddresses[address].length > 0) {
           lastUsedIndex = Math.max(c, lastUsedIndex) + 1; // point to next, which is supposed to be unused
         }
@@ -686,6 +598,18 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     }
 
     return lastUsedIndex;
+  }
+
+  async _binarySearchIterationForInternalAddress(index: number) {
+    return this._binarySearchLastUsedIndex(index, c => this._getInternalAddressByIndex(c));
+  }
+
+  async _binarySearchIterationForExternalAddress(index: number) {
+    return this._binarySearchLastUsedIndex(index, c => this._getExternalAddressByIndex(c));
+  }
+
+  async _binarySearchIterationForBIP47Address(paymentCode: string, index: number) {
+    return this._binarySearchLastUsedIndex(index, c => this._getBIP47AddressReceive(paymentCode, c));
   }
 
   async fetchBalance() {
@@ -1147,6 +1071,18 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     const keypairs: Record<number, ECPairInterface> = {};
     const values: Record<number, number> = {};
 
+    // this is not correct fingerprint, as we dont know real fingerprint - we got zpub with 84/0, but fingerpting
+    // should be from root. basically, fingerprint should be provided from outside  by user when importing zpub
+    let masterFingerprintBuffer: Uint8Array;
+    if (masterFingerprint) {
+      let masterFingerprintHex = Number(masterFingerprint).toString(16);
+      if (masterFingerprintHex.length < 8) masterFingerprintHex = '0' + masterFingerprintHex; // conversion without explicit zero might result in lost byte
+      const hexBuffer = hexToUint8Array(masterFingerprintHex);
+      masterFingerprintBuffer = hexBuffer.reverse();
+    } else {
+      masterFingerprintBuffer = new Uint8Array([0x00, 0x00, 0x00, 0x00]);
+    }
+
     inputs.forEach(input => {
       let keyPair;
       if (!skipSigning) {
@@ -1160,18 +1096,6 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
         // skiping signing related stuff
         if (!input.address || !this._getWifForAddress(input.address)) throw new Error('Internal error: no address or WIF to sign input');
       }
-
-      let masterFingerprintBuffer;
-      if (masterFingerprint) {
-        let masterFingerprintHex = Number(masterFingerprint).toString(16);
-        if (masterFingerprintHex.length < 8) masterFingerprintHex = '0' + masterFingerprintHex; // conversion without explicit zero might result in lost byte
-        const hexBuffer = hexToUint8Array(masterFingerprintHex);
-        masterFingerprintBuffer = hexBuffer.reverse();
-      } else {
-        masterFingerprintBuffer = new Uint8Array([0x00, 0x00, 0x00, 0x00]);
-      }
-      // this is not correct fingerprint, as we dont know real fingerprint - we got zpub with 84/0, but fingerpting
-      // should be from root. basically, fingerprint should be provided from outside  by user when importing zpub
 
       psbt = this._addPsbtInput(psbt, input, sequence, masterFingerprintBuffer);
     });
@@ -1187,19 +1111,6 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
 
       const path = this._getDerivationPathByAddress(String(output.address));
       const pubkey = this._getPubkeyByAddress(String(output.address));
-      let masterFingerprintBuffer;
-
-      if (masterFingerprint) {
-        let masterFingerprintHex = Number(masterFingerprint).toString(16);
-        if (masterFingerprintHex.length < 8) masterFingerprintHex = '0' + masterFingerprintHex; // conversion without explicit zero might result in lost byte
-        const hexBuffer = hexToUint8Array(masterFingerprintHex);
-        masterFingerprintBuffer = hexBuffer.reverse();
-      } else {
-        masterFingerprintBuffer = new Uint8Array([0x00, 0x00, 0x00, 0x00]);
-      }
-
-      // this is not correct fingerprint, as we dont know realfingerprint - we got zpub with 84/0, but fingerpting
-      // should be from root. basically, fingerprint should be provided from outside  by user when importing zpub
 
       if (output.address?.startsWith('PM')) {
         // ok its BIP47 payment code, so we need to unwrap a joint address for the receiver and use it instead:

--- a/class/wallets/abstract-hd-wallet.ts
+++ b/class/wallets/abstract-hd-wallet.ts
@@ -148,33 +148,7 @@ export class AbstractHDWallet extends LegacyWallet {
    */
   async getAddressAsync(): Promise<string> {
     // looking for free external address
-    let freeAddress = '';
-    let c;
-    for (c = 0; c < this.gap_limit + 1; c++) {
-      if (this.next_free_address_index + c < 0) continue;
-      const address = this._getExternalAddressByIndex(this.next_free_address_index + c);
-      this.external_addresses_cache[this.next_free_address_index + c] = address; // updating cache just for any case
-      let txs = [];
-      try {
-        txs = await BlueElectrum.getTransactionsByAddress(address);
-      } catch (Err: any) {
-        console.warn('BlueElectrum.getTransactionsByAddress()', Err.message);
-      }
-      if (txs.length === 0) {
-        // found free address
-        freeAddress = address;
-        this.next_free_address_index += c; // now points to _this one_
-        break;
-      }
-    }
-
-    if (!freeAddress) {
-      // could not find in cycle above, give up
-      freeAddress = this._getExternalAddressByIndex(this.next_free_address_index + c); // we didnt check this one, maybe its free
-      this.next_free_address_index += c; // now points to this one
-    }
-    this._address = freeAddress;
-    return freeAddress;
+    return this._getNextFreeAddress(false);
   }
 
   /**
@@ -186,12 +160,21 @@ export class AbstractHDWallet extends LegacyWallet {
    */
   async getChangeAddressAsync(): Promise<string> {
     // looking for free internal address
-    let freeAddress = '';
+    return this._getNextFreeAddress(true);
+  }
+
+  async _getNextFreeAddress(internal: boolean): Promise<string> {
+    const startIndex = internal ? this.next_free_change_address_index : this.next_free_address_index;
+    const cache = internal ? this.internal_addresses_cache : this.external_addresses_cache;
+    const getAddressByIndex = internal
+      ? (index: number) => this._getInternalAddressByIndex(index)
+      : (index: number) => this._getExternalAddressByIndex(index);
+
     let c;
     for (c = 0; c < this.gap_limit + 1; c++) {
-      if (this.next_free_change_address_index + c < 0) continue;
-      const address = this._getInternalAddressByIndex(this.next_free_change_address_index + c);
-      this.internal_addresses_cache[this.next_free_change_address_index + c] = address; // updating cache just for any case
+      if (startIndex + c < 0) continue;
+      const address = getAddressByIndex(startIndex + c);
+      cache[startIndex + c] = address; // updating cache just for any case
       let txs = [];
       try {
         txs = await BlueElectrum.getTransactionsByAddress(address);
@@ -200,16 +183,17 @@ export class AbstractHDWallet extends LegacyWallet {
       }
       if (txs.length === 0) {
         // found free address
-        freeAddress = address;
-        this.next_free_change_address_index += c; // now points to _this one_
         break;
       }
     }
 
-    if (!freeAddress) {
-      // could not find in cycle above, give up
-      freeAddress = this._getInternalAddressByIndex(this.next_free_change_address_index + c); // we didnt check this one, maybe its free
-      this.next_free_change_address_index += c; // now points to this one
+    // if the loop found no free address we give up and take the first unchecked one — maybe its free
+    const freeAddress = getAddressByIndex(startIndex + c);
+    // now points to _this one_
+    if (internal) {
+      this.next_free_change_address_index = startIndex + c;
+    } else {
+      this.next_free_address_index = startIndex + c;
     }
     this._address = freeAddress;
     return freeAddress;

--- a/class/wallets/hd-aezeed-wallet.ts
+++ b/class/wallets/hd-aezeed-wallet.ts
@@ -1,10 +1,9 @@
 import { CipherSeed } from 'aezeed';
 import BIP32Factory from 'bip32';
 import * as bitcoin from 'bitcoinjs-lib';
-import b58 from 'bs58check';
 
 import ecc from '../../blue_modules/noble_ecc';
-import { concatUint8Arrays, hexToUint8Array, uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
+import { hexToUint8Array, uint8ArrayToHex } from '../../blue_modules/uint8array-extras';
 import { AbstractHDElectrumWallet } from './abstract-hd-electrum-wallet';
 
 const bip32 = BIP32Factory(ecc);
@@ -55,10 +54,7 @@ export class HDAezeedWallet extends AbstractHDElectrumWallet {
     const xpub = child.toBase58();
 
     // bitcoinjs does not support zpub yet, so we just convert it from xpub
-    let data = b58.decode(xpub);
-    data = data.slice(4);
-    const concatenated = concatUint8Arrays([hexToUint8Array('04b24746'), data]);
-    this._xpub = b58.encode(concatenated);
+    this._xpub = this._xpubToZpub(xpub);
 
     return this._xpub;
   }

--- a/class/wallets/hd-segwit-electrum-seed-p2wpkh-wallet.ts
+++ b/class/wallets/hd-segwit-electrum-seed-p2wpkh-wallet.ts
@@ -1,10 +1,8 @@
 import BIP32Factory from 'bip32';
 import * as bitcoin from 'bitcoinjs-lib';
-import b58 from 'bs58check';
 import * as mn from 'electrum-mnemonic';
 
 import ecc from '../../blue_modules/noble_ecc';
-import { concatUint8Arrays, hexToUint8Array } from '../../blue_modules/uint8array-extras';
 import { HDSegwitBech32Wallet } from './hd-segwit-bech32-wallet';
 
 const bip32 = BIP32Factory(ecc);
@@ -52,10 +50,7 @@ export class HDSegwitElectrumSeedP2WPKHWallet extends HDSegwitBech32Wallet {
     const xpub = root.derivePath("m/0'").neutered().toBase58();
 
     // bitcoinjs does not support zpub yet, so we just convert it from xpub
-    let data = b58.decode(xpub);
-    data = data.slice(4);
-    const concatenated = concatUint8Arrays([hexToUint8Array('04b24746'), data]);
-    this._xpub = b58.encode(concatenated);
+    this._xpub = this._xpubToZpub(xpub);
 
     return this._xpub;
   }

--- a/class/wallets/hd-segwit-p2sh-wallet.ts
+++ b/class/wallets/hd-segwit-p2sh-wallet.ts
@@ -1,11 +1,9 @@
 import BIP32Factory, { BIP32Interface } from 'bip32';
 import * as bitcoin from 'bitcoinjs-lib';
 import { Psbt } from 'bitcoinjs-lib';
-import b58 from 'bs58check';
 import { CoinSelectReturnInput } from 'coinselect';
 
 import ecc from '../../blue_modules/noble_ecc';
-import { concatUint8Arrays, hexToUint8Array } from '../../blue_modules/uint8array-extras';
 import { AbstractHDElectrumWallet } from './abstract-hd-electrum-wallet';
 
 const bip32 = BIP32Factory(ecc);
@@ -71,10 +69,7 @@ export class HDSegwitP2SHWallet extends AbstractHDElectrumWallet {
     const xpub = child.toBase58();
 
     // bitcoinjs does not support ypub yet, so we just convert it from xpub
-    let data = b58.decode(xpub);
-    data = data.slice(4);
-    const concatenated = concatUint8Arrays([hexToUint8Array('049d7cb2'), data]);
-    this._xpub = b58.encode(concatenated);
+    this._xpub = this._xpubToYpub(xpub);
 
     return this._xpub;
   }

--- a/class/wallets/multisig-hd-wallet.ts
+++ b/class/wallets/multisig-hd-wallet.ts
@@ -735,22 +735,23 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
     throw new Error('Not applicable in multisig');
   }
 
-  _addPsbtInput(psbt: Psbt, input: CoinSelectReturnInput, sequence: number, masterFingerprintBuffer?: Uint8Array) {
-    const bip32Derivation = []; // array per each pubkey thats gona be used
+  /**
+   * Builds bip32Derivation entries (and the corresponding pubkeys) for every cosigner for a given address
+   * of this wallet. Used both for inputs and for change outputs.
+   */
+  _getBip32DerivationsByAddress(address: string) {
+    const bip32Derivation: TBip32Derivation = []; // array per each pubkey thats gona be used
     const pubkeys = [];
     for (const [cosignerIndex] of this._cosigners.entries()) {
-      if (!input.address) {
-        throw new Error('Could not find address in input');
-      }
       const path = this._getDerivationPathByAddressWithCustomPath(
-        input.address,
+        address,
         this._cosignersCustomPaths[cosignerIndex] || this._derivationPath,
       );
       // ^^ path resembles _custom path_, if provided by user during setup, otherwise default path for wallet type gona be used
       const masterFingerprint = hexToUint8Array(this._cosignersFingerprints[cosignerIndex]);
 
       if (!path) {
-        throw new Error('Could not find derivation path for address ' + input.address);
+        throw new Error('Could not find derivation path for address ' + address);
       }
 
       const xpub = this._getXpubFromCosignerIndex(cosignerIndex);
@@ -768,6 +769,15 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
         pubkey,
       });
     }
+
+    return { bip32Derivation, pubkeys };
+  }
+
+  _addPsbtInput(psbt: Psbt, input: CoinSelectReturnInput, sequence: number, masterFingerprintBuffer?: Uint8Array) {
+    if (!input.address) {
+      throw new Error('Could not find address in input');
+    }
+    const { bip32Derivation, pubkeys } = this._getBip32DerivationsByAddress(input.address);
 
     if (!input.txhex) {
       throw new Error('Electrum server didnt provide txhex to properly create PSBT transaction');
@@ -848,35 +858,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
   }
 
   _getOutputDataForChange(address: string): TOutputData {
-    const bip32Derivation: TBip32Derivation = []; // array per each pubkey thats gona be used
-    const pubkeys = [];
-    for (const [cosignerIndex] of this._cosigners.entries()) {
-      const path = this._getDerivationPathByAddressWithCustomPath(
-        address,
-        this._cosignersCustomPaths[cosignerIndex] || this._derivationPath,
-      );
-      // ^^ path resembles _custom path_, if provided by user during setup, otherwise default path for wallet type gona be used
-      const masterFingerprint = hexToUint8Array(this._cosignersFingerprints[cosignerIndex]);
-
-      if (!path) {
-        throw new Error('Could not find derivation path for address ' + address);
-      }
-
-      const xpub = this._getXpubFromCosignerIndex(cosignerIndex);
-      const hdNode0 = bip32.fromBase58(xpub);
-      const splt = path.split('/');
-      const internal = +splt[splt.length - 2];
-      const index = +splt[splt.length - 1];
-      const _node0 = hdNode0.derive(internal);
-      const pubkey = _node0.derive(index).publicKey;
-      pubkeys.push(pubkey);
-
-      bip32Derivation.push({
-        masterFingerprint,
-        path,
-        pubkey,
-      });
-    }
+    const { bip32Derivation, pubkeys } = this._getBip32DerivationsByAddress(address);
 
     if (this.isLegacy()) {
       const p2sh = bitcoin.payments.p2ms({ m: this._m, pubkeys: MultisigHDWallet.sortBuffers(pubkeys) });


### PR DESCRIPTION
Same code copy-pasted many times. Now one helper, thin wrappers. Behavior same.

- abstract-hd-electrum-wallet: 3 identical binary-search-last-used-index methods → one `_binarySearchLastUsedIndex(index, getAddressByIndex)`
- abstract-hd-electrum-wallet: inline xpub→zpub bytes surgery → existing `_xpubToZpub`. Same fix in hd-segwit-p2sh (`_xpubToYpub`), hd-aezeed, hd-segwit-electrum-seed. Version-byte constants now live in one place
- abstract-hd-electrum-wallet: `masterFingerprintBuffer` block was duplicated inside inputs loop AND outputs loop → computed once before both
- abstract-hd-wallet: `getAddressAsync` / `getChangeAddressAsync` mirror 30-line loops → one `_getNextFreeAddress(internal)`
- multisig-hd-wallet: cosigner bip32Derivation loop copy-pasted in `_addPsbtInput` and `_getOutputDataForChange` → one `_getBip32DerivationsByAddress`

This will be a series of 4 PRs so it is easier to read 