### PR TITLE
FIX: Harden RNG by using the native secure random module

### DIFF
--- a/blue_modules/encryption.ts
+++ b/blue_modules/encryption.ts
@@ -1,7 +1,7 @@
 import { cbc } from '@noble/ciphers/aes';
 import { md5 } from '@noble/hashes/legacy';
-import { randomBytes } from '@noble/hashes/utils';
 
+import { randomBytes } from '../class/rng';
 import { areUint8ArraysEqual, base64ToUint8Array, concatUint8Arrays, stringToUint8Array, uint8ArrayToBase64 } from './uint8array-extras';
 
 /**
@@ -53,9 +53,9 @@ const BLOCK_LEN = 16;
  * change a drop-in replacement so existing encrypted wallets on user
  * devices remain readable, with no migration step.
  */
-export function encrypt(data: string, password: string): string {
+export async function encrypt(data: string, password: string): Promise<string> {
   if (data.length < 10) throw new Error('data length cant be < 10');
-  const salt = randomBytes(SALT_LEN);
+  const salt = await randomBytes(SALT_LEN);
   const kdf = evpBytesToKeyMd5(stringToUint8Array(password), salt, KEY_LEN + IV_LEN);
   const key = kdf.subarray(0, KEY_LEN);
   const iv = kdf.subarray(KEY_LEN);

--- a/class/blue-app.ts
+++ b/class/blue-app.ts
@@ -220,7 +220,7 @@ export class BlueApp {
     let data = await this.getItem('data');
     // TODO: refactor ^^^ (should not save & load to fetch data)
 
-    const encrypted = encryption.encrypt(data, password);
+    const encrypted = await encryption.encrypt(data, password);
     data = [];
     data.push(encrypted); // putting in array as we might have many buckets with storages
     data = JSON.stringify(data);
@@ -247,7 +247,7 @@ export class BlueApp {
 
     let buckets = await this.getItem('data');
     buckets = JSON.parse(buckets);
-    buckets.push(encryption.encrypt(JSON.stringify(data), fakePassword));
+    buckets.push(await encryption.encrypt(JSON.stringify(data), fakePassword));
     this.cachedPassword = fakePassword;
     const bucketsString = JSON.stringify(buckets);
     await this.setItem('data', bucketsString);
@@ -683,7 +683,7 @@ export class BlueApp {
           } else {
             // decrypted ok, this is our bucket
             // we serialize our object's data, encrypt it, and add it to buckets
-            newData.push(encryption.encrypt(JSON.stringify(data), this.cachedPassword));
+            newData.push(await encryption.encrypt(JSON.stringify(data), this.cachedPassword));
           }
         }
 

--- a/class/rng.ts
+++ b/class/rng.ts
@@ -3,20 +3,37 @@
  * into one place to try and prevent mistakes when touching the crypto code.
  */
 
-// React Native: entropy via global crypto.getRandomValues (polyfilled by react-native-get-random-values)
+import { base64 } from '@scure/base';
+import { NativeModules } from 'react-native';
+
+const MAX_BYTES = 65536;
 
 /**
  * Generate cryptographically secure random bytes using native api.
+ * Throws instead of falling back to JavaScript randomness when the native
+ * bridge is unavailable, including during Chrome remote debugging.
  * @param  {number}   size      The number of bytes of randomness
  * @return {Promise.<Uint8Array>}   The random bytes
  */
 export async function randomBytes(size: number): Promise<Uint8Array> {
-  const g = globalThis as any;
-  const rnCrypto = g && g.crypto;
-  if (!rnCrypto || typeof rnCrypto.getRandomValues !== 'function') {
-    throw new Error('crypto.getRandomValues is not available');
+  if (!Number.isSafeInteger(size) || size < 1 || size > MAX_BYTES) {
+    throw new Error(`randomBytes: invalid size ${size}`);
   }
-  const bytes = new Uint8Array(size);
-  rnCrypto.getRandomValues(bytes);
+
+  const native = NativeModules.RNGetRandomValues;
+  if (typeof native?.getRandomBase64 !== 'function') {
+    throw new Error('Secure RNG unavailable: RNGetRandomValues is not linked');
+  }
+
+  const encoded = native.getRandomBase64(size);
+  if (typeof encoded !== 'string') {
+    throw new Error('Secure RNG returned a non-string value');
+  }
+
+  const bytes = base64.decode(encoded);
+  if (bytes.length !== size) {
+    throw new Error(`Secure RNG length mismatch: expected ${size}, got ${bytes.length}`);
+  }
+
   return bytes;
 }

--- a/screen/settings/SelfTest.tsx
+++ b/screen/settings/SelfTest.tsx
@@ -252,7 +252,7 @@ export default class SelfTest extends Component {
       //
 
       const data2encrypt = 'really long data string';
-      const crypted = encryption.encrypt(data2encrypt, 'password');
+      const crypted = await encryption.encrypt(data2encrypt, 'password');
       const decrypted = encryption.decrypt(crypted, 'password');
 
       if (decrypted !== data2encrypt) {

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,6 +1,8 @@
 /* global jest */
 
 import mockClipboard from '@react-native-clipboard/clipboard/jest/clipboard-mock.js';
+import { randomBytes as nodeRandomBytes } from 'crypto';
+import { NativeModules } from 'react-native';
 
 const consoleWarnOrig = console.warn;
 console.warn = (...args) => {
@@ -37,6 +39,10 @@ console.debug = console.log = (...args) => {
 
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js
+// Jest has no linked iOS/Android native modules, so provide the bridge used by class/rng.ts.
+NativeModules.RNGetRandomValues = {
+  getRandomBase64: size => nodeRandomBytes(size).toString('base64'),
+};
 if (typeof globalThis.fetch !== 'function') {
   throw new Error('Native fetch missing; Node >= 22.11 is required (see package.json engines)');
 }

--- a/tests/unit/encryption.test.ts
+++ b/tests/unit/encryption.test.ts
@@ -1,13 +1,21 @@
 import assert from 'assert';
+import { NativeModules } from 'react-native';
 
 import * as c from '../../blue_modules/encryption';
 
 describe('unit - encryption', function () {
-  it('encrypts and decrypts', function () {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('encrypts and decrypts using the shared secure RNG', async function () {
+    const getRandomBase64 = jest.spyOn(NativeModules.RNGetRandomValues, 'getRandomBase64');
     const data2encrypt = 'really long data string bla bla really long data string bla bla really long data string bla bla';
-    const crypted = c.encrypt(data2encrypt, 'password');
+    const crypted = await c.encrypt(data2encrypt, 'password');
     const decrypted = c.decrypt(crypted, 'password');
 
+    expect(getRandomBase64).toHaveBeenCalledTimes(1);
+    expect(getRandomBase64).toHaveBeenCalledWith(8);
     assert.ok(crypted);
     assert.ok(decrypted);
     assert.strictEqual(decrypted, data2encrypt);
@@ -19,13 +27,7 @@ describe('unit - encryption', function () {
     } catch (e) {}
     assert.ok(!decryptedWithBadPassword);
 
-    let exceptionRaised = false;
-    try {
-      c.encrypt('yolo', 'password');
-    } catch (_) {
-      exceptionRaised = true;
-    }
-    assert.ok(exceptionRaised);
+    await assert.rejects(c.encrypt('yolo', 'password'));
   });
 
   it('handles ok malformed data', function () {

--- a/tests/unit/rng.test.ts
+++ b/tests/unit/rng.test.ts
@@ -1,0 +1,78 @@
+import { NativeModules } from 'react-native';
+
+import { randomBytes } from '../../class/rng';
+
+describe('randomBytes', () => {
+  const nativeModule = NativeModules.RNGetRandomValues;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    NativeModules.RNGetRandomValues = nativeModule;
+  });
+
+  it.each([
+    { useCase: 'checksum-word selection', size: 1 },
+    { useCase: 'HD and Ark wallet entropy', size: 16 },
+    { useCase: 'legacy-wallet private keys', size: 32 },
+    { useCase: 'Realm encryption keys', size: 64 },
+    { useCase: 'maximum native request', size: 65536 },
+  ])('returns $size native random bytes as a plain Uint8Array for $useCase', async ({ size }) => {
+    const getRandomBase64 = jest.spyOn(NativeModules.RNGetRandomValues, 'getRandomBase64');
+
+    const result = await randomBytes(size);
+
+    expect(getRandomBase64).toHaveBeenCalledTimes(1);
+    expect(getRandomBase64).toHaveBeenCalledWith(size);
+    expect(result).toHaveLength(size);
+    expect(result.constructor).toBe(Uint8Array);
+  });
+
+  it.each([0, -1, 1.5, NaN, Infinity, 65537, Number.MAX_SAFE_INTEGER + 1])('rejects invalid size %s', async size => {
+    const getRandomBase64 = jest.spyOn(NativeModules.RNGetRandomValues, 'getRandomBase64');
+
+    await expect(randomBytes(size)).rejects.toThrow(`randomBytes: invalid size ${size}`);
+    expect(getRandomBase64).not.toHaveBeenCalled();
+  });
+
+  it('fails clearly when the native module is unavailable', async () => {
+    NativeModules.RNGetRandomValues = undefined;
+
+    await expect(randomBytes(32)).rejects.toThrow('Secure RNG unavailable: RNGetRandomValues is not linked');
+  });
+
+  it('rejects a non-string native response', async () => {
+    jest.spyOn(NativeModules.RNGetRandomValues, 'getRandomBase64').mockReturnValue(undefined);
+
+    await expect(randomBytes(32)).rejects.toThrow('Secure RNG returned a non-string value');
+  });
+
+  it('rejects malformed base64 from the native module', async () => {
+    jest.spyOn(NativeModules.RNGetRandomValues, 'getRandomBase64').mockReturnValue('not valid base64!');
+
+    await expect(randomBytes(32)).rejects.toThrow();
+  });
+
+  it('rejects a decoded length that differs from the request', async () => {
+    jest.spyOn(NativeModules.RNGetRandomValues, 'getRandomBase64').mockReturnValue('AQI=');
+
+    await expect(randomBytes(32)).rejects.toThrow('Secure RNG length mismatch: expected 32, got 2');
+  });
+
+  it('propagates native errors including Chrome remote debugging failures', async () => {
+    jest.spyOn(NativeModules.RNGetRandomValues, 'getRandomBase64').mockImplementation(() => {
+      throw new Error('Calling synchronous methods on native modules is not supported in Chrome');
+    });
+
+    await expect(randomBytes(32)).rejects.toThrow('Calling synchronous methods on native modules is not supported in Chrome');
+  });
+
+  it('never routes through the insecure crypto polyfill', async () => {
+    const getRandomValues = jest.spyOn(globalThis.crypto, 'getRandomValues');
+    const mathRandom = jest.spyOn(Math, 'random');
+
+    await randomBytes(32);
+
+    expect(getRandomValues).not.toHaveBeenCalled();
+    expect(mathRandom).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

This PR hardens random byte generation by calling
`NativeModules.RNGetRandomValues.getRandomBase64()` directly instead of going
through the global `crypto.getRandomValues` polyfill.

The polyfill falls back to `Math.random()` during Chrome remote debugging,
which is not cryptographically secure. Calling the native module directly
ensures wallet secrets and encryption keys are always generated using the
platform's secure random number generator or the operation fails.

The Jest environment now provides the same native-module interface using
Node's secure `crypto.randomBytes()` implementation.

## Testing

- TypeScript and ESLint checks pass
- All 53 unit test suites pass
- 515 tests pass, with 1 existing skipped test

Closes #8826
