### PR TITLE
REF: show Chinese language labels in native script

### DIFF
--- a/loc/languages.ts
+++ b/loc/languages.ts
@@ -14,8 +14,6 @@ const _availableLanguages = Object.freeze([
   { label: 'Bahasa Melayu (MS)', value: 'ms' },
   { label: 'Català (CA)', value: 'ca' },
   { label: 'Česky (CZ)', value: 'cs_cz' },
-  { label: 'Chinese (TW)', value: 'zh_tw' },
-  { label: 'Chinese (ZH)', value: 'zh_cn' },
   { label: 'Croatian (HR)', value: 'hr_hr' },
   { label: 'Cymraeg (CY)', value: 'cy' },
   { label: 'Danish (DK)', value: 'da_dk' },
@@ -75,6 +73,8 @@ const _availableLanguages = Object.freeze([
   { label: 'ქართული (KA)', value: 'ka' },
   { label: 'ខ្មែរ (KM)', value: 'km' },
   { label: '客家話 (HAK)', value: 'hak' },
+  { label: '简体中文 (ZH-CN)', value: 'zh_cn' },
+  { label: '繁體中文 (ZH-TW)', value: 'zh_tw' },
   { label: '日本語 (JP)', value: 'jp_jp' },
   { label: '한국어 (KO)', value: 'ko_kr' },
 ] as const) satisfies readonly TLanguage[];

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -116,12 +116,11 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await goBack();
 
     // language
-    // change language to Chinese (ZH), test it and switch back to English
+    // change language to Afrikaans, test it and switch back to English
     await element(by.id('Language')).tap();
-    await element(by.id('LanguageFlatList')).scroll(250, 'down');
-    await element(by.text('Chinese (ZH)')).tap();
+    await element(by.text('Afrikaans (AFR)')).tap();
     await goBack();
-    await expect(element(by.text('语言'))).toBeVisible();
+    await expect(element(by.text('Taal'))).toBeVisible();
     await element(by.id('Language')).tap();
     await element(by.text('English')).tap();
     await goBack();


### PR DESCRIPTION
Requested by zh_CN community translator.

Was: \`Chinese (ZH)\`, \`Chinese (TW)\`. Now: \`简体中文 (ZH-CN)\`, \`繁體中文 (ZH-TW)\`.

Why: every other language in picker shown in own script. Chinese was odd one out. Users scan list for native script, not English.

Moved both rows to CJK block at bottom of list. E2E test updated: scroll to bottom, tap new label.