### PR TITLE
FIX: Support new electrum db file version

### DIFF
--- a/class/wallets/multisig-hd-wallet.ts
+++ b/class/wallets/multisig-hd-wallet.ts
@@ -536,16 +536,17 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
       for (let c = 1; c <= n; c++) {
         const cosignerData = json['x' + c + '/'] || json['x' + c];
         if (cosignerData) {
+          const derivationPath = cosignerData.derivation ? cosignerData.derivation.replace(/h/g, "'") : undefined;
           const fingerprint =
             (cosignerData.ckcc_xfp
               ? MultisigHDWallet.ckccXfp2fingerprint(cosignerData.ckcc_xfp)
               : cosignerData.root_fingerprint?.toUpperCase()) || '00000000';
           if (cosignerData.seed) {
-            this.addCosigner(ELECTRUM_SEED_PREFIX + cosignerData.seed, fingerprint, cosignerData.derivation, cosignerData.passphrase);
+            this.addCosigner(ELECTRUM_SEED_PREFIX + cosignerData.seed, fingerprint, derivationPath, cosignerData.passphrase);
           } else if (cosignerData.xprv && MultisigHDWallet.isXprvValid(cosignerData.xprv)) {
-            this.addCosigner(cosignerData.xprv, fingerprint, cosignerData.derivation);
+            this.addCosigner(cosignerData.xprv, fingerprint, derivationPath);
           } else {
-            this.addCosigner(cosignerData.xpub, fingerprint, cosignerData.derivation);
+            this.addCosigner(cosignerData.xpub, fingerprint, derivationPath);
           }
         }
 

--- a/class/wallets/multisig-hd-wallet.ts
+++ b/class/wallets/multisig-hd-wallet.ts
@@ -534,7 +534,7 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
       this.setM(parseInt(mofn[0].trim(), 10));
       const n = parseInt(mofn[1].trim(), 10);
       for (let c = 1; c <= n; c++) {
-        const cosignerData = json['x' + c + '/'];
+        const cosignerData = json['x' + c + '/'] || json['x' + c];
         if (cosignerData) {
           const fingerprint =
             (cosignerData.ckcc_xfp

--- a/tests/unit/multisig-hd-wallet.test.js
+++ b/tests/unit/multisig-hd-wallet.test.js
@@ -1422,8 +1422,7 @@ describe('multisig-wallet (native segwit)', () => {
       delete newStorage['x' + c + '/'];
 
       // replace hardened notation
-      newStorage['x' + c].derivation =
-        newStorage['x' + c].derivation.replaceAll("'", 'h');
+      newStorage['x' + c].derivation = newStorage['x' + c].derivation.replaceAll("'", 'h');
     }
 
     const originalWallet = new MultisigHDWallet();
@@ -1435,26 +1434,14 @@ describe('multisig-wallet (native segwit)', () => {
     assert.strictEqual(newWallet.getM(), originalWallet.getM());
     assert.strictEqual(newWallet.getN(), originalWallet.getN());
 
-    assert.strictEqual(
-      newWallet.isNativeSegwit(),
-      originalWallet.isNativeSegwit(),
-    );
+    assert.strictEqual(newWallet.isNativeSegwit(), originalWallet.isNativeSegwit());
 
-    assert.deepStrictEqual(
-      newWallet.getCustomDerivationPathForCosigner(1),
-      originalWallet.getCustomDerivationPathForCosigner(1),
-    );
+    assert.deepStrictEqual(newWallet.getCustomDerivationPathForCosigner(1), originalWallet.getCustomDerivationPathForCosigner(1));
 
-    assert.deepStrictEqual(
-      newWallet._getExternalAddressByIndex(0),
-      originalWallet._getExternalAddressByIndex(0),
-    );
+    assert.deepStrictEqual(newWallet._getExternalAddressByIndex(0), originalWallet._getExternalAddressByIndex(0));
 
-    assert.deepStrictEqual(
-      newWallet._getInternalAddressByIndex(0),
-      originalWallet._getInternalAddressByIndex(0),
-    );
-  });;
+    assert.deepStrictEqual(newWallet._getInternalAddressByIndex(0), originalWallet._getInternalAddressByIndex(0));
+  });
 
   it('can import electrum json file format with seeds and passphrase', () => {
     const json = require('./fixtures/electrum-multisig-wallet-with-seed-and-passphrase.json');

--- a/tests/unit/multisig-hd-wallet.test.js
+++ b/tests/unit/multisig-hd-wallet.test.js
@@ -1410,26 +1410,51 @@ describe('multisig-wallet (native segwit)', () => {
     }
   });
 
-  it('can import electrum json file format with seed version 71', () => {
+  it('can import electrum json with h paths and no trailing slashes', () => {
     const content = require('./fixtures/electrum-multisig-wallet-with-seed.json');
-    const json = JSON.parse(JSON.stringify(content));
+
+    const originalStorage = JSON.parse(JSON.stringify(content));
+    const newStorage = JSON.parse(JSON.stringify(content));
 
     for (let c = 1; c <= 3; c++) {
-      // test electrum json keys without trailing slashes
-      json['x' + c] = json['x' + c + '/'];
-      delete json['x' + c + '/'];
+      // test keys without trailing slashes
+      newStorage['x' + c] = newStorage['x' + c + '/'];
+      delete newStorage['x' + c + '/'];
 
-      // test h notation in derivation paths
-      json['x' + c].derivation = json['x' + c].derivation.replaceAll(/'/g, 'h');
+      // replace hardened notation
+      newStorage['x' + c].derivation =
+        newStorage['x' + c].derivation.replaceAll("'", 'h');
     }
 
-    const w = new MultisigHDWallet();
-    w.setSecret(JSON.stringify(json));
+    const originalWallet = new MultisigHDWallet();
+    originalWallet.setSecret(JSON.stringify(originalStorage));
 
-    assert.strictEqual(w.getM(), 2);
-    assert.strictEqual(w.getN(), 3);
-    assert.ok(w.isNativeSegwit());
-  });
+    const newWallet = new MultisigHDWallet();
+    newWallet.setSecret(JSON.stringify(newStorage));
+
+    assert.strictEqual(newWallet.getM(), originalWallet.getM());
+    assert.strictEqual(newWallet.getN(), originalWallet.getN());
+
+    assert.strictEqual(
+      newWallet.isNativeSegwit(),
+      originalWallet.isNativeSegwit(),
+    );
+
+    assert.deepStrictEqual(
+      newWallet.getCustomDerivationPathForCosigner(1),
+      originalWallet.getCustomDerivationPathForCosigner(1),
+    );
+
+    assert.deepStrictEqual(
+      newWallet._getExternalAddressByIndex(0),
+      originalWallet._getExternalAddressByIndex(0),
+    );
+
+    assert.deepStrictEqual(
+      newWallet._getInternalAddressByIndex(0),
+      originalWallet._getInternalAddressByIndex(0),
+    );
+  });;
 
   it('can import electrum json file format with seeds and passphrase', () => {
     const json = require('./fixtures/electrum-multisig-wallet-with-seed-and-passphrase.json');

--- a/tests/unit/multisig-hd-wallet.test.js
+++ b/tests/unit/multisig-hd-wallet.test.js
@@ -1410,6 +1410,23 @@ describe('multisig-wallet (native segwit)', () => {
     }
   });
 
+  it('can import electrum json with cosigner keys without trailing slashes', () => {
+    const content = require('./fixtures/electrum-multisig-wallet-with-seed.json');
+    const json = JSON.parse(JSON.stringify(content));
+
+    for (let c = 1; c <= 3; c++) {
+      json['x' + c] = json['x' + c + '/'];
+      delete json['x' + c + '/'];
+    }
+
+    const w = new MultisigHDWallet();
+    w.setSecret(JSON.stringify(json));
+
+    assert.strictEqual(w.getM(), 2);
+    assert.strictEqual(w.getN(), 3);
+    assert.ok(w.isNativeSegwit());
+  });
+
   it('can import electrum json file format with seeds and passphrase', () => {
     const json = require('./fixtures/electrum-multisig-wallet-with-seed-and-passphrase.json');
     const w = new MultisigHDWallet();

--- a/tests/unit/multisig-hd-wallet.test.js
+++ b/tests/unit/multisig-hd-wallet.test.js
@@ -1410,13 +1410,17 @@ describe('multisig-wallet (native segwit)', () => {
     }
   });
 
-  it('can import electrum json with cosigner keys without trailing slashes', () => {
+  it('can import electrum json file format with seed version 71', () => {
     const content = require('./fixtures/electrum-multisig-wallet-with-seed.json');
     const json = JSON.parse(JSON.stringify(content));
 
     for (let c = 1; c <= 3; c++) {
+      // test electrum json keys without trailing slashes
       json['x' + c] = json['x' + c + '/'];
       delete json['x' + c + '/'];
+
+      // test h notation in derivation paths
+      json['x' + c].derivation = json['x' + c].derivation.replaceAll(/'/g, 'h');
     }
 
     const w = new MultisigHDWallet();


### PR DESCRIPTION
# Support Electrum Wallet Files Without Trailing Slashes

## Overview

This PR adds support for newer Electrum wallet files where multisig cosigner keys no longer contain a trailing `/`.

Older Electrum wallet files use keys such as:

```text
x1/
x2/
```

Newer versions use:

```text
x1
x2
```

Electrum introduced a migration that removes the trailing `/` from dictionary keys and updates the wallet version to `55`.

### Official Electrum Migration

[Electrum wallet_db.py — version 55 migration](https://github.com/spesmilo/electrum/blob/1bfee7d1956ccb31778c76955683b789d1585d0c/electrum/wallet_db.py?utm_source=chatgpt.com#L1111)

The official Python migration:

* Finds dictionary keys ending with `/`.
* Removes the trailing `/`.
* Preserves the associated values.
* Updates `seed_version` to `55`.



## BlueWallet Fix

BlueWallet does not need to migrate the wallet file. It only needs to support both key formats when reading the cosigner data.

The fix is:

```javascript
const cosignerData = json['x' + c + '/'] || json['x' + c];
```

This preserves compatibility with existing Electrum wallet files while also supporting files generated or upgraded by newer Electrum versions.

## Steps to Reproduce

### 1. Create a multisig wallet with a new Electrum version

Create a multisig wallet using a recent version of Electrum.

Import the wallet file into BlueWallet.

**Expected:**
BlueWallet should detect the wallet and read the cosigner data.

**Actual:**
BlueWallet does not find the expected cosigner data because newer Electrum files use keys without the trailing `/`.

### 2. Upgrade an existing wallet with Electrum

Import the [test wallet](https://github.com/BlueWallet/BlueWallet/blob/9651f7c49706bb345601cdec52fb723b45d46747/tests/unit/fixtures/electrum-multisig-wallet-with-seed.json) file into Electrum.

Electrum upgrades the wallet file to the latest database version, currently version `59`.

Export/save the upgraded wallet file and import it into BlueWallet again.

**Expected:**
BlueWallet should successfully read the wallet.

**Actual:**
The import fails because BlueWallet only looks for the old `xN/` key format.

## Result

After this change, BlueWallet supports both Electrum formats:

```text
x1/  → legacy format
x1   → new format
```

This keeps backward compatibility while allowing BlueWallet to import wallet files created or upgraded by newer Electrum versions.