### PR TITLE
FIX: keyboard on pushed screen scrolled previous screens on iOS

### DIFF
--- a/components/SafeAreaScrollView.tsx
+++ b/components/SafeAreaScrollView.tsx
@@ -65,12 +65,15 @@ const SafeAreaScrollView = forwardRef<ScrollView, SafeAreaScrollViewProps>((prop
     <ScrollView
       ref={ref}
       style={componentStyle}
-      // `scrollToOverflowEnabled` works around RN's keyboard handler: it re-applies the current offset via `scrollTo:`,
-      // which clamps to the raw `contentInset` instead of `adjustedContentInset`, so content under a large-title header
-      // jumps up by the header height when the keyboard opens. Upstream fix: https://github.com/react/react-native/pull/56189
+      // `automaticallyAdjustKeyboardInsets` is opt-in: RN's keyboard handler also fires for screens below the
+      // stack top and clamps their offset (RCTScrollViewComponentView `_keyboardWillChangeFrame` / `scrollTo:`),
+      // scrolling the previous screen. Screens with text inputs pass the prop explicitly.
+      // `scrollToOverflowEnabled` works around the same handler for screens that do opt in: it re-applies the current
+      // offset via `scrollTo:`, which clamps to the raw `contentInset` instead of `adjustedContentInset`, so content under
+      // a large-title header jumps up by the header height when the keyboard opens.
+      // Upstream fix: https://github.com/react/react-native/pull/56189
       contentInsetAdjustmentBehavior="automatic"
       scrollToOverflowEnabled
-      automaticallyAdjustKeyboardInsets
       automaticallyAdjustsScrollIndicatorInsets
       contentContainerStyle={contentStyle}
       {...otherProps}

--- a/components/SafeAreaSectionList.tsx
+++ b/components/SafeAreaSectionList.tsx
@@ -52,12 +52,15 @@ const SafeAreaSectionList = <ItemT, SectionT>(props: SafeAreaSectionListProps<It
   return (
     <SectionList
       style={componentStyle}
-      // `scrollToOverflowEnabled` works around RN's keyboard handler: it re-applies the current offset via `scrollTo:`,
-      // which clamps to the raw `contentInset` instead of `adjustedContentInset`, so content under a large-title header
-      // jumps up by the header height when the keyboard opens. Upstream fix: https://github.com/react/react-native/pull/56189
+      // `automaticallyAdjustKeyboardInsets` is opt-in: RN's keyboard handler also fires for screens below the
+      // stack top and clamps their offset (RCTScrollViewComponentView `_keyboardWillChangeFrame` / `scrollTo:`),
+      // scrolling the previous screen. Screens with text inputs pass the prop explicitly.
+      // `scrollToOverflowEnabled` works around the same handler for screens that do opt in: it re-applies the current
+      // offset via `scrollTo:`, which clamps to the raw `contentInset` instead of `adjustedContentInset`, so content under
+      // a large-title header jumps up by the header height when the keyboard opens.
+      // Upstream fix: https://github.com/react/react-native/pull/56189
       contentInsetAdjustmentBehavior="automatic"
       scrollToOverflowEnabled
-      automaticallyAdjustKeyboardInsets
       automaticallyAdjustContentInsets
       automaticallyAdjustsScrollIndicatorInsets
       contentContainerStyle={contentStyle}

--- a/components/WalletsCarousel.tsx
+++ b/components/WalletsCarousel.tsx
@@ -920,7 +920,6 @@ const WalletsCarousel = forwardRef<CarouselListRefType, WalletsCarouselProps>((p
       ListHeaderComponent={ListHeaderSeparator}
       contentInsetAdjustmentBehavior="automatic"
       automaticallyAdjustContentInsets
-      automaticallyAdjustKeyboardInsets
       automaticallyAdjustsScrollIndicatorInsets
       scrollToOverflowEnabled
       style={{ minHeight: sliderHeight }}

--- a/screen/send/Broadcast.tsx
+++ b/screen/send/Broadcast.tsx
@@ -100,7 +100,7 @@ const Broadcast: React.FC = () => {
   }
 
   return (
-    <SettingsScrollView testID="BroadcastView">
+    <SettingsScrollView testID="BroadcastView" automaticallyAdjustKeyboardInsets>
       <SettingsSection>
         <View style={settingsCardContent}>
           {BROADCAST_RESULT.success !== broadcastResult && (

--- a/screen/settings/LightningSettings.tsx
+++ b/screen/settings/LightningSettings.tsx
@@ -109,7 +109,7 @@ const LightningSettings: React.FC = () => {
   };
 
   return (
-    <SettingsScrollView>
+    <SettingsScrollView automaticallyAdjustKeyboardInsets>
       <SettingsSection>
         <View style={settingsCardContent}>
           <SettingsFootnote>{loc.settings.lightning_settings_explain}</SettingsFootnote>

--- a/screen/settings/SettingsBlockExplorer.tsx
+++ b/screen/settings/SettingsBlockExplorer.tsx
@@ -118,7 +118,7 @@ const SettingsBlockExplorer: React.FC = () => {
   }, [customUrl, isCustomEnabled, setBlockExplorerStorage]);
 
   return (
-    <SettingsScrollView>
+    <SettingsScrollView automaticallyAdjustKeyboardInsets>
       <SettingsSection title={loc._.suggested}>
         {predefinedExplorers.map((explorer, index) => {
           const isSelected = !isCustomEnabled && normalizeUrl(selectedBlockExplorer.url || '') === normalizeUrl(explorer.url || '');

--- a/screen/wallets/generateWord.tsx
+++ b/screen/wallets/generateWord.tsx
@@ -43,7 +43,7 @@ const GenerateWord = () => {
   };
 
   return (
-    <SettingsScrollView keyboardShouldPersistTaps="handled">
+    <SettingsScrollView keyboardShouldPersistTaps="handled" automaticallyAdjustKeyboardInsets>
       <SettingsSection>
         <View style={settingsCardContent}>
           <BlueFormMultiInput

--- a/tests/e2e/bluewallet.spec.js
+++ b/tests/e2e/bluewallet.spec.js
@@ -14,7 +14,6 @@ import {
   restoreSynchronizationIfAnimatedQrClosed,
   scanText,
   scanUrParts,
-  scrollUpOnHomeScreen,
   setCustomFeeRate,
   sleep,
   tapAndTapAgainIfElementIsNotVisible,
@@ -440,7 +439,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await waitForKeyboardToClose();
     await confirmPasswordDialog(); // first time might not always work
     await sleep(1000); // propagate
-    await scrollUpOnHomeScreen();
 
     // created fake storage.
     // creating a wallet inside this fake storage
@@ -481,7 +479,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await waitForKeyboardToClose();
     await confirmPasswordDialog(); // in case it didnt work first time
     await sleep(1000); // propagate
-    await scrollUpOnHomeScreen();
     await expect(element(by.text('fake_wallet'))).toBeVisible();
 
     process.env.CI && require('fs').writeFileSync(lockFile, '1');
@@ -529,12 +526,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
       await waitForId('Wallets');
     }
     await sleep(1000); // propagate
-    // Match t4's flow: scroll up so the next helperCreateWallet's
-    // whileElement(WalletsList).scroll('right') starts from a known
-    // position. Without this, Android lands the user on a list state
-    // where CreateAWallet is not visible after scroll-right and the
-    // 6s tapAndTapAgainIfElementIsNotVisible budget runs out.
-    await scrollUpOnHomeScreen();
     // created fake storage.
     // creating a wallet inside this fake storage
     await helperCreateWallet('fake_wallet');
@@ -624,7 +615,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await element(by.id('CreateButton')).tap();
     await waitForText('OK');
     await tapIfTextPresent('OK');
-    await scrollUpOnHomeScreen();
     await waitForId('Multisig Vault');
     await element(by.id('Multisig Vault')).tap(); // go inside the wallet
     await waitForId('ReceiveButton');
@@ -681,7 +671,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
         console.warn('[detox] leaving sync disabled after multisig import: animated QR/scanner still open');
       }
     }
-    await scrollUpOnHomeScreen();
     // ok, wallet imported — left the UR / QR import UI
 
     // lets go inside wallet
@@ -866,7 +855,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     // now, gona import second wallet (ln) and test bip21 with both onchain and offchain present
 
     await goBack();
-    await scrollUpOnHomeScreen();
     await waitForId('WalletsList');
     await waitFor(element(by.id('CreateAWallet')))
       .toBeVisible()
@@ -1067,7 +1055,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
         .scroll(500, 'down');
       await element(by.id('PleasebackupOk')).tap();
       await waitForId('WalletsList');
-      await scrollUpOnHomeScreen();
     } finally {
       if (isIOS) {
         await device.enableSynchronization();
@@ -1126,7 +1113,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await tapIfTextPresent('OK');
 
     // navigate into wallet
-    await scrollUpOnHomeScreen();
     await waitForId('Multisig Vault');
     await element(by.id('Multisig Vault')).tap();
     await waitForId('ReceiveButton');
@@ -1206,7 +1192,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await waitForId('WalletsList');
 
     // verify receive address remains unchanged after forgetting cosigner 3 seed
-    await scrollUpOnHomeScreen();
     await waitForId('Multisig Vault');
     await element(by.id('Multisig Vault')).tap();
     await waitForId('ReceiveButton');
@@ -1247,7 +1232,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await waitForId('WalletsList');
 
     // verify receive address remains unchanged after restoring cosigner 3 seed
-    await scrollUpOnHomeScreen();
     await waitForId('Multisig Vault');
     await element(by.id('Multisig Vault')).tap();
     await waitForId('ReceiveButton');
@@ -1307,7 +1291,6 @@ describe('BlueWallet UI Tests - no wallets', () => {
     await tapIfTextPresent('OK');
 
     // navigate into wallet and verify format
-    await scrollUpOnHomeScreen();
     await waitForId('Multisig Vault');
     await element(by.id('Multisig Vault')).tap();
     await waitForId('ReceiveButton');

--- a/tests/e2e/bluewallet2.spec.js
+++ b/tests/e2e/bluewallet2.spec.js
@@ -10,7 +10,6 @@ import {
   hashIt,
   helperImportWallet,
   scanText,
-  scrollUpOnHomeScreen,
   setCustomFeeRate,
   sleep,
   tapAndTapAgainIfElementIsNotVisible,
@@ -512,7 +511,6 @@ describe('BlueWallet UI Tests - import BIP84 wallet', () => {
     await goBack();
     await goBack();
     await goBack();
-    await scrollUpOnHomeScreen(); // on the ios we need to scroll up to the wallet list
 
     await element(by.text('Imported HD SegWit (BIP84 Bech32 Native)')).tap();
     await waitForId('SendButton');

--- a/tests/e2e/bluewallet3.spec.js
+++ b/tests/e2e/bluewallet3.spec.js
@@ -5,7 +5,6 @@ import {
   helperDeleteWallet,
   helperImportWallet,
   scanText,
-  scrollUpOnHomeScreen,
   sleep,
   tapHeaderMenuItem,
   waitForId,
@@ -115,7 +114,6 @@ describe('BlueWallet UI Tests - import Watch-only wallet (zpub)', () => {
     await goBack();
     await goBack();
     await goBack();
-    await scrollUpOnHomeScreen(); // on the ios we need to scroll up to the wallet list
 
     await helperDeleteWallet('Imported Watch-only', '10000');
 

--- a/tests/e2e/helperz.js
+++ b/tests/e2e/helperz.js
@@ -158,7 +158,6 @@ export async function helperImportWallet(importText, walletType, expectedWalletL
   // waiting for import result
   await waitForText('OK', 3 * 61000);
   await element(by.text('OK')).tap();
-  await scrollUpOnHomeScreen();
 
   // lets go inside wallet
   await element(by.text(expectedWalletLabel)).tap();
@@ -260,7 +259,6 @@ export async function helperCreateWallet(walletName) {
 
     await element(by.id('PleasebackupOk')).tap();
     await sleep(1000);
-    await scrollUpOnHomeScreen();
   } finally {
     if (isIOS) {
       await device.enableSynchronization();
@@ -579,25 +577,6 @@ export async function typeTextIntoAlertInput(text) {
     await element(by.type('_UIAlertControllerTextField')).replaceText(text);
   }
   await sleep(1000);
-}
-
-/**
- * Scrolls up on the home screen. This is needed on the iOS.
- */
-export async function scrollUpOnHomeScreen() {
-  if (device.getPlatform() !== 'ios') {
-    return;
-  }
-  try {
-    await element(by.type('RCTEnhancedScrollView').withDescendant(by.type('RCTEnhancedScrollView')))
-      .atIndex(0)
-      .swipe('down', 'slow', 0.5);
-  } catch (_) {
-    // if no wallets there will be just one scroll (or nested matcher missed); atIndex
-    // avoids "Multiple elements found" when several scroll views are present.
-    await element(by.type('RCTEnhancedScrollView')).atIndex(0).swipe('down', 'slow', 0.5);
-  }
-  await sleep(1000); // bounce animation
 }
 
 /**


### PR DESCRIPTION
## Problem

On iOS, opening the keyboard on a pushed screen (e.g. Settings → Language → search, or any screen with a text input) left the screens **below** it in the native stack scrolled down after going back: Settings root and the home wallets list lost their top (`WalletsList` carousel y 176 → 60, Settings first row y 308 → 88). Android unaffected. The e2e suite has been papering over this with `scrollUpOnHomeScreen()`.

## Root cause

RN 0.85 Fabric `RCTScrollViewComponentView` subscribes every scroll view that has `automaticallyAdjustKeyboardInsets` to `UIKeyboardWillChangeFrameNotification`, including screens still mounted under the stack top. The handler ends with `scrollTo:`, which clamps `y >= -contentInset.top` using the raw inset rather than `adjustedContentInset`. Lists under a transparent/large header with `contentInsetAdjustmentBehavior="automatic"` rest at `y = -adjustedContentInset.top`, so the clamp forces `y = 0` — scrolled by the header height.

`SafeAreaScrollView`, `SafeAreaSectionList` and `WalletsCarousel` set that prop by default, so the home list and Settings root (no text inputs at all) were reacting to keyboards shown elsewhere.

## Fix

`automaticallyAdjustKeyboardInsets` is now opt-in:
- removed the default from `SafeAreaScrollView`, `SafeAreaSectionList`, `WalletsCarousel` (comment explains why);
- screens with inline inputs that relied on the wrapper default now pass it explicitly: `Broadcast`, `LightningSettings`, `SettingsBlockExplorer`, `generateWord`. The other input screens (`Add`, `ImportWallet`, `ElectrumSettings`, `IsItMyAddress`, `ReceiveDetails`, `CPFP`) already did.

The e2e suite no longer needs `scrollUpOnHomeScreen()` (an iOS-only swipe that compensated for exactly this bug after every return to the home screen), so the helper, its 17 call sites and the imports are removed in a second commit.

## Before / after

Settings → Tools → Is it my address → type into the address field → back ×3.

**Before** (master): home list and Settings end up scrolled after coming back

https://github.com/user-attachments/assets/3249fd30-d8c3-4112-8134-98908547b5a2 

**After** (this PR)

https://github.com/user-attachments/assets/34a8db31-713f-4463-8c3e-1b65a48462c0

## Verification

Verified with a temporary Detox e2e (not part of this PR) that records `frame.y` of the home carousel and a Settings row, opens Settings → Tools → Is it my address, types into `AddressInput`, goes back, and asserts both positions unchanged. Red on `master`, green with the fix.

Also re-ran on iOS 26.3 sim: `all settings screens work`, `can create wallet, reload app and it persists…`, `can discover wallet account and import it` — all green. `npm run lint` and `npm run unit` pass.

After dropping the helper, re-ran the tests that used it: `bluewallet3.spec.js` (watch-only zpub import), `can create wallet and delete wallet`, `can encrypt storage, and decrypt storage works`, `can create wallet, and use main screen SCAN button to scan address` — all green (the last one needed a rerun: the QR backdoor left the scanner open once, unrelated to scrolling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Prha4c4pgdDWXtqDfMio7q

