### PR TITLE
DEL: dead code in wallet classes

### DIFF
--- a/class/wallets/abstract-hd-electrum-wallet.ts
+++ b/class/wallets/abstract-hd-electrum-wallet.ts
@@ -1075,7 +1075,6 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
     let psbt = new bitcoin.Psbt();
     let c = 0;
     const keypairs: Record<number, ECPairInterface> = {};
-    const values: Record<number, number> = {};
 
     // this is not correct fingerprint, as we dont know real fingerprint - we got zpub with 84/0, but fingerpting
     // should be from root. basically, fingerprint should be provided from outside  by user when importing zpub
@@ -1096,7 +1095,6 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
         keyPair = ECPair.fromWIF(this._getWifForAddress(String(input.address)));
         keypairs[c] = keyPair;
       }
-      values[c] = input.value;
       c++;
       if (!skipSigning) {
         // skiping signing related stuff

--- a/class/wallets/abstract-hd-wallet.ts
+++ b/class/wallets/abstract-hd-wallet.ts
@@ -26,7 +26,6 @@ export class AbstractHDWallet extends LegacyWallet {
   internal_addresses_cache: Record<number, string>;
   external_addresses_cache: Record<number, string>;
   _xpub: string;
-  usedAddresses: string[];
   _address_to_wif_cache: Record<string, string>;
   gap_limit: number;
   passphrase?: string;
@@ -41,7 +40,6 @@ export class AbstractHDWallet extends LegacyWallet {
     this.internal_addresses_cache = {}; // index => address
     this.external_addresses_cache = {}; // index => address
     this._xpub = ''; // cache
-    this.usedAddresses = [];
     this._address_to_wif_cache = {};
     this.gap_limit = 20;
     this._derivationPath = Constructor.derivationPath;

--- a/class/wallets/legacy-wallet.ts
+++ b/class/wallets/legacy-wallet.ts
@@ -462,7 +462,6 @@ export class LegacyWallet extends AbstractWallet {
     sequence = sequence || 0xffffffff; // disable RBF by default
     const psbt = new bitcoin.Psbt();
     let c = 0;
-    const values: Record<number, number> = {};
     let keyPair: Signer | null = null;
 
     if (!skipSigning) {
@@ -471,7 +470,6 @@ export class LegacyWallet extends AbstractWallet {
     }
 
     inputs.forEach(input => {
-      values[c] = input.value;
       c++;
 
       if (!input.txhex) throw new Error('UTXO is missing txhex of the input, which is required by PSBT for non-segwit input');

--- a/class/wallets/lightning-ark-wallet.ts
+++ b/class/wallets/lightning-ark-wallet.ts
@@ -649,10 +649,6 @@ export class LightningArkWallet extends LightningCustodianWallet {
 
     const invoiceDetails = decodeInvoice(invoice);
 
-    console.log('Invoice amount:', invoiceDetails.amountSats, 'sats');
-    console.log('Description:', invoiceDetails.description);
-    console.log('Payment Hash:', invoiceDetails.paymentHash);
-
     assert(invoiceDetails.amountSats > this._limitMin, `Minimum you can send is ${this._limitMin} sat`);
     assert(invoiceDetails.amountSats < this._limitMax, `Maximum you can is ${this._limitMax} sat`);
 
@@ -663,11 +659,6 @@ export class LightningArkWallet extends LightningCustodianWallet {
       payment_hash: invoiceDetails.paymentHash,
       payment_request: invoice,
     };
-
-    console.log('Payment successful!');
-    console.log('Amount:', paymentResult.amount);
-    console.log('Preimage:', paymentResult.preimage);
-    console.log('Transaction ID:', paymentResult.txid);
   }
 
   /**
@@ -710,12 +701,6 @@ export class LightningArkWallet extends LightningCustodianWallet {
       amount: amt + serviceFee,
       description: memo,
     });
-
-    console.log('Expiry (seconds):', result.expiry);
-    console.log('Lightning Invoice:', result.invoice);
-    console.log('Payment Hash:', result.paymentHash);
-    console.log('Pending swap', result.pendingSwap);
-    console.log('Preimage', result.preimage);
 
     registerArkPaymentPush(result.paymentHash, memo, result.pendingSwap); // fire-and-forget, never throws
 

--- a/class/wallets/lightning-custodian-wallet.ts
+++ b/class/wallets/lightning-custodian-wallet.ts
@@ -41,10 +41,6 @@ export class LightningCustodianWallet extends LegacyWallet {
     return this.baseURI;
   }
 
-  allowSend() {
-    return true;
-  }
-
   getAddress(): string | false {
     if (this.refill_addressess.length > 0) {
       return this.refill_addressess[0];
@@ -55,10 +51,6 @@ export class LightningCustodianWallet extends LegacyWallet {
 
   getSecret() {
     return this.secret + '@' + this.baseURI;
-  }
-
-  timeToRefreshBalance() {
-    return (+new Date() - this._lastBalanceFetch) / 1000 > 300; // 5 min
   }
 
   timeToRefreshTransaction() {
@@ -567,10 +559,6 @@ export class LightningCustodianWallet extends LegacyWallet {
       throw new Error('API error: ' + json.message + ' (code ' + json.code + ')');
     }
 
-    return true;
-  }
-
-  allowReceive() {
     return true;
   }
 

--- a/class/wallets/multisig-hd-wallet.ts
+++ b/class/wallets/multisig-hd-wallet.ts
@@ -398,18 +398,6 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
     return xpub;
   }
 
-  convertXprvToMultisignatureXprv(xpub: string): string {
-    let data = b58.decode(xpub);
-    data = data.slice(4);
-    if (this.isNativeSegwit()) {
-      return b58.encode(concatUint8Arrays([hexToUint8Array('02aa7a99'), data]));
-    } else if (this.isWrappedSegwit()) {
-      return b58.encode(concatUint8Arrays([hexToUint8Array('0295b005'), data]));
-    }
-
-    return xpub;
-  }
-
   static isXpubString(xpub: string): boolean {
     return ['xpub', 'ypub', 'zpub', 'Ypub', 'Zpub'].includes(xpub.substring(0, 4));
   }
@@ -1266,13 +1254,6 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
     this._cosignersPassphrases = this._cosignersPassphrases.filter((el, index) => {
       return index !== foundIndex;
     });
-
-    /* const newCosigners = [];
-    for (let c = 0; c < this._cosignersFingerprints.length; c++) {
-      if (c !== index)  newCosigners.push(this._cosignersFingerprints[c]);
-    } */
-
-    // this._cosignersFingerprints = newCosigners;
   }
 
   getFormat() {

--- a/class/wallets/segwit-bech32-wallet.ts
+++ b/class/wallets/segwit-bech32-wallet.ts
@@ -86,11 +86,9 @@ export class SegwitBech32Wallet extends LegacyWallet {
     sequence = sequence || 0xffffffff; // disable RBF by default
     const psbt = new bitcoin.Psbt();
     let c = 0;
-    const values: Record<number, number> = {};
     const keyPair = ECPair.fromWIF(this.secret);
 
     inputs.forEach(input => {
-      values[c] = input.value;
       c++;
 
       const pubkey = keyPair.publicKey;
@@ -139,10 +137,6 @@ export class SegwitBech32Wallet extends LegacyWallet {
   }
 
   allowSend() {
-    return true;
-  }
-
-  allowSendMax() {
     return true;
   }
 

--- a/class/wallets/segwit-p2sh-wallet.ts
+++ b/class/wallets/segwit-p2sh-wallet.ts
@@ -104,11 +104,9 @@ export class SegwitP2SHWallet extends LegacyWallet {
     sequence = sequence || 0xffffffff; // disable RBF by default
     const psbt = new bitcoin.Psbt();
     let c = 0;
-    const values: Record<number, number> = {};
     const keyPair = ECPair.fromWIF(this.secret);
 
     inputs.forEach(input => {
-      values[c] = input.value;
       c++;
 
       const pubkey = keyPair.publicKey;
@@ -156,10 +154,6 @@ export class SegwitP2SHWallet extends LegacyWallet {
       tx = psbt.finalizeAllInputs().extractTransaction();
     }
     return { tx, inputs, outputs, fee, psbt };
-  }
-
-  allowSendMax() {
-    return true;
   }
 
   isSegwit() {

--- a/class/wallets/taproot-wallet.ts
+++ b/class/wallets/taproot-wallet.ts
@@ -37,10 +37,6 @@ export class TaprootWallet extends SegwitBech32Wallet {
     return true;
   }
 
-  allowSendMax() {
-    return true;
-  }
-
   isSegwit() {
     return true;
   }


### PR DESCRIPTION
Stacked on #8829. Everything here verified unused by repo-wide grep. Delete only.

- `allowSendMax()` in segwit-bech32, segwit-p2sh, taproot — zero call sites, no base-class declaration
- `convertXprvToMultisignatureXprv()` in multisig — zero call sites
- `usedAddresses` field in abstract-hd-wallet — declared, initialized, never read or written
- write-only `values` record in `createTransaction` of legacy, segwit-bech32, segwit-p2sh, abstract-hd-electrum
- `allowSend()` / `allowReceive()` / `timeToRefreshBalance()` overrides in lightning-custodian — identical to inherited (base returns true for both allow*; LegacyWallet timeToRefreshBalance same 5-min check). Note: inherited check is `>=` vs old `>` — differs only at the exact millisecond
- commented-out legacy block in multisig `deleteCosigner`
- leftover debug `console.log` blocks in lightning-ark `payInvoice`/`addInvoice`

tsc clean, eslint clean, 515 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)