### PR TITLE
REF: cut wasted work in wallet hot paths

### DIFF
--- a/class/wallets/abstract-hd-electrum-wallet.ts
+++ b/class/wallets/abstract-hd-electrum-wallet.ts
@@ -134,7 +134,8 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     for (const pc of this._receive_payment_codes) {
       ret += this._getBalancesByPaymentCodeIndex(pc).c;
     }
-    return ret + (this.getUnconfirmedBalance() < 0 ? this.getUnconfirmedBalance() : 0);
+    const unconfirmed = this.getUnconfirmedBalance();
+    return ret + (unconfirmed < 0 ? unconfirmed : 0);
   }
 
   /**
@@ -615,13 +616,19 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
   async fetchBalance() {
     try {
       if (this.next_free_change_address_index === 0 && this.next_free_address_index === 0) {
-        // doing binary search for last used address:
-        this.next_free_change_address_index = await this._binarySearchIterationForInternalAddress(1000);
-        this.next_free_address_index = await this._binarySearchIterationForExternalAddress(1000);
+        // doing binary search for last used address; chains are independent so we scan them in parallel:
+        const [nextFreeChange, nextFreeExternal] = await Promise.all([
+          this._binarySearchIterationForInternalAddress(1000),
+          this._binarySearchIterationForExternalAddress(1000),
+        ]);
+        this.next_free_change_address_index = nextFreeChange;
+        this.next_free_address_index = nextFreeExternal;
         if (this._receive_payment_codes) {
-          for (const pc of this._receive_payment_codes) {
-            this._next_free_payment_code_address_index_receive[pc] = await this._binarySearchIterationForBIP47Address(pc, 1000);
-          }
+          await Promise.all(
+            this._receive_payment_codes.map(async pc => {
+              this._next_free_payment_code_address_index_receive[pc] = await this._binarySearchIterationForBIP47Address(pc, 1000);
+            }),
+          );
         }
       } // end rescanning fresh wallet
 
@@ -884,7 +891,8 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
       }
     }
 
-    for (const tx of this.getTransactions()) {
+    const txs = this.getTransactions();
+    for (const tx of txs) {
       for (const output of tx.outputs) {
         let address: string | false = false;
         if (output.scriptPubKey && output.scriptPubKey.addresses && output.scriptPubKey.addresses[0]) {
@@ -908,18 +916,16 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     if (returnSpentUtxoAsWell) return utxos;
 
     // got all utxos we ever had. lets filter out the ones that are spent:
-    const txs = this.getTransactions();
+    const spentOutpoints = new Set<string>();
+    for (const tx of txs) {
+      for (const input of tx.inputs) {
+        spentOutpoints.add(input.txid + ':' + input.vout);
+      }
+    }
+
     const ret = [];
     for (const utxo of utxos) {
-      let spent = false;
-      for (const tx of txs) {
-        for (const input of tx.inputs) {
-          if (input.txid === utxo.txid && input.vout === utxo.vout) spent = true;
-          // utxo we got previously was actually spent right here ^^
-        }
-      }
-
-      if (!spent) {
+      if (!spentOutpoints.has(utxo.txid + ':' + utxo.vout)) {
         // filling WIFs only for legit unspent UTXO, as it is a slow operation
         utxo.wif = this._getWifForAddress(utxo.address);
         ret.push(utxo);

--- a/class/wallets/hd-legacy-p2pkh-wallet.ts
+++ b/class/wallets/hd-legacy-p2pkh-wallet.ts
@@ -71,12 +71,13 @@ export class HDLegacyP2PKHWallet extends AbstractHDElectrumWallet {
   async fetchUtxo(): Promise<void> {
     await super.fetchUtxo();
     // now we need to fetch txhash for each input as required by PSBT
+    const utxos = this.getUtxo();
     const txhexes = await BlueElectrum.multiGetTransactionByTxid(
-      this.getUtxo().map(x => x.txid),
+      utxos.map(x => x.txid),
       false,
     );
 
-    for (const u of this.getUtxo()) {
+    for (const u of utxos) {
       if (txhexes[u.txid]) u.txhex = txhexes[u.txid];
     }
   }

--- a/class/wallets/legacy-wallet.ts
+++ b/class/wallets/legacy-wallet.ts
@@ -56,8 +56,11 @@ export class LegacyWallet extends AbstractWallet {
    * @return {boolean}
    */
   timeToRefreshTransaction(): boolean {
+    if (this._lastTxFetch >= +new Date() - 5 * 60 * 1000) {
+      return false;
+    }
     for (const tx of this.getTransactions()) {
-      if ((tx.confirmations ?? 0) < 7 && this._lastTxFetch < +new Date() - 5 * 60 * 1000) {
+      if ((tx.confirmations ?? 0) < 7) {
         return true;
       }
     }
@@ -512,11 +515,12 @@ export class LegacyWallet extends AbstractWallet {
   }
 
   getLatestTransactionTime(): string | 0 {
-    if (this.getTransactions().length === 0) {
+    const transactions = this.getTransactions();
+    if (transactions.length === 0) {
       return 0;
     }
     let max = 0;
-    for (const tx of this.getTransactions()) {
+    for (const tx of transactions) {
       max = Math.max(tx.timestamp ? tx.timestamp * 1000 : 0, max);
     }
     return new Date(max).toString();

--- a/class/wallets/lightning-custodian-wallet.ts
+++ b/class/wallets/lightning-custodian-wallet.ts
@@ -159,15 +159,8 @@ export class LightningCustodianWallet extends LegacyWallet {
       // but the ones received later should overwrite older ones
 
       for (const oldInvoice of this.user_invoices_raw) {
-        // iterate all OLD invoices
-        let found = false;
-        for (const newInvoice of json) {
-          // iterate all NEW invoices
-          if (newInvoice.payment_request === oldInvoice.payment_request) found = true;
-        }
-
-        if (!found) {
-          // if old invoice is not found in NEW array, we simply add it:
+        // if old invoice is not found in NEW array, we simply add it:
+        if (!json.some((newInvoice: { payment_request: string }) => newInvoice.payment_request === oldInvoice.payment_request)) {
           json.push(oldInvoice);
         }
       }

--- a/class/wallets/multisig-hd-wallet.ts
+++ b/class/wallets/multisig-hd-wallet.ts
@@ -88,6 +88,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
   private _isWrappedSegwit: boolean = false;
   private _isLegacy: boolean = false;
   private _nodes: Record<number, Record<number, BIP32Interface>> = {}; // nodeIndex -> cosignerIndex -> BIP32Interface
+  private _cosignerXpubCache: Record<string, string> = {}; // cosigner+path+passphrase -> xpub, since deriving xpub from seed is expensive
   public _derivationPath: string = '';
   public gap_limit: number = 20;
 
@@ -276,6 +277,9 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
       throw new Error('Invalid cosigner index or cosigners not initialized');
     }
     let cosigner: string = this._cosigners[index];
+    const cacheKey =
+      cosigner + '|' + (this._cosignersCustomPaths[index] || this._derivationPath) + '|' + (this._cosignersPassphrases[index] ?? '');
+    if (this._cosignerXpubCache[cacheKey]) return this._cosignerXpubCache[cacheKey]; // cache hit
     if (MultisigHDWallet.isXprvString(cosigner)) cosigner = MultisigHDWallet.convertXprvToXpub(cosigner);
     let xpub = cosigner;
     if (!MultisigHDWallet.isXpubString(cosigner)) {
@@ -285,7 +289,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
         this._cosignersPassphrases[index],
       );
     }
-    return this._zpubToXpub(xpub);
+    return (this._cosignerXpubCache[cacheKey] = this._zpubToXpub(xpub));
   }
 
   _getExternalAddressByIndex(index: number) {
@@ -999,24 +1003,26 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
     });
 
     if (!skipSigning) {
-      for (let cc = 0; cc < c; cc++) {
-        let signaturesMade = 0;
-        for (const [cosignerIndex, cosigner] of this._cosigners.entries()) {
-          if (MultisigHDWallet.isXpubString(cosigner)) continue;
-          // ok this is a mnemonic, lets try to sign
-          if (signaturesMade >= this.getM()) {
-            // dont sign more than we need, otherwise there will be "Too many signatures" error
-            continue;
-          }
-          const passphrase = this._cosignersPassphrases[cosignerIndex];
-          let seed = bip39.mnemonicToSeedSync(cosigner, passphrase);
-          if (cosigner.startsWith(ELECTRUM_SEED_PREFIX)) {
-            seed = MultisigHDWallet.convertElectrumMnemonicToSeed(cosigner, passphrase);
-          }
+      // deriving a seed is an expensive pbkdf2 operation, so we prepare each signing cosigner's hd root
+      // only once and reuse it for every input
+      const hdRoots: BIP32Interface[] = [];
+      for (const [cosignerIndex, cosigner] of this._cosigners.entries()) {
+        if (MultisigHDWallet.isXpubString(cosigner)) continue;
+        // ok this is a mnemonic, lets try to sign
+        if (hdRoots.length >= this.getM()) {
+          // dont sign more than we need, otherwise there will be "Too many signatures" error
+          continue;
+        }
+        const passphrase = this._cosignersPassphrases[cosignerIndex];
+        const seed = cosigner.startsWith(ELECTRUM_SEED_PREFIX)
+          ? MultisigHDWallet.convertElectrumMnemonicToSeed(cosigner, passphrase)
+          : bip39.mnemonicToSeedSync(cosigner, passphrase);
+        hdRoots.push(bip32.fromSeed(seed));
+      }
 
-          const hdRoot = bip32.fromSeed(seed);
+      for (let cc = 0; cc < c; cc++) {
+        for (const hdRoot of hdRoots) {
           psbt.signInputHD(cc, hdRoot);
-          signaturesMade++;
         }
       }
     }
@@ -1053,6 +1059,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
     // deleting structures that cant be serialized
     // @ts-ignore I dont want to make it optional
     delete this._nodes;
+    this._cosignerXpubCache = {}; // no need to persist the cache
   }
 
   static isPathValid(path: string): boolean {
@@ -1075,18 +1082,17 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
   async fetchUtxo() {
     await super.fetchUtxo();
     // now we need to fetch txhash for each input as required by PSBT
+    const utxos = this.getUtxo(true);
     const txhexes = await BlueElectrum.multiGetTransactionByTxid(
-      this.getUtxo(true).map(x => x.txid),
+      utxos.map(x => x.txid),
       false,
     );
 
-    const newUtxos = [];
-    for (const u of this.getUtxo(true)) {
+    for (const u of utxos) {
       if (txhexes[u.txid]) u.txhex = txhexes[u.txid];
-      newUtxos.push(u);
     }
 
-    this._utxo = newUtxos;
+    this._utxo = utxos;
   }
 
   getID() {
@@ -1146,22 +1152,28 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
    * and returns Transaction (ready to extract hex)
    */
   cosignPsbt(psbt: Psbt): { tx: Transaction | false } {
+    // deriving a seed is an expensive pbkdf2 operation, so we prepare each signing cosigner's hd root
+    // only once and reuse it for every input
+    const hdRoots: { cosignerIndex: number; hdRoot: BIP32Interface }[] = [];
+    for (const [cosignerIndex, cosigner] of this._cosigners.entries()) {
+      if (MultisigHDWallet.isXpubString(cosigner)) continue;
+
+      let hdRoot;
+      if (MultisigHDWallet.isXprvString(cosigner)) {
+        const xprv = MultisigHDWallet.convertMultisigXprvToRegularXprv(cosigner);
+        hdRoot = bip32.fromBase58(xprv);
+      } else {
+        const passphrase = this._cosignersPassphrases[cosignerIndex];
+        const seed = cosigner.startsWith(ELECTRUM_SEED_PREFIX)
+          ? MultisigHDWallet.convertElectrumMnemonicToSeed(cosigner, passphrase)
+          : bip39.mnemonicToSeedSync(cosigner, passphrase);
+        hdRoot = bip32.fromSeed(seed);
+      }
+      hdRoots.push({ cosignerIndex, hdRoot });
+    }
+
     for (let cc = 0; cc < psbt.inputCount; cc++) {
-      for (const [cosignerIndex, cosigner] of this._cosigners.entries()) {
-        if (MultisigHDWallet.isXpubString(cosigner)) continue;
-
-        let hdRoot;
-        if (MultisigHDWallet.isXprvString(cosigner)) {
-          const xprv = MultisigHDWallet.convertMultisigXprvToRegularXprv(cosigner);
-          hdRoot = bip32.fromBase58(xprv);
-        } else {
-          const passphrase = this._cosignersPassphrases[cosignerIndex];
-          const seed = cosigner.startsWith(ELECTRUM_SEED_PREFIX)
-            ? MultisigHDWallet.convertElectrumMnemonicToSeed(cosigner, passphrase)
-            : bip39.mnemonicToSeedSync(cosigner, passphrase);
-          hdRoot = bip32.fromSeed(seed);
-        }
-
+      for (const { cosignerIndex, hdRoot } of hdRoots) {
         try {
           psbt.signInputHD(cc, hdRoot);
         } catch (_) {} // protects agains duplicate cosignings


### PR DESCRIPTION
Stacked on #8828. Same results, less CPU and fewer round-trips.

- multisig: pbkdf2 (mnemonicToSeedSync, ~50-200ms each) ran per input × per cosigner in `createTransaction` and `cosignPsbt`. Now hd root derived once per cosigner. 10 inputs × 2 cosigners: was ~40 pbkdf2 runs, now 2
- multisig: `_getXpubFromCosignerIndex` memoized (was pbkdf2 per call for seed cosigners; called per input and per change output). Cache key = cosigner|path|passphrase, cleared in `prepareForSerialization`
- multisig: electrum-seed cosigners no longer run useless bip39 pbkdf2 before overwriting the result
- multisig + hd-legacy-p2pkh: `fetchUtxo` called `getUtxo()` twice back to back → once
- abstract-hd-electrum: fresh-wallet import scanned internal, then external, then each payment code sequentially → `Promise.all` (breadwallet already did this)
- abstract-hd-electrum: `getDerivedUtxoFromOurTransaction` called `getTransactions()` twice + O(utxos × txs × inputs) spent-scan → one call + Set of outpoints
- abstract-hd-electrum: `getBalance()` computed `getUnconfirmedBalance()` twice
- legacy: `timeToRefreshTransaction` ran full `getTransactions()` even when the 5-min timestamp check alone decides → cheap check first. `getLatestTransactionTime` called `getTransactions()` twice
- lightning-custodian: O(n²) invoice merge → `.some()`

tsc clean, eslint clean, 515 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)