### PR TITLE
FIX: keep fractional sat/vB when computing tx ETA

### DIFF
--- a/screen/transactions/TransactionStatus.tsx
+++ b/screen/transactions/TransactionStatus.tsx
@@ -466,7 +466,7 @@ const TransactionStatus: React.FC = () => {
             setMempoolFee(txFromMempool.fee);
           }
 
-          const satPerVbyte = txFromMempool.fee && fetchedTx.vsize ? Math.round(txFromMempool.fee / fetchedTx.vsize) : 0;
+          const satPerVbyte = txFromMempool.fee && fetchedTx.vsize ? txFromMempool.fee / fetchedTx.vsize : 0;
           const fees = await BlueElectrum.estimateFees();
 
           // Only set ETA if we have valid fee data


### PR DESCRIPTION
## Summary
- Pending tx details stayed on "Analyzing..." when fee rate was below 1 sat/vB.
- ETA used `Math.round(fee / vsize)`, so values like `15 / 141 ≈ 0.106` became `0` and failed the `satPerVbyte > 0` check.
- Keep the fractional sat/vB value so low-feerate mempool txs get an ETA.

## Test plan
- [ ] Import/watch an address with a mempool tx below 1 sat/vB (e.g. ~0.1 sat/vB).
- [ ] Open tx details and confirm "Analyzing..." resolves to an ETA (likely ~1 day).
- [ ] Confirm a normal pending tx (≥1 sat/vB) still shows the expected ETA and Speed Up when applicable.


Made with [Cursor](https://cursor.com)