### PR TITLE
FIX: accept h/H and smart-quote hardened markers in derivation paths (follow-up to #8861)

### DIFF
--- a/class/wallet-import.ts
+++ b/class/wallet-import.ts
@@ -23,9 +23,20 @@ import bip39WalletFormatsElectrum from './bip39_wallet_formats.json'; // https:/
 import bip39WalletFormatsBlueWallet from './bip39_wallet_formats_bluewallet.json';
 import type { TWallet } from './wallets/types';
 
+// Canonicalize a user-typed derivation path: trim, iOS smart quotes and h/H hardened notation
+// become ', a leading M becomes m. The stored form must use ' because bitcoinjs derivePath
+// rejects h notation (its schema is /^(m\/)?(\d+'?\/)*\d+'?$/).
+export const normalizeDerivationPath = (path: string): string =>
+  path
+    .trim()
+    .replace(/[‘’]/g, "'")
+    .replace(/[hH]/g, "'")
+    .replace(/^M\//, 'm/');
+
 // https://github.com/bitcoinjs/bip32/blob/master/ts-src/bip32.ts#L43
-// require m/ so bip174 does not drop the first path level (it treats index 0 as m)
-export const validateBip32 = (path: string) => path.match(/^m\/(\d+'?\/)*\d+'?$/) !== null;
+// require m/ so bip174 does not drop the first path level (it treats index 0 as m); normalize
+// first so h notation (m/84h/0h/0h) is accepted the same as m/84'/0'/0'
+export const validateBip32 = (path: string) => normalizeDerivationPath(path).match(/^m\/(\d+'?\/)*\d+'?$/) !== null;
 
 // because original file bip39WalletFormatsElectrum is from Electrum X and doesn't contain p2tr wallets, we need to add it
 bip39WalletFormatsElectrum.push({

--- a/class/wallets/abstract-wallet.ts
+++ b/class/wallets/abstract-wallet.ts
@@ -253,7 +253,7 @@ export class AbstractWallet {
       const xpub = this.secret.substring(xpubIndex).replace(/[()]/g, '').split('/')[0];
 
       const pathIndex = fpAndPath.indexOf('/');
-      const path = 'm' + fpAndPath.substring(pathIndex).replace(/h/g, "'");
+      const path = 'm' + fpAndPath.substring(pathIndex).replace(/[hH‘’]/g, "'");
       const fp = fpAndPath.substring(0, pathIndex);
 
       this._derivationPath = path;
@@ -283,7 +283,8 @@ export class AbstractWallet {
     const m = this.secret.match(re);
     if (m && m.length === 3) {
       let [hexFingerprint, ...derivationPathArray] = m[1].split('/');
-      const derivationPath = `m/${derivationPathArray.join('/').replace(/h/g, "'")}`;
+      // H is the same hardened bit as h; leaving it skips xpub to zpub and imports BIP84 as legacy 1...
+      const derivationPath = `m/${derivationPathArray.join('/').replace(/[hH‘’]/g, "'")}`;
       if (hexFingerprint.length === 8) {
         hexFingerprint = uint8ArrayToHex(hexToUint8Array(hexFingerprint).reverse());
         this.masterFingerprint = parseInt(hexFingerprint, 16);
@@ -328,7 +329,7 @@ export class AbstractWallet {
         }
         if (parsedSecret.keystore.derivation) {
           this._derivationPath = parsedSecret.keystore.derivation;
-          this._derivationPath = this._derivationPath?.replace(/h/g, "'");
+          this._derivationPath = this._derivationPath?.replace(/[hH‘’]/g, "'");
         }
         this.secret = parsedSecret.keystore.xpub;
         this.masterFingerprint = masterFingerprint;

--- a/screen/wallets/ImportCustomDerivationPath.tsx
+++ b/screen/wallets/ImportCustomDerivationPath.tsx
@@ -10,7 +10,7 @@ import { HDSegwitBech32Wallet } from '../../class/wallets/hd-segwit-bech32-walle
 import { HDSegwitP2SHWallet } from '../../class/wallets/hd-segwit-p2sh-wallet';
 import { HDTaprootWallet } from '../../class/wallets/hd-taproot-wallet';
 import { WatchOnlyWallet } from '../../class/wallets/watch-only-wallet';
-import { validateBip32 } from '../../class/wallet-import';
+import { normalizeDerivationPath, validateBip32 } from '../../class/wallet-import';
 import { TWallet } from '../../class/wallets/types';
 import Button from '../../components/Button';
 import SafeArea from '../../components/SafeArea';
@@ -53,7 +53,9 @@ const ImportCustomDerivationPath: React.FC = () => {
       wallet.setSecret(importText);
       if (!(wallet.valid() && wallet.isHd())) return fallback;
       wallet.init();
-      return { isWatchOnlyHd: true, defaultPath: wallet.getDerivationPath() || fallback.defaultPath };
+      // belt and braces: keep the field canonical whatever getDerivationPath returns, so importing
+      // without editing never stores a raw h/H path
+      return { isWatchOnlyHd: true, defaultPath: normalizeDerivationPath(wallet.getDerivationPath() || fallback.defaultPath) };
     } catch {
       return fallback;
     }
@@ -188,10 +190,9 @@ const ImportCustomDerivationPath: React.FC = () => {
 
   const disabled = wallets[path] === WRONG_PATH || wallets[path]?.[selected] === undefined;
 
-  // iOS curly quotes and hardware-wallet h → ' so validateBip32 can accept the path
+  // normalize as typed/pasted (smart quotes, h/H → ') so the stored path is canonical
   const handlePathChange = useCallback((text: string) => {
-    const normalized = text.split('‘').join("'").split('’').join("'").split('“').join('"').split('”').join('"').replace(/h/gi, "'");
-    setPath(normalized);
+    setPath(normalizeDerivationPath(text));
   }, []);
 
   return (

--- a/screen/wallets/WalletDetails.tsx
+++ b/screen/wallets/WalletDetails.tsx
@@ -13,7 +13,7 @@ import { MultisigHDWallet } from '../../class/wallets/multisig-hd-wallet';
 import { SegwitBech32Wallet } from '../../class/wallets/segwit-bech32-wallet';
 import { SegwitP2SHWallet } from '../../class/wallets/segwit-p2sh-wallet';
 import { WatchOnlyWallet } from '../../class/wallets/watch-only-wallet';
-import { validateBip32 } from '../../class/wallet-import';
+import { normalizeDerivationPath, validateBip32 } from '../../class/wallet-import';
 import { AbstractHDElectrumWallet } from '../../class/wallets/abstract-hd-electrum-wallet';
 import { LightningCustodianWallet } from '../../class/wallets/lightning-custodian-wallet';
 import presentAlert from '../../components/Alert';
@@ -512,7 +512,7 @@ const WalletDetails: React.FC = () => {
     } catch (_) {
       return; // cancelled
     }
-    newPath = newPath.trim().split('‘').join("'").split('’').join("'").replace(/h/gi, "'");
+    newPath = normalizeDerivationPath(newPath);
     if (!validateBip32(newPath)) {
       presentAlert({ message: loc.wallets.details_derivation_path_invalid });
       return;

--- a/tests/unit/wallet-import.test.ts
+++ b/tests/unit/wallet-import.test.ts
@@ -1,15 +1,35 @@
 import assert from 'assert';
 
-import { validateBip32 } from '../../class/wallet-import';
+import { normalizeDerivationPath, validateBip32 } from '../../class/wallet-import';
 
 describe('validateBip32', () => {
   it('requires an m/ prefix so bip174 does not drop the first path level', () => {
     assert.ok(validateBip32("m/84'/0'/0'"));
     assert.ok(validateBip32("m/0'"));
     assert.ok(validateBip32('m/0/0'));
+    assert.ok(validateBip32("m/84/0'/0'")); // mixed hardened and non-hardened levels
+    assert.ok(validateBip32('m/84/0/0')); // all non-hardened
     assert.ok(!validateBip32("84'/0'/0'"));
     assert.ok(!validateBip32('m'));
-    assert.ok(!validateBip32('m/84h/0h/0h'));
+    assert.ok(!validateBip32('m//0')); // empty path segment
     assert.ok(!validateBip32(''));
+  });
+
+  it('accepts h and H hardened notation the same as an apostrophe', () => {
+    assert.ok(validateBip32('m/84h/0h/0h'));
+    assert.ok(validateBip32('m/84H/0H/0H'));
+    assert.ok(validateBip32("M/84'/0'/0'")); // leading M is normalized to m
+    assert.ok(validateBip32("  m/0'  ")); // surrounding whitespace is trimmed
+  });
+});
+
+describe('normalizeDerivationPath', () => {
+  it('canonicalizes h/H and smart quotes to apostrophes', () => {
+    assert.strictEqual(normalizeDerivationPath('m/84h/0h/0h'), "m/84'/0'/0'");
+    assert.strictEqual(normalizeDerivationPath('m/84H/0H/0H'), "m/84'/0'/0'");
+    assert.strictEqual(normalizeDerivationPath('m/84‘/0’/0’'), "m/84'/0'/0'"); // iOS smart quotes
+    assert.strictEqual(normalizeDerivationPath("M/84'/0'/0'"), "m/84'/0'/0'");
+    assert.strictEqual(normalizeDerivationPath("  m/0'  "), "m/0'");
+    assert.strictEqual(normalizeDerivationPath("m/84'/0'/0'"), "m/84'/0'/0'"); // already canonical
   });
 });

--- a/tests/unit/watch-only-wallet.test.js
+++ b/tests/unit/watch-only-wallet.test.js
@@ -379,6 +379,38 @@ describe('Watch only wallet', () => {
     assert.ok(!w.useWithHardwareWalletEnabled());
   });
 
+  it('can import BIP84 origin with uppercase H as native segwit, not legacy', async () => {
+    const w = new WatchOnlyWallet();
+    w.setSecret(
+      '[dafedf1c/84H/0H/0H]xpub6DFMZMLizqqnyyHoWTG7qzmCR1irpiDEGT4JQX7ubeoFtV838ABKPfgAPQbM1TEekEyCuJF1BrmnA7JPrnzqi2VbycD3tVE3v5xsDQqYA3A',
+    );
+    w.init();
+    assert.ok(w.valid());
+
+    assert.strictEqual(w.getMasterFingerprintHex(), 'dafedf1c');
+    assert.strictEqual(w.getDerivationPath(), "m/84'/0'/0'");
+    assert.strictEqual(
+      w.getSecret(),
+      'zpub6rutAggZJCvkgZg3BAqNGAxCkx1khxCE6g6jyJugMfZ1zgkVdUWSdnzSRpWX1GYVZXCpQFS87BUsvgXXJBpsJVroiHbu4Js2TY69zbWcTNb',
+    );
+    assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1q68y6r45k4kvxe42xl37dgjueg2suqwnh4ze0sr');
+    assert.ok(!w._getExternalAddressByIndex(0).startsWith('1'));
+  });
+
+  it('can import BIP84 origin with iOS smart quotes as native segwit, not legacy', async () => {
+    // smart quotes ‘ ’ instead of ' — same hardened-marker hole as uppercase H
+    const w = new WatchOnlyWallet();
+    w.setSecret(
+      '[dafedf1c/84‘/0’/0‘]xpub6DFMZMLizqqnyyHoWTG7qzmCR1irpiDEGT4JQX7ubeoFtV838ABKPfgAPQbM1TEekEyCuJF1BrmnA7JPrnzqi2VbycD3tVE3v5xsDQqYA3A',
+    );
+    w.init();
+    assert.ok(w.valid());
+    assert.strictEqual(w.getMasterFingerprintHex(), 'dafedf1c');
+    assert.strictEqual(w.getDerivationPath(), "m/84'/0'/0'");
+    assert.strictEqual(w._getExternalAddressByIndex(0), 'bc1q68y6r45k4kvxe42xl37dgjueg2suqwnh4ze0sr');
+    assert.ok(!w._getExternalAddressByIndex(0).startsWith('1'));
+  });
+
   it('can import wallet descriptor for BIP84 from Sparrow Wallet', async () => {
     const payload =
       'UR:CRYPTO-OUTPUT/TAADMWTAADDLOLAOWKAXHDCLAXINTOCTFTNNIERONTNYGALYEMAAWPHDAXDIEOWPJEGHKPGMKERHIABDTBLUBNMUMWAAHDCXFHSNBGTSGWSWPTDWVTDIHYHNHPLBBSJEOLSNFZBDIYJLTTPFIMEYTEECKTGSBZBDAHTAADEHOEADAEAOAEAMTAADDYOTADLNCSGHYKAEYKAEYKAOCYFNLBCYGMAXAXAYCYSRRTSPGADLMKBGTD';


### PR DESCRIPTION
## Why

Follow up to #8861. Closes the two review threads left open there:
- `h`/`H` notation: https://github.com/BlueWallet/BlueWallet/pull/8861#discussion_r3927955069
- extra path tests (mixed / non-hardened): https://github.com/BlueWallet/BlueWallet/pull/8861#discussion_r3930507778

@ojokne noticed `validateBip32` rejected `h`/`H` paths like `m/84h/0h/0h`. Fixing that turned up a worse bug in `setSecret`.

`setSecret` only lowercased `h` (`/h/g`). So a BIP84 origin with uppercase `H` or iOS smart quotes, like `[fp/84H/0H/0H]xpub`, kept the `H`, failed the `startsWith("m/84'/0'/")` check, never converted the xpub to zpub, and imported as a legacy `1…` wallet. Wrong addresses for a native segwit key. The main import screen calls `setSecret` on raw text too, so this already happens there, not just on the new screen.

## What changed

- `validateBip32` now accepts `h`/`H` and smart quotes. It normalizes first (`normalizeDerivationPath`: trim, `‘’` and `h`/`H` to `'`, leading `M` to `m`) then runs the old regex. Stored path is always the `'` form, because bitcoinjs `derivePath` rejects `h`. Nice side effect: `84h` / `84H` / `84'` end up as the same wallet id.
- `setSecret` rewrites `h`, `H` and smart quotes on the path (`/[hH‘’]/g`) at the three places it builds one. So those origins convert to zpub/ypub like they should, instead of staying legacy.
- Both watch-only screens normalize the path before saving, so a raw `h`/`H`/`‘’` path never gets stored.

## Behavior

`'`, `h`, `H`, `‘`, `’` on a BIP84 origin all give the same `bc1q…` wallet now, same fingerprint, path `m/84'/0'/0'`. Existing wallets are not touched. Load is `fromJson` + `init()`, which never calls `setSecret`.

## Tests

- New: `validateBip32` accepts `h`/`H`, rejects no-`m/` / bare `m` / `//`. `normalizeDerivationPath` canonicalizes. Watch-only import of a BIP84 origin with uppercase `H` and with smart quotes asserts `bc1q…`, not `1…`.
- `jest tests/unit`, integration import test, `tsc` and eslint all pass.

## Not here (follow up)

The same lowercase `/h/g` is still in the multisig cosigner parser and the Cobo `AccountKeyPath` branch. Different import paths, this PR does not touch them. Cobo is low risk anyway (it carries the script type in the zpub, so `h`/`H` is only cosmetic there). Worth a separate PR.
