### PR TITLE
OPS: bump @arkade-os/sdk to 0.4.67 and @arkade-os/boltz-swap to 0.3.67

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.3.61",
-        "@arkade-os/sdk": "0.4.56",
+        "@arkade-os/boltz-swap": "0.3.67",
+        "@arkade-os/sdk": "0.4.67",
         "@bugsnag/react-native": "8.9.0",
         "@bugsnag/source-maps": "2.3.3",
         "@keystonehq/bc-ur-registry": "0.8.0",
@@ -174,12 +174,12 @@
       }
     },
     "node_modules/@arkade-os/boltz-swap": {
-      "version": "0.3.61",
-      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.3.61.tgz",
-      "integrity": "sha512-bXdZgCuTgjd4vvJFi+dNSbRlAk39abfl/rYcvFhoi2A2srZWweWv32s8ULbnc/HZzgTUsD63rvSHc0RHVALkag==",
+      "version": "0.3.67",
+      "resolved": "https://registry.npmjs.org/@arkade-os/boltz-swap/-/boltz-swap-0.3.67.tgz",
+      "integrity": "sha512-NqbboMXy8GICdoEH5tauMhsYmgGM1WGEaqaJ2ZnGnLfqdSLmajOgyGedeQpiotoYMXHcSocgdN8KVT/A+rVeHQ==",
       "license": "MIT",
       "dependencies": {
-        "@arkade-os/sdk": "0.4.56",
+        "@arkade-os/sdk": "0.4.62",
         "@noble/curves": "2.0.1",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",
@@ -222,9 +222,9 @@
       }
     },
     "node_modules/@arkade-os/sdk": {
-      "version": "0.4.56",
-      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.4.56.tgz",
-      "integrity": "sha512-cg64msS92yDu5UI18xzhNsnplpN5cYUxBzc/y1wKlZwvWohs5FST0rK8eOfkpi5otcrDSYCyg2Kj4yK4mRzPhQ==",
+      "version": "0.4.67",
+      "resolved": "https://registry.npmjs.org/@arkade-os/sdk/-/sdk-0.4.67.tgz",
+      "integrity": "sha512-fgX0WtzNj6ncCZmzHdjVxM/XJvFSZrojalOaunfKwYtcU+RJco3mPaiVBl2RogrRsQCc8kqraE3fisaM0LAxZA==",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors-scure": "3.1.7",
@@ -238,7 +238,7 @@
         "ws-electrumx-client": "1.0.5"
       },
       "engines": {
-        "node": ">=22.12.0 <25"
+        "node": ">=22.12.0 <27"
       },
       "peerDependencies": {
         "@react-native-async-storage/async-storage": ">=1.0.0",
@@ -1481,9 +1481,9 @@
       }
     },
     "node_modules/@bitcoinerlab/descriptors-scure/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -4177,26 +4177,26 @@
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.2.0.tgz",
-      "integrity": "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.4.0.tgz",
+      "integrity": "sha512-i3DS0CptAocyvqE4n3SUkpzeQK4vJMFwWLofTwRiiKo2aWojBOfyMCgfKw9HVpO6fSY5AK86sHS/Uzn8kK9Few==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "2.2.0",
-        "@noble/hashes": "2.2.0",
-        "@scure/base": "2.2.0"
+        "@noble/curves": "2.4.0",
+        "@noble/hashes": "2.4.0",
+        "@scure/base": "2.4.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -4206,13 +4206,22 @@
       }
     },
     "node_modules/@scure/bip32/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
       },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@scure/base": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.4.0.tgz",
+      "integrity": "sha512-thZ1TuJwFwBblOhgsjDKvvGirBxNp+wSvY/DR6tJBJOTDhdAAcHJ8Vbr2eFnqaxeca4+t0i9KBf+uHYGWwZORg==",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -18538,9 +18547,9 @@
       }
     },
     "node_modules/ws-electrumx-client/node_modules/ws": {
-      "version": "8.21.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
-      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
     "unit": "jest -b tests/unit/*"
   },
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.3.61",
-    "@arkade-os/sdk": "0.4.56",
+    "@arkade-os/boltz-swap": "0.3.67",
+    "@arkade-os/sdk": "0.4.67",
     "@bugsnag/react-native": "8.9.0",
     "@bugsnag/source-maps": "2.3.3",
     "@keystonehq/bc-ur-registry": "0.8.0",
@@ -190,5 +190,8 @@
     "text-encoding": "0.7.0",
     "url": "0.11.4",
     "wif": "2.0.6"
+  },
+  "overrides": {
+    "@arkade-os/sdk": "0.4.67"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `@arkade-os/sdk` from 0.4.56 to 0.4.67 and `@arkade-os/boltz-swap` from 0.3.61 to 0.3.67.
- Add an npm override so `@arkade-os/sdk` stays at 0.4.67. Published `boltz-swap@0.3.67` pins sdk 0.4.62, and two copies fail TypeScript (`Wallet` vs `IWallet`).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run unit` (55 suites, 525 passed, 1 skipped)
- [ ] Open an Arkade Lightning wallet and confirm balance, receive, and swap history still load


Made with [Cursor](https://cursor.com)