### PR TITLE
REF: small wallet cleanups

### DIFF
--- a/class/wallets/abstract-wallet.ts
+++ b/class/wallets/abstract-wallet.ts
@@ -124,14 +124,13 @@ export class AbstractWallet {
    * @returns {number} Available to spend amount, int, in sats
    */
   getBalance(): number {
-    return this.balance + (this.getUnconfirmedBalance() < 0 ? this.getUnconfirmedBalance() : 0);
+    const unconfirmed = this.getUnconfirmedBalance();
+    return this.balance + (unconfirmed < 0 ? unconfirmed : 0);
   }
 
   getPreferredBalanceUnit(): BitcoinUnit {
-    for (const value of Object.values(BitcoinUnit)) {
-      if (value === this.preferredBalanceUnit) {
-        return this.preferredBalanceUnit;
-      }
+    if (Object.values(BitcoinUnit).includes(this.preferredBalanceUnit)) {
+      return this.preferredBalanceUnit;
     }
     return BitcoinUnit.BTC;
   }
@@ -418,11 +417,11 @@ export class AbstractWallet {
   }
 
   getAddressAsync(): Promise<string | false | undefined> {
-    return new Promise(resolve => resolve(this.getAddress()));
+    return Promise.resolve(this.getAddress());
   }
 
   async getChangeAddressAsync(): Promise<string | false | undefined> {
-    return new Promise(resolve => resolve(this.getAddress()));
+    return Promise.resolve(this.getAddress());
   }
 
   useWithHardwareWalletEnabled(): boolean {

--- a/class/wallets/hd-legacy-breadwallet-wallet.ts
+++ b/class/wallets/hd-legacy-breadwallet-wallet.ts
@@ -159,11 +159,11 @@ export class HDLegacyBreadwalletWallet extends HDLegacyP2PKHWallet {
   }
 
   _addPsbtInput(psbt: Psbt, input: CoinSelectReturnInput, sequence: number, masterFingerprintBuffer: Uint8Array) {
-    // hack to use
     // AbstractHDElectrumWallet._addPsbtInput for bech32 address
     // HDLegacyP2PKHWallet._addPsbtInput for legacy address
-    const ProxyClass = input?.address?.startsWith('bc1') ? AbstractHDElectrumWallet : HDLegacyP2PKHWallet;
-    const proxy = new ProxyClass();
-    return proxy._addPsbtInput.apply(this, [psbt, input, sequence, masterFingerprintBuffer]);
+    if (input?.address?.startsWith('bc1')) {
+      return AbstractHDElectrumWallet.prototype._addPsbtInput.call(this, psbt, input, sequence, masterFingerprintBuffer);
+    }
+    return super._addPsbtInput(psbt, input, sequence, masterFingerprintBuffer);
   }
 }

--- a/class/wallets/legacy-wallet.ts
+++ b/class/wallets/legacy-wallet.ts
@@ -43,10 +43,7 @@ export class LegacyWallet extends AbstractWallet {
    * @return {boolean}
    */
   timeToRefreshBalance(): boolean {
-    if (+new Date() - this._lastBalanceFetch >= 5 * 60 * 1000) {
-      return true;
-    }
-    return false;
+    return +new Date() - this._lastBalanceFetch >= 5 * 60 * 1000;
   }
 
   /**

--- a/class/wallets/lightning-custodian-wallet.ts
+++ b/class/wallets/lightning-custodian-wallet.ts
@@ -216,14 +216,7 @@ export class LightningCustodianWallet extends LegacyWallet {
    * @return {Promise.<void>}
    */
   async authorize() {
-    let login, password;
-    if (this.secret.indexOf('blitzhub://') !== -1) {
-      login = this.secret.replace('blitzhub://', '').split(':')[0];
-      password = this.secret.replace('blitzhub://', '').split(':')[1];
-    } else {
-      login = this.secret.replace('lndhub://', '').split(':')[0];
-      password = this.secret.replace('lndhub://', '').split(':')[1];
-    }
+    const [login, password] = this.secret.replace(/^(blitzhub|lndhub):\/\//, '').split(':');
     const response = await fetch(this.baseURI + '/auth?type=auth', {
       method: 'POST',
       body: JSON.stringify({ login, password }),

--- a/class/wallets/watch-only-wallet.ts
+++ b/class/wallets/watch-only-wallet.ts
@@ -47,7 +47,7 @@ export class WatchOnlyWallet extends LegacyWallet {
   }
 
   allowRBF() {
-    return this._hdWalletInstance?.type === HDSegwitBech32Wallet.type;
+    return this._hdWalletInstance?.allowRBF() ?? false;
   }
 
   allowSignVerifyMessage() {
@@ -146,29 +146,27 @@ export class WatchOnlyWallet extends LegacyWallet {
   }
 
   async fetchBalance() {
-    if (this.secret.startsWith('xpub') || this.secret.startsWith('ypub') || this.secret.startsWith('zpub')) {
+    if (this.isHd()) {
       if (!this._hdWalletInstance) this.init();
       if (!this._hdWalletInstance) throw new Error('Internal error: _hdWalletInstance is not initialized');
       return this._hdWalletInstance.fetchBalance();
     } else {
-      // return LegacyWallet.prototype.fetchBalance.call(this);
       return super.fetchBalance();
     }
   }
 
   async fetchTransactions() {
-    if (this.secret.startsWith('xpub') || this.secret.startsWith('ypub') || this.secret.startsWith('zpub')) {
+    if (this.isHd()) {
       if (!this._hdWalletInstance) this.init();
       if (!this._hdWalletInstance) throw new Error('Internal error: _hdWalletInstance is not initialized');
       return this._hdWalletInstance.fetchTransactions();
     } else {
-      // return LegacyWallet.prototype.fetchBalance.call(this);
       return super.fetchTransactions();
     }
   }
 
   async getAddressAsync(): Promise<string> {
-    if (this.isAddressValid(this.secret)) return new Promise(resolve => resolve(this.secret));
+    if (this.isAddressValid(this.secret)) return Promise.resolve(this.secret);
     if (this._hdWalletInstance) return this._hdWalletInstance.getAddressAsync();
     throw new Error('Not initialized');
   }
@@ -277,7 +275,7 @@ export class WatchOnlyWallet extends LegacyWallet {
   }
 
   allowMasterFingerprint() {
-    return this.getSecret().startsWith('zpub') || this.getSecret().startsWith('ypub') || this.getSecret().startsWith('xpub');
+    return this.isHd();
   }
 
   useWithHardwareWalletEnabled() {


### PR DESCRIPTION
Stacked on #8830. Small stuff: logic at right layer, plain forms instead of hand-rolled ones.

- watch-only: `allowRBF()` compared `_hdWalletInstance?.type === HDSegwitBech32Wallet.type` → delegates `_hdWalletInstance?.allowRBF() ?? false`. Same result today, works for future RBF-capable inner wallets
- watch-only: inline `startsWith('xpub') || 'ypub' || 'zpub'` ×3 → existing `isHd()`; dead commented lines removed
- hd-legacy-breadwallet: `_addPsbtInput` built a throwaway wallet instance just to borrow a method → `AbstractHDElectrumWallet.prototype._addPsbtInput.call(this, ...)` / `super`
- abstract-wallet: hand-rolled loop in `getPreferredBalanceUnit` → `Object.values(...).includes(...)` (same as the setter below it); `new Promise(resolve => resolve(x))` → `Promise.resolve(x)`; `getBalance()` computed unconfirmed twice
- legacy: `if (cond) return true; return false;` → `return cond;`
- lightning-custodian: `authorize()` parsed the secret four times → once with one regex

tsc clean, eslint clean, 515 unit tests pass. With this merged, the four stacked PRs sum to the fully verified working state (diff vs it is empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)