### PR TITLE
FIX: misaligned icon on receive-onchain screen

### DIFF
--- a/components/TransactionPendingIconBig.tsx
+++ b/components/TransactionPendingIconBig.tsx
@@ -17,7 +17,7 @@ export const TransactionPendingIconBig: React.FC = () => {
     <View>
       <View style={styles.boxIncoming}>
         <View style={[styles.ball, hookStyles.ball]}>
-          <Icon name="more-horiz" type="material" size={100} color={colors.foregroundColor} iconStyle={styles.iconStyle} />
+          <Icon name="more-horiz" type="material" size={100} color={colors.foregroundColor} />
         </View>
       </View>
     </View>
@@ -32,9 +32,7 @@ const styles = StyleSheet.create({
     width: 150,
     height: 150,
     borderRadius: 75,
-  },
-  iconStyle: {
-    left: 0,
-    top: 25,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 });


### PR DESCRIPTION
before: 

<img width="900" height="1960" alt="image" src="https://github.com/user-attachments/assets/8eaea0c7-955a-43ee-90c0-5c6271913484" />

after:

<img width="962" height="2004" alt="image" src="https://github.com/user-attachments/assets/c882575f-e20a-4d0d-bc02-ba85f3786369" />
