### PR TITLE
FIX: fee too low when spending from legacy wallet with uncompressed key

### DIFF
--- a/class/wallets/legacy-wallet.ts
+++ b/class/wallets/legacy-wallet.ts
@@ -391,6 +391,13 @@ export class LegacyWallet extends AbstractWallet {
     const _utxos = JSON.parse(JSON.stringify(utxos)) as CreateTransactionUtxo[];
     const _targets = JSON.parse(JSON.stringify(targets)) as CreateTransactionTarget[];
 
+    let isUncompressedKey = false;
+    if (!this.segwitType || this.segwitType === 'p2pkh') {
+      try {
+        isUncompressedKey = !ECPair.fromWIF(this.secret).compressed;
+      } catch (e) {}
+    }
+
     // compensating for coinselect inability to deal with segwit inputs, and overriding script length for proper vbytes calculation
     for (const u of _utxos) {
       if (u.script?.length) {
@@ -409,6 +416,8 @@ export class LegacyWallet extends AbstractWallet {
         // So it would be 65 bytes (assuming max size) + the pushbyte for 65 bytes on the stack, which makes 66.
         // 66 / 4 = 16.5 round up to 17
         u.script = { length: 17 };
+      } else if (isUncompressedKey) {
+        u.script = { length: 139 };
       }
     }
 

--- a/tests/unit/legacy-wallet.test.js
+++ b/tests/unit/legacy-wallet.test.js
@@ -127,6 +127,24 @@ describe('Legacy wallet', () => {
     assert.strictEqual(psbt.data.inputs.length, 1);
   });
 
+  it('can create transaction that pays requested fee rate from uncompressed key', async () => {
+    const l = new LegacyWallet();
+    l.setSecret('5JqSfbkoVDrzM5i7PH7939G5fwWVDWmnFTSMbVctAmet3tYMq2S');
+
+    const prevTx = new bitcoin.Transaction();
+    prevTx.addInput(new Uint8Array(32), 0);
+    prevTx.addOutput(bitcoin.address.toOutputScript(l.getAddress()), BigInt(100000));
+    const utxos = [{ txid: prevTx.getId(), vout: 0, value: 100000, txhex: prevTx.toHex() }];
+
+    let txNew = l.createTransaction(utxos, [{ value: 50000, address: '3BDsBDxDimYgNZzsqszNZobqQq3yeUoJf2' }], 1, l.getAddress());
+    assert.strictEqual(txNew.tx.outs.length, 2);
+    assert.ok(txNew.fee >= txNew.tx.virtualSize(), `fee ${txNew.fee} is below 1 sat/vbyte for ${txNew.tx.virtualSize()} vbytes`);
+
+    txNew = l.createTransaction(utxos, [{ address: '3BDsBDxDimYgNZzsqszNZobqQq3yeUoJf2' }], 1, l.getAddress());
+    assert.strictEqual(txNew.tx.outs.length, 1);
+    assert.ok(txNew.fee >= txNew.tx.virtualSize(), `fee ${txNew.fee} is below 1 sat/vbyte for ${txNew.tx.virtualSize()} vbytes`);
+  });
+
   it("throws error if you can't create wallet from this entropy", async () => {
     const l = new LegacyWallet();
     const zeroes = [...Array(32)].map(() => 0);


### PR DESCRIPTION
Fixes #1464

## Why

Legacy (P2PKH) wallets imported from an uncompressed WIF pay less than the fee rate the user picked. `coinselect` assumes a compressed pubkey for P2PKH inputs (107-byte scriptSig), but an uncompressed pubkey is 32 bytes longer (139-byte scriptSig), so every input is undercounted by 32 vbytes. At low fee rates the transaction ends up below min relay fee.

The numbers in the issue match this exactly: 10 + 148 + 34 = 192 estimated vs 10 + 180 + 32 = 222 real. In the new unit test (1 input, P2SH output + change) the wallet paid 226 sats for a 256 vB transaction, about 0.88 sat/vB when 1 sat/vB was requested.

## What changed

- `LegacyWallet.coinselect()` checks whether the secret is a WIF with an uncompressed key and, if so, sets the input script length to 139 (72 sig + 1 + 65 pubkey + 1) instead of relying on coinselect's default.
- The check only runs when `segwitType` is unset or `p2pkh`. HD seeds, xpubs and watch-only addresses aren't WIFs, so they can't be uncompressed and keep the current behaviour. Segwit/taproot wallets are untouched.

## Tests

- Added a unit test in `tests/unit/legacy-wallet.test.js` that spends from an uncompressed key (normal send and send max) and asserts the fee covers the real vsize at 1 sat/vB. It fails on master and passes with this change.
- `npm run lint` and `npm run unit` pass locally.

No UI change, so no screenshot.
