### PR TITLE
FIX: content jumped under large title when keyboard opened on iOS

### DIFF
--- a/components/SafeAreaFlatList.tsx
+++ b/components/SafeAreaFlatList.tsx
@@ -41,7 +41,17 @@ const SafeAreaFlatList = <ItemT,>(props: SafeAreaFlatListProps<ItemT>) => {
     );
   }, [insets, contentContainerStyle, headerHeight, floatingButtonHeight]);
 
-  return <FlatList style={componentStyle} contentContainerStyle={contentStyle} {...otherProps} />;
+  return (
+    <FlatList
+      style={componentStyle}
+      // `scrollToOverflowEnabled` works around RN's keyboard handler: it re-applies the current offset via `scrollTo:`,
+      // which clamps to the raw `contentInset` instead of `adjustedContentInset`, so content under a large-title header
+      // jumps up by the header height when the keyboard opens. Upstream fix: https://github.com/react/react-native/pull/56189
+      scrollToOverflowEnabled
+      contentContainerStyle={contentStyle}
+      {...otherProps}
+    />
+  );
 };
 
 export default SafeAreaFlatList;

--- a/components/SafeAreaScrollView.tsx
+++ b/components/SafeAreaScrollView.tsx
@@ -65,7 +65,11 @@ const SafeAreaScrollView = forwardRef<ScrollView, SafeAreaScrollViewProps>((prop
     <ScrollView
       ref={ref}
       style={componentStyle}
+      // `scrollToOverflowEnabled` works around RN's keyboard handler: it re-applies the current offset via `scrollTo:`,
+      // which clamps to the raw `contentInset` instead of `adjustedContentInset`, so content under a large-title header
+      // jumps up by the header height when the keyboard opens. Upstream fix: https://github.com/react/react-native/pull/56189
       contentInsetAdjustmentBehavior="automatic"
+      scrollToOverflowEnabled
       automaticallyAdjustKeyboardInsets
       automaticallyAdjustsScrollIndicatorInsets
       contentContainerStyle={contentStyle}

--- a/components/SafeAreaSectionList.tsx
+++ b/components/SafeAreaSectionList.tsx
@@ -52,7 +52,11 @@ const SafeAreaSectionList = <ItemT, SectionT>(props: SafeAreaSectionListProps<It
   return (
     <SectionList
       style={componentStyle}
+      // `scrollToOverflowEnabled` works around RN's keyboard handler: it re-applies the current offset via `scrollTo:`,
+      // which clamps to the raw `contentInset` instead of `adjustedContentInset`, so content under a large-title header
+      // jumps up by the header height when the keyboard opens. Upstream fix: https://github.com/react/react-native/pull/56189
       contentInsetAdjustmentBehavior="automatic"
+      scrollToOverflowEnabled
       automaticallyAdjustKeyboardInsets
       automaticallyAdjustContentInsets
       automaticallyAdjustsScrollIndicatorInsets

--- a/components/WalletsCarousel.tsx
+++ b/components/WalletsCarousel.tsx
@@ -922,6 +922,7 @@ const WalletsCarousel = forwardRef<CarouselListRefType, WalletsCarouselProps>((p
       automaticallyAdjustContentInsets
       automaticallyAdjustKeyboardInsets
       automaticallyAdjustsScrollIndicatorInsets
+      scrollToOverflowEnabled
       style={{ minHeight: sliderHeight }}
       onScrollToIndexFailed={onScrollToIndexFailed}
       ListFooterComponent={onNewWalletPress ? <NewWalletPanel onPress={onNewWalletPress} /> : null}

--- a/screen/lnd/ScanLNDInvoice.tsx
+++ b/screen/lnd/ScanLNDInvoice.tsx
@@ -396,6 +396,7 @@ const ScanLNDInvoice = () => {
           automaticallyAdjustContentInsets
           automaticallyAdjustKeyboardInsets
           contentInsetAdjustmentBehavior="automatic"
+          scrollToOverflowEnabled
         >
           <View style={styles.scrollMargin}>
             <AmountInput.AmountInput

--- a/screen/wallets/ExportMultisigCoordinationSetup.tsx
+++ b/screen/wallets/ExportMultisigCoordinationSetup.tsx
@@ -206,6 +206,7 @@ const ExportMultisigCoordinationSetup: React.FC = () => {
       contentContainerStyle={isLoading ? styles.loadingContainer : styles.contentContainer}
       automaticallyAdjustContentInsets
       automaticallyAdjustKeyboardInsets
+      scrollToOverflowEnabled
       automaticallyAdjustsScrollIndicatorInsets
       contentInsetAdjustmentBehavior="automatic"
     >

--- a/screen/wallets/ViewEditMultisigCosigners.tsx
+++ b/screen/wallets/ViewEditMultisigCosigners.tsx
@@ -531,6 +531,7 @@ const ViewEditMultisigCosigners: React.FC = () => {
         renderItem={_renderKeyItem}
         automaticallyAdjustKeyboardInsets
         contentInsetAdjustmentBehavior="automatic"
+        scrollToOverflowEnabled
         automaticallyAdjustContentInsets
         keyExtractor={(_item, index) => `${index}`}
         contentContainerStyle={styles.contentContainerStyle}

--- a/screen/wallets/WalletAddresses.tsx
+++ b/screen/wallets/WalletAddresses.tsx
@@ -241,6 +241,7 @@ const WalletAddresses: React.FC = () => {
       automaticallyAdjustContentInsets
       automaticallyAdjustsScrollIndicatorInsets
       automaticallyAdjustKeyboardInsets
+      scrollToOverflowEnabled
       ListHeaderComponent={
         <View style={styles.segmentedHeader}>
           <SegmentedControl

--- a/screen/wallets/signVerify.tsx
+++ b/screen/wallets/signVerify.tsx
@@ -128,6 +128,7 @@ const SignVerify = () => {
         automaticallyAdjustContentInsets
         automaticallyAdjustKeyboardInsets
         contentInsetAdjustmentBehavior="automatic"
+        scrollToOverflowEnabled
         contentContainerStyle={[styles.root, scrollBottomPad !== undefined && { paddingBottom: scrollBottomPad }]}
         style={styles.scroll}
       >


### PR DESCRIPTION
## Problem

On iOS, on any screen with a large-title header, focusing a text input makes the whole content jump up by the header height the moment the keyboard appears: the input slides under the header, the next control (e.g. "Check address") ends up pinned at the top. Seen on Settings → Tools → Is it my address, and on every other input screen under a large title (Add wallet, Import, Electrum, Broadcast, Lightning settings, …).

## Root cause

RN Fabric `RCTScrollViewComponentView._keyboardWillChangeFrame` (fires for every scroll view with `automaticallyAdjustKeyboardInsets`) ends with `[self scrollTo:x y:currentOffset]`. `scrollTo:` clamps the target to `y >= -contentInset.top` using the **raw** `contentInset`, not `adjustedContentInset`. A list under a large-title header with `contentInsetAdjustmentBehavior="automatic"` rests at `y = -adjustedContentInset.top`, so the clamp forces `y = 0`.

Upstream fix (open, not merged yet): react/react-native#56189 "[iOS] Fix ScrollView stale keyboard inset after dismiss" — it moves the clamp to `adjustedContentInset`. Once BlueWallet ships an RN version containing it, this workaround can be removed.

## Fix

`scrollToOverflowEnabled` makes RN skip that clamp (`if (!CGRectContainsPoint(maxRect, offset) && !props.scrollToOverflowEnabled)`), so the keyboard handler re-applies the offset unchanged. Added it to:
- the shared wrappers `SafeAreaScrollView`, `SafeAreaSectionList`, `SafeAreaFlatList` (with a comment linking the upstream PR);
- the five screens that use a bare `ScrollView`/`FlatList` with `automaticallyAdjustKeyboardInsets` + `contentInsetAdjustmentBehavior="automatic"`: `signVerify`, `ScanLNDInvoice`, `WalletAddresses`, `ExportMultisigCoordinationSetup`, `ViewEditMultisigCosigners`.
- `WalletsCarousel` (hardcodes both props on its `FlatList`; vertical mode in `SelectWallet` is a root list under the nav bar). No realistic trigger found there — the keyboard can't be open while it is pushed, and picking a wallet pops it — but it is the last scroll view in the app with that prop combination, so it gets the same treatment.

Audit of every keyboard-capable screen: all other scroll views either use the wrappers above, use `contentInsetAdjustmentBehavior="never"` (`SendDetails`), or don't set `automaticallyAdjustKeyboardInsets` at all (form sheets, `ManageWallets` with `KeyboardAvoidingView`, etc.), so RN's keyboard handler never runs `scrollTo:` on them.

`SendDetails` uses `contentInsetAdjustmentBehavior="never"` and is not affected.

Side effect of the prop: only programmatic `scrollTo` calls beyond the content bounds are no longer clamped. Audited all `scrollTo*` call sites — they target measured/valid offsets, and `scrollToEnd` clamps on its own.

Note: this also independently prevents the "previous screens scrolled after keyboard" symptom from #8903, since the same clamp caused both. Both PRs are kept: #8903 removes keyboard-inset handling from screens that never needed it; this one fixes the screens that do.

## Before / after

Settings → Tools → Is it my address → tap the address field.

**Before** (master): input jumps under the header when the keyboard opens

https://github.com/user-attachments/assets/db7708cf-bff8-43bd-a83a-e3b7222de25c

**After** (this PR)

https://github.com/user-attachments/assets/edc91cab-29a3-4e95-b157-8d9268cd9616

## Verification

iOS 26.3 simulator, Release build: keyboard opens, input and large title stay in place; keyboard inset still applied. `npm run lint` and `tsc` pass; the temporary Detox check from #8903 also passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Prha4c4pgdDWXtqDfMio7q

