### PR TITLE
FIX: Support decimal points in rbf custom fee input and handle navigation

### DIFF
--- a/class/hd-segwit-bech32-transaction.ts
+++ b/class/hd-segwit-bech32-transaction.ts
@@ -412,7 +412,7 @@ export class HDSegwitBech32Transaction {
       fee = createdTx.fee;
       assert(tx, 'tx is createCPFPbumpFee() is undefined');
       const combinedFeeRate = (oldFee + fee) / (this._txDecoded!.virtualSize() + tx.virtualSize()); // avg
-      if (Math.round(combinedFeeRate) < newFeerate) {
+      if (combinedFeeRate < newFeerate) {
         add *= 2;
         if (!add) add = 2;
       } else {

--- a/components/ReplaceFeeSuggestions.tsx
+++ b/components/ReplaceFeeSuggestions.tsx
@@ -91,9 +91,9 @@ const ReplaceFeeSuggestions: React.FC<ReplaceFeeSuggestionsProps> = ({ onFeeSele
   };
 
   const handleCustomFeeChange = (customFee: string) => {
-    const sanitizedFee = customFee.replace(/[^0-9]/g, '');
+    const sanitizedFee = customFee.replace(/[^\d.,]/g, '').replace(/([.,].*?)[.,]/g, '$1');
     setCustomFeeValue(sanitizedFee);
-    onFeeSelected(Number(sanitizedFee));
+    onFeeSelected(Number(sanitizedFee.replace(',', '.')));
     setSelectedFeeType(NetworkTransactionFeeType.CUSTOM);
   };
 

--- a/navigation/SendDetailsStackParamList.ts
+++ b/navigation/SendDetailsStackParamList.ts
@@ -132,6 +132,8 @@ export type SendDetailsStackParamList = {
     amountUnit?: BitcoinUnit;
     txid?: string;
     invoiceDescription?: string;
+    walletID?: string;
+    walletType?: string;
   };
   SelectWallet: {
     chainType?: Chain;

--- a/screen/send/success.tsx
+++ b/screen/send/success.tsx
@@ -14,6 +14,7 @@ import { HandOffActivityType } from '../../components/types';
 import { useSettings } from '../../hooks/context/useSettings';
 import { SendDetailsStackParamList } from '../../navigation/SendDetailsStackParamList.ts';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { DetailViewStackParamList } from '../../navigation/DetailViewStackParamList.ts';
 
 type RouteProps = RouteProp<SendDetailsStackParamList, 'Success'>;
 type NavigationProps = NativeStackNavigationProp<SendDetailsStackParamList, 'Success'>;
@@ -23,7 +24,7 @@ const Success = () => {
   const { selectedBlockExplorer } = useSettings();
   const route = useRoute<RouteProps>();
   const navigation = useNavigation<NavigationProps>();
-  const { amount, fee, amountUnit = BitcoinUnit.BTC, invoiceDescription = '', txid } = route.params || {};
+  const { amount, fee, amountUnit = BitcoinUnit.BTC, invoiceDescription = '', txid, walletID, walletType } = route.params || {};
   const stylesHook = StyleSheet.create({
     root: {
       backgroundColor: colors.elevated,
@@ -38,6 +39,13 @@ const Success = () => {
 
   const onDonePressed = () => {
     // Close SendDetails modal stack and return to the underlying wallet view.
+    if (walletID && walletType) {
+      (navigation as NativeStackNavigationProp<DetailViewStackParamList>).popTo('WalletTransactions', {
+        walletID,
+        walletType,
+      });
+      return;
+    }
     navigation.getParent()?.goBack();
   };
 

--- a/screen/transactions/CPFP.js
+++ b/screen/transactions/CPFP.js
@@ -164,7 +164,7 @@ export default class CPFP extends Component {
           <ReplaceFeeSuggestions onFeeSelected={fee => this.setState({ newFeeRate: fee })} transactionMinimum={this.state.feeRate} />
           <BlueSpacing />
           <Button
-            disabled={this.state.newFeeRate <= this.state.feeRate}
+            disabled={this.state.newFeeRate <= this.state.feeRate || !Number.isFinite(this.state.newFeeRate)}
             onPress={() => this.createTransaction()}
             title={loc.transactions.cpfp_create}
           />

--- a/screen/transactions/CPFP.js
+++ b/screen/transactions/CPFP.js
@@ -101,7 +101,11 @@ export default class CPFP extends Component {
     this.context.txMetadata[this.state.newTxid] = { memo: 'Child pays for parent (CPFP)' };
     majorTomToGroundControl([], [], [this.state.newTxid]);
     this.context.sleep(4000).then(() => this.context.fetchAndSaveWalletTransactions(this.state.wallet.getID()));
-    this.props.navigation.navigate('Success', { amount: undefined });
+    this.props.navigation.navigate('Success', {
+      amount: undefined,
+      walletID: this.state.wallet.getID(),
+      walletType: this.state.wallet.type,
+    });
   }
 
   async componentDidMount() {
@@ -134,7 +138,7 @@ export default class CPFP extends Component {
   }
 
   async createTransaction() {
-    const newFeeRate = parseInt(this.state.newFeeRate, 10);
+    const newFeeRate = Number(this.state.newFeeRate);
     if (newFeeRate > this.state.feeRate) {
       /** @type {HDSegwitBech32Transaction} */
       const tx = this.state.tx;

--- a/screen/transactions/RBFBumpFee.js
+++ b/screen/transactions/RBFBumpFee.js
@@ -56,7 +56,7 @@ export default class RBFBumpFee extends CPFP {
   }
 
   async createTransaction() {
-    const newFeeRate = parseInt(this.state.newFeeRate, 10);
+    const newFeeRate = Number(this.state.newFeeRate);
     if (newFeeRate > this.state.feeRate) {
       /** @type {HDSegwitBech32Transaction} */
       const tx = this.state.tx;
@@ -104,7 +104,11 @@ export default class RBFBumpFee extends CPFP {
       this.context.txMetadata[this.state.newTxid] = this.context.txMetadata[this.state.txid];
     }
     this.context.sleep(4000).then(() => this.context.fetchAndSaveWalletTransactions(this.state.wallet.getID()));
-    this.props.navigation.navigate('Success', { amount: undefined });
+    this.props.navigation.navigate('Success', {
+      amount: undefined,
+      walletID: this.state.wallet.getID(),
+      walletType: this.state.wallet.type,
+    });
   }
 
   render() {

--- a/screen/transactions/RBFCancel.js
+++ b/screen/transactions/RBFCancel.js
@@ -53,7 +53,7 @@ export default class RBFCancel extends CPFP {
   }
 
   async createTransaction() {
-    const newFeeRate = parseInt(this.state.newFeeRate, 10);
+    const newFeeRate = Number(this.state.newFeeRate);
     if (newFeeRate > this.state.feeRate) {
       /** @type {HDSegwitBech32Transaction} */
       const tx = this.state.tx;
@@ -107,7 +107,11 @@ export default class RBFCancel extends CPFP {
       this.context.txMetadata[this.state.newTxid].memo = 'Cancelled transaction';
     }
     this.context.sleep(4000).then(() => this.context.fetchAndSaveWalletTransactions(this.state.wallet.getID()));
-    this.props.navigation.navigate('Success', { amount: undefined });
+    this.props.navigation.navigate('Success', {
+      amount: undefined,
+      walletID: this.state.wallet.getID(),
+      walletType: this.state.wallet.type,
+    });
   }
 
   render() {

--- a/typings/navigation.d.ts
+++ b/typings/navigation.d.ts
@@ -1,4 +1,4 @@
-import type { ParamListBase } from "@react-navigation/native";
+import type { ParamListBase } from '@react-navigation/native';
 
 declare global {
   namespace ReactNavigation {


### PR DESCRIPTION
This pr adds support for decimal point entry on the rbf custom fee input and fixes the issue on `Done` button in Success screen which when clicked was not navigating to wallet transactions screen


Video showing decimal fee input on rbf cancel  and then navigating to wallet transaxtions


https://github.com/user-attachments/assets/082b37d4-7c30-444c-af6f-804a39525e3e


